### PR TITLE
Create es.json

### DIFF
--- a/custom_components/hair/translations/es.json
+++ b/custom_components/hair/translations/es.json
@@ -1,0 +1,31 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Configurar HAIR",
+        "description": "HAIR permite gestionar tus dispositivos de infrarrojos desde un único panel.\n\nHardware detectado:\n\n{hardware_summary}",
+        "data": {}
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "HAIR ya está configurado.",
+      "no_ir_hardware": "No se ha detectado ningún dispositivo compatible con infrarrojos. Para capturar señales necesitas un dispositivo ESPHome con el componente remote_receiver. Para enviar señales necesitas una integración compatible con la plataforma nativa de infrarrojos de Home Assistant (Broadlink, ESPHome, etc.). Consulta la [guía de configuración]({setup_url}) para obtener más información."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Opciones de HAIR",
+        "description": "Configura los ajustes globales para la gestión de dispositivos de infrarrojos.",
+        "data": {
+          "capture_timeout": "Tiempo de espera para la captura (segundos)",
+          "default_repeat_count": "Número predeterminado de repeticiones de las órdenes IR"
+        },
+        "data_description": {
+          "capture_timeout": "Tiempo máximo de espera para recibir una señal de infrarrojos durante la captura (entre 5 y 60 segundos).",
+          "default_repeat_count": "Número de veces que, de forma predeterminada, se repetirá la transmisión de cada orden de infrarrojos (entre 1 y 10)."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add Spanish translation

## What

This pull request adds a complete Spanish (`es`) translation for HAIR.

The translation is based on the current `en.json` and preserves the same structure and translation keys.

I hope it is useful for the Spanish-speaking Home Assistant community.

Thank you for creating HAIR!
## Why

HAIR currently only provides English translations.

Home Assistant supports multiple languages, and adding a Spanish translation would make the integration much easier to use for Spanish-speaking users.

## How

I have prepared a complete Spanish translation (`es.json`) based on the existing `en.json`.

The translation keeps exactly the same structure and keys as the English version, so it can simply be added to the `translations` directory.

I'd be happy to submit it as a Pull Request if preferred.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactor (no functional changes)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [ ] `pytest` passes locally
- [ ] `ruff check .` passes locally
- [ ] Frontend builds cleanly (`npm run build` in `frontend/`)
- [ ] New code has tests where applicable
- [ ] Tested manually on a Home Assistant instance (if applicable)
- [ ] Documentation updated (README, docstrings, etc.)
- [ ] If this PR changes user-facing features, README, or documentation, I have updated `llms.txt` accordingly.

## Screenshots

If this changes the UI, include before/after screenshots.

## Related Issues

Closes #36
