### PR TITLE
Update xiao-ir-mate-full.yaml

### DIFF
--- a/esphome/xiao-ir-mate/xiao-ir-mate-full.yaml
+++ b/esphome/xiao-ir-mate/xiao-ir-mate-full.yaml
@@ -36,7 +36,7 @@ substitutions:
 
 esphome:
   name: ${name}
-  name_add_mac_suffix: false
+  name_add_mac_suffix: true
   friendly_name: ${friendly_name}
 
 esp32:
@@ -154,11 +154,11 @@ remote_receiver:
 # can discover it as an emitter and receiver automatically.
 infrared:
   - platform: ir_rf_proxy
-    name: ${friendly_name} Proxy Tx
+    name: Proxy Tx
     id: ir_proxy_tx
     remote_transmitter_id: ir_tx
   - platform: ir_rf_proxy
-    name: ${friendly_name} Proxy Rx
+    name: Proxy Rx
     id: ir_proxy_rx
     remote_receiver_id: ir_rx
 


### PR DESCRIPTION
## What

This is a change to one of the provided ESPHome configurations. This change modifies entity naming to avoid over-long names due to the recently-changed compound name generation behavior in HA and to include device MAC in the device name in case users have more than one similar device.

## Why

The original config included the, previously required, use of substitutions like `${friendly_name}` to get unique entity names.  However, recent changes in ESPHome and HA now add that context automatically and the inclusion of those substitutions makes entity IDs unnecessarily long and repetitive.    

## How

Removed most instances of the `${friendly_name}` substitution.
Changed `name_add_mac_suffix` to true.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional changes)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [N/A] `pytest` passes locally
- [N/A] `ruff check .` passes locally
- [N/A] Frontend builds cleanly (`npm run build` in `frontend/`)
- [N/A] New code has tests where applicable
- [x] Tested manually on a Home Assistant instance (if applicable)
- [N/A] Documentation updated (README, docstrings, etc.)
- [N/A] If this PR changes user-facing features, README, or documentation, I have updated `llms.txt` accordingly.

## Screenshots

If this changes the UI, include before/after screenshots.

## Related Issues

Closes #
