### PR TITLE
v0.5.7 -- Location Awareness + Dots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to HAIR will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.6] - 2026-06-25 -- Forehead Removal
+## [0.5.7] - 2026-07-05
+
+### Added
+
+- Location-aware triggers. A trigger's event now reports where the signal was received: the event data carries `receiver_entity_id` plus the receiver's `receiver_area_id` and `receiver_area_name`, resolved live from Home Assistant's area registry at fire time. You can now route an automation by room, for example mute only the speakers in the room whose receiver heard the button. Triggers also gain an optional Receiver scope in the trigger dialog: leave it on "Any receiver" (the default, unchanged behavior) or pick one or more receivers so the trigger fires only when one of them observes the signal. A single physical press heard by several receivers fires each matching trigger once. Requested by @blalor, with a workaround and independent endorsement from @Didgeridrew (GH #34).
+- Multiple triggers on the same signal are now supported, so you can create one per room with different receiver scopes.
+
+### Changed
+
+- Signal-row indicators are now unified on a single corner-dot pattern. The Assign button shows a green dot when a signal is assigned to at least one device command, with a small count when it maps to more than one; hover for the list. The Trigger button shows a yellow dot, counted the same way, and the old solid-fill "trigger on" styling is gone. The Trigger button opens a small picker when a signal already has one or more triggers, so you can edit an existing one or add another.
+- Assign and Trigger indicators now refresh live across browser tabs when a signal's assignments change.
 
 ### Fixed
 

--- a/conftest.py
+++ b/conftest.py
@@ -381,6 +381,12 @@ _stub("homeassistant.helpers.entity_registry", {
     "RegistryEntry": MagicMock,
 })
 
+_mock_area_registry = MagicMock()
+_stub("homeassistant.helpers.area_registry", {
+    "async_get": MagicMock(return_value=_mock_area_registry),
+    "AreaEntry": MagicMock,
+})
+
 _stub("homeassistant.helpers.entity_platform", {
     "AddEntitiesCallback": MagicMock,
 })

--- a/custom_components/hair/const.py
+++ b/custom_components/hair/const.py
@@ -56,6 +56,10 @@ EVENT_CAPTURE_TIMEOUT = f"{DOMAIN}_capture_timeout"
 EVENT_CAPTURE_ERROR = f"{DOMAIN}_capture_error"
 EVENT_SIGNAL_DETECTED = f"{DOMAIN}_signal_detected"
 EVENT_SIGNAL_REMOVED = f"{DOMAIN}_signal_removed"
+# Fired when a signal's assignment set changes (assign, or a device command
+# referencing it is added/removed). Carries {signal_fingerprint}. Lets other
+# browser tabs refresh the green Assign badge and yellow trigger dot live.
+EVENT_SIGNAL_UPDATED = f"{DOMAIN}_signal_updated"
 # Fired (rate-limited) when a signal arrives whose device fingerprint is in
 # the persisted dismiss set. Drives the Sniffer's "Show Dismissed" button
 # glow + dot indicator so users can tell that dismissed remotes are still
@@ -92,6 +96,11 @@ SIGNAL_RAW_FINGERPRINT_LEN = 64
 # ---------------------------------------------------------------------------
 TRIGGER_HIT_RESET_WINDOW_S = 5
 EVENT_TRIGGER_FIRED = f"{DOMAIN}_trigger_fired"
+# Location-aware triggers (v0.5.7). A single physical press captured by several
+# receivers within this window counts as one press per (trigger, fingerprint):
+# it increments a trigger's hit state once and fires each matching trigger at
+# most once. Composes with min_hits (distinct presses still accumulate).
+MULTI_RECEIVER_DEDUP_WINDOW_S = 0.060
 
 # Pronto S/L classification threshold (in Pronto timing units).
 # Timing words below this are "short" (S), above are "long" (L).

--- a/custom_components/hair/frontend/dist/ha-panel-ir-devices.js
+++ b/custom_components/hair/frontend/dist/ha-panel-ir-devices.js
@@ -1,32 +1,103 @@
-function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPropertyDescriptor(t,i):s;if("object"==typeof Reflect&&"function"==typeof Reflect.decorate)n=Reflect.decorate(e,t,i,s);else for(var r=e.length-1;r>=0;r--)(a=e[r])&&(n=(o<3?a(n):o>3?a(t,i,n):a(t,i))||n);return o>3&&n&&Object.defineProperty(t,i,n),n}"function"==typeof SuppressedError&&SuppressedError;const t=globalThis,i=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"adoptedStyleSheets"in Document.prototype&&"replace"in CSSStyleSheet.prototype,s=Symbol(),a=new WeakMap;let o=class{constructor(e,t,i){if(this._$cssResult$=!0,i!==s)throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");this.cssText=e,this.t=t}get styleSheet(){let e=this.o;const t=this.t;if(i&&void 0===e){const i=void 0!==t&&1===t.length;i&&(e=a.get(t)),void 0===e&&((this.o=e=new CSSStyleSheet).replaceSync(this.cssText),i&&a.set(t,e))}return e}toString(){return this.cssText}};const n=(e,...t)=>{const i=1===e.length?e[0]:t.reduce((t,i,s)=>t+(e=>{if(!0===e._$cssResult$)return e.cssText;if("number"==typeof e)return e;throw Error("Value passed to 'css' function must be a 'css' function result: "+e+". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.")})(i)+e[s+1],e[0]);return new o(i,e,s)},r=i?e=>e:e=>e instanceof CSSStyleSheet?(e=>{let t="";for(const i of e.cssRules)t+=i.cssText;return(e=>new o("string"==typeof e?e:e+"",void 0,s))(t)})(e):e,{is:l,defineProperty:d,getOwnPropertyDescriptor:c,getOwnPropertyNames:h,getOwnPropertySymbols:p,getPrototypeOf:g}=Object,u=globalThis,m=u.trustedTypes,v=m?m.emptyScript:"",_=u.reactiveElementPolyfillSupport,b=(e,t)=>e,f={toAttribute(e,t){switch(t){case Boolean:e=e?v:null;break;case Object:case Array:e=null==e?e:JSON.stringify(e)}return e},fromAttribute(e,t){let i=e;switch(t){case Boolean:i=null!==e;break;case Number:i=null===e?null:Number(e);break;case Object:case Array:try{i=JSON.parse(e)}catch(e){i=null}}return i}},y=(e,t)=>!l(e,t),x={attribute:!0,type:String,converter:f,reflect:!1,useDefault:!1,hasChanged:y};Symbol.metadata??=Symbol("metadata"),u.litPropertyMetadata??=new WeakMap;let $=class extends HTMLElement{static addInitializer(e){this._$Ei(),(this.l??=[]).push(e)}static get observedAttributes(){return this.finalize(),this._$Eh&&[...this._$Eh.keys()]}static createProperty(e,t=x){if(t.state&&(t.attribute=!1),this._$Ei(),this.prototype.hasOwnProperty(e)&&((t=Object.create(t)).wrapped=!0),this.elementProperties.set(e,t),!t.noAccessor){const i=Symbol(),s=this.getPropertyDescriptor(e,i,t);void 0!==s&&d(this.prototype,e,s)}}static getPropertyDescriptor(e,t,i){const{get:s,set:a}=c(this.prototype,e)??{get(){return this[t]},set(e){this[t]=e}};return{get:s,set(t){const o=s?.call(this);a?.call(this,t),this.requestUpdate(e,o,i)},configurable:!0,enumerable:!0}}static getPropertyOptions(e){return this.elementProperties.get(e)??x}static _$Ei(){if(this.hasOwnProperty(b("elementProperties")))return;const e=g(this);e.finalize(),void 0!==e.l&&(this.l=[...e.l]),this.elementProperties=new Map(e.elementProperties)}static finalize(){if(this.hasOwnProperty(b("finalized")))return;if(this.finalized=!0,this._$Ei(),this.hasOwnProperty(b("properties"))){const e=this.properties,t=[...h(e),...p(e)];for(const i of t)this.createProperty(i,e[i])}const e=this[Symbol.metadata];if(null!==e){const t=litPropertyMetadata.get(e);if(void 0!==t)for(const[e,i]of t)this.elementProperties.set(e,i)}this._$Eh=new Map;for(const[e,t]of this.elementProperties){const i=this._$Eu(e,t);void 0!==i&&this._$Eh.set(i,e)}this.elementStyles=this.finalizeStyles(this.styles)}static finalizeStyles(e){const t=[];if(Array.isArray(e)){const i=new Set(e.flat(1/0).reverse());for(const e of i)t.unshift(r(e))}else void 0!==e&&t.push(r(e));return t}static _$Eu(e,t){const i=t.attribute;return!1===i?void 0:"string"==typeof i?i:"string"==typeof e?e.toLowerCase():void 0}constructor(){super(),this._$Ep=void 0,this.isUpdatePending=!1,this.hasUpdated=!1,this._$Em=null,this._$Ev()}_$Ev(){this._$ES=new Promise(e=>this.enableUpdating=e),this._$AL=new Map,this._$E_(),this.requestUpdate(),this.constructor.l?.forEach(e=>e(this))}addController(e){(this._$EO??=new Set).add(e),void 0!==this.renderRoot&&this.isConnected&&e.hostConnected?.()}removeController(e){this._$EO?.delete(e)}_$E_(){const e=new Map,t=this.constructor.elementProperties;for(const i of t.keys())this.hasOwnProperty(i)&&(e.set(i,this[i]),delete this[i]);e.size>0&&(this._$Ep=e)}createRenderRoot(){const e=this.shadowRoot??this.attachShadow(this.constructor.shadowRootOptions);return((e,s)=>{if(i)e.adoptedStyleSheets=s.map(e=>e instanceof CSSStyleSheet?e:e.styleSheet);else for(const i of s){const s=document.createElement("style"),a=t.litNonce;void 0!==a&&s.setAttribute("nonce",a),s.textContent=i.cssText,e.appendChild(s)}})(e,this.constructor.elementStyles),e}connectedCallback(){this.renderRoot??=this.createRenderRoot(),this.enableUpdating(!0),this._$EO?.forEach(e=>e.hostConnected?.())}enableUpdating(e){}disconnectedCallback(){this._$EO?.forEach(e=>e.hostDisconnected?.())}attributeChangedCallback(e,t,i){this._$AK(e,i)}_$ET(e,t){const i=this.constructor.elementProperties.get(e),s=this.constructor._$Eu(e,i);if(void 0!==s&&!0===i.reflect){const a=(void 0!==i.converter?.toAttribute?i.converter:f).toAttribute(t,i.type);this._$Em=e,null==a?this.removeAttribute(s):this.setAttribute(s,a),this._$Em=null}}_$AK(e,t){const i=this.constructor,s=i._$Eh.get(e);if(void 0!==s&&this._$Em!==s){const e=i.getPropertyOptions(s),a="function"==typeof e.converter?{fromAttribute:e.converter}:void 0!==e.converter?.fromAttribute?e.converter:f;this._$Em=s;const o=a.fromAttribute(t,e.type);this[s]=o??this._$Ej?.get(s)??o,this._$Em=null}}requestUpdate(e,t,i,s=!1,a){if(void 0!==e){const o=this.constructor;if(!1===s&&(a=this[e]),i??=o.getPropertyOptions(e),!((i.hasChanged??y)(a,t)||i.useDefault&&i.reflect&&a===this._$Ej?.get(e)&&!this.hasAttribute(o._$Eu(e,i))))return;this.C(e,t,i)}!1===this.isUpdatePending&&(this._$ES=this._$EP())}C(e,t,{useDefault:i,reflect:s,wrapped:a},o){i&&!(this._$Ej??=new Map).has(e)&&(this._$Ej.set(e,o??t??this[e]),!0!==a||void 0!==o)||(this._$AL.has(e)||(this.hasUpdated||i||(t=void 0),this._$AL.set(e,t)),!0===s&&this._$Em!==e&&(this._$Eq??=new Set).add(e))}async _$EP(){this.isUpdatePending=!0;try{await this._$ES}catch(e){Promise.reject(e)}const e=this.scheduleUpdate();return null!=e&&await e,!this.isUpdatePending}scheduleUpdate(){return this.performUpdate()}performUpdate(){if(!this.isUpdatePending)return;if(!this.hasUpdated){if(this.renderRoot??=this.createRenderRoot(),this._$Ep){for(const[e,t]of this._$Ep)this[e]=t;this._$Ep=void 0}const e=this.constructor.elementProperties;if(e.size>0)for(const[t,i]of e){const{wrapped:e}=i,s=this[t];!0!==e||this._$AL.has(t)||void 0===s||this.C(t,void 0,i,s)}}let e=!1;const t=this._$AL;try{e=this.shouldUpdate(t),e?(this.willUpdate(t),this._$EO?.forEach(e=>e.hostUpdate?.()),this.update(t)):this._$EM()}catch(t){throw e=!1,this._$EM(),t}e&&this._$AE(t)}willUpdate(e){}_$AE(e){this._$EO?.forEach(e=>e.hostUpdated?.()),this.hasUpdated||(this.hasUpdated=!0,this.firstUpdated(e)),this.updated(e)}_$EM(){this._$AL=new Map,this.isUpdatePending=!1}get updateComplete(){return this.getUpdateComplete()}getUpdateComplete(){return this._$ES}shouldUpdate(e){return!0}update(e){this._$Eq&&=this._$Eq.forEach(e=>this._$ET(e,this[e])),this._$EM()}updated(e){}firstUpdated(e){}};$.elementStyles=[],$.shadowRootOptions={mode:"open"},$[b("elementProperties")]=new Map,$[b("finalized")]=new Map,_?.({ReactiveElement:$}),(u.reactiveElementVersions??=[]).push("2.1.2");const w=globalThis,k=e=>e,D=w.trustedTypes,S=D?D.createPolicy("lit-html",{createHTML:e=>e}):void 0,C="$lit$",T=`lit$${Math.random().toFixed(9).slice(2)}$`,E="?"+T,A=`<${E}>`,I=document,R=()=>I.createComment(""),M=e=>null===e||"object"!=typeof e&&"function"!=typeof e,P=Array.isArray,H="[ \t\n\f\r]",N=/<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g,z=/-->/g,V=/>/g,L=RegExp(`>|${H}(?:([^\\s"'>=/]+)(${H}*=${H}*(?:[^ \t\n\f\r"'\`<>=]|("|')|))|$)`,"g"),O=/'/g,U=/"/g,B=/^(?:script|style|textarea|title)$/i,F=(e,...t)=>({_$litType$:1,strings:e,values:t}),q=Symbol.for("lit-noChange"),j=Symbol.for("lit-nothing"),X=new WeakMap,Z=I.createTreeWalker(I,129);function Y(e,t){if(!P(e)||!e.hasOwnProperty("raw"))throw Error("invalid template strings array");return void 0!==S?S.createHTML(t):t}class W{constructor({strings:e,_$litType$:t},i){let s;this.parts=[];let a=0,o=0;const n=e.length-1,r=this.parts,[l,d]=((e,t)=>{const i=e.length-1,s=[];let a,o=2===t?"<svg>":3===t?"<math>":"",n=N;for(let t=0;t<i;t++){const i=e[t];let r,l,d=-1,c=0;for(;c<i.length&&(n.lastIndex=c,l=n.exec(i),null!==l);)c=n.lastIndex,n===N?"!--"===l[1]?n=z:void 0!==l[1]?n=V:void 0!==l[2]?(B.test(l[2])&&(a=RegExp("</"+l[2],"g")),n=L):void 0!==l[3]&&(n=L):n===L?">"===l[0]?(n=a??N,d=-1):void 0===l[1]?d=-2:(d=n.lastIndex-l[2].length,r=l[1],n=void 0===l[3]?L:'"'===l[3]?U:O):n===U||n===O?n=L:n===z||n===V?n=N:(n=L,a=void 0);const h=n===L&&e[t+1].startsWith("/>")?" ":"";o+=n===N?i+A:d>=0?(s.push(r),i.slice(0,d)+C+i.slice(d)+T+h):i+T+(-2===d?t:h)}return[Y(e,o+(e[i]||"<?>")+(2===t?"</svg>":3===t?"</math>":"")),s]})(e,t);if(this.el=W.createElement(l,i),Z.currentNode=this.el.content,2===t||3===t){const e=this.el.content.firstChild;e.replaceWith(...e.childNodes)}for(;null!==(s=Z.nextNode())&&r.length<n;){if(1===s.nodeType){if(s.hasAttributes())for(const e of s.getAttributeNames())if(e.endsWith(C)){const t=d[o++],i=s.getAttribute(e).split(T),n=/([.?@])?(.*)/.exec(t);r.push({type:1,index:a,name:n[2],strings:i,ctor:"."===n[1]?ee:"?"===n[1]?te:"@"===n[1]?ie:Q}),s.removeAttribute(e)}else e.startsWith(T)&&(r.push({type:6,index:a}),s.removeAttribute(e));if(B.test(s.tagName)){const e=s.textContent.split(T),t=e.length-1;if(t>0){s.textContent=D?D.emptyScript:"";for(let i=0;i<t;i++)s.append(e[i],R()),Z.nextNode(),r.push({type:2,index:++a});s.append(e[t],R())}}}else if(8===s.nodeType)if(s.data===E)r.push({type:2,index:a});else{let e=-1;for(;-1!==(e=s.data.indexOf(T,e+1));)r.push({type:7,index:a}),e+=T.length-1}a++}}static createElement(e,t){const i=I.createElement("template");return i.innerHTML=e,i}}function K(e,t,i=e,s){if(t===q)return t;let a=void 0!==s?i._$Co?.[s]:i._$Cl;const o=M(t)?void 0:t._$litDirective$;return a?.constructor!==o&&(a?._$AO?.(!1),void 0===o?a=void 0:(a=new o(e),a._$AT(e,i,s)),void 0!==s?(i._$Co??=[])[s]=a:i._$Cl=a),void 0!==a&&(t=K(e,a._$AS(e,t.values),a,s)),t}class G{constructor(e,t){this._$AV=[],this._$AN=void 0,this._$AD=e,this._$AM=t}get parentNode(){return this._$AM.parentNode}get _$AU(){return this._$AM._$AU}u(e){const{el:{content:t},parts:i}=this._$AD,s=(e?.creationScope??I).importNode(t,!0);Z.currentNode=s;let a=Z.nextNode(),o=0,n=0,r=i[0];for(;void 0!==r;){if(o===r.index){let t;2===r.type?t=new J(a,a.nextSibling,this,e):1===r.type?t=new r.ctor(a,r.name,r.strings,this,e):6===r.type&&(t=new se(a,this,e)),this._$AV.push(t),r=i[++n]}o!==r?.index&&(a=Z.nextNode(),o++)}return Z.currentNode=I,s}p(e){let t=0;for(const i of this._$AV)void 0!==i&&(void 0!==i.strings?(i._$AI(e,i,t),t+=i.strings.length-2):i._$AI(e[t])),t++}}class J{get _$AU(){return this._$AM?._$AU??this._$Cv}constructor(e,t,i,s){this.type=2,this._$AH=j,this._$AN=void 0,this._$AA=e,this._$AB=t,this._$AM=i,this.options=s,this._$Cv=s?.isConnected??!0}get parentNode(){let e=this._$AA.parentNode;const t=this._$AM;return void 0!==t&&11===e?.nodeType&&(e=t.parentNode),e}get startNode(){return this._$AA}get endNode(){return this._$AB}_$AI(e,t=this){e=K(this,e,t),M(e)?e===j||null==e||""===e?(this._$AH!==j&&this._$AR(),this._$AH=j):e!==this._$AH&&e!==q&&this._(e):void 0!==e._$litType$?this.$(e):void 0!==e.nodeType?this.T(e):(e=>P(e)||"function"==typeof e?.[Symbol.iterator])(e)?this.k(e):this._(e)}O(e){return this._$AA.parentNode.insertBefore(e,this._$AB)}T(e){this._$AH!==e&&(this._$AR(),this._$AH=this.O(e))}_(e){this._$AH!==j&&M(this._$AH)?this._$AA.nextSibling.data=e:this.T(I.createTextNode(e)),this._$AH=e}$(e){const{values:t,_$litType$:i}=e,s="number"==typeof i?this._$AC(e):(void 0===i.el&&(i.el=W.createElement(Y(i.h,i.h[0]),this.options)),i);if(this._$AH?._$AD===s)this._$AH.p(t);else{const e=new G(s,this),i=e.u(this.options);e.p(t),this.T(i),this._$AH=e}}_$AC(e){let t=X.get(e.strings);return void 0===t&&X.set(e.strings,t=new W(e)),t}k(e){P(this._$AH)||(this._$AH=[],this._$AR());const t=this._$AH;let i,s=0;for(const a of e)s===t.length?t.push(i=new J(this.O(R()),this.O(R()),this,this.options)):i=t[s],i._$AI(a),s++;s<t.length&&(this._$AR(i&&i._$AB.nextSibling,s),t.length=s)}_$AR(e=this._$AA.nextSibling,t){for(this._$AP?.(!1,!0,t);e!==this._$AB;){const t=k(e).nextSibling;k(e).remove(),e=t}}setConnected(e){void 0===this._$AM&&(this._$Cv=e,this._$AP?.(e))}}class Q{get tagName(){return this.element.tagName}get _$AU(){return this._$AM._$AU}constructor(e,t,i,s,a){this.type=1,this._$AH=j,this._$AN=void 0,this.element=e,this.name=t,this._$AM=s,this.options=a,i.length>2||""!==i[0]||""!==i[1]?(this._$AH=Array(i.length-1).fill(new String),this.strings=i):this._$AH=j}_$AI(e,t=this,i,s){const a=this.strings;let o=!1;if(void 0===a)e=K(this,e,t,0),o=!M(e)||e!==this._$AH&&e!==q,o&&(this._$AH=e);else{const s=e;let n,r;for(e=a[0],n=0;n<a.length-1;n++)r=K(this,s[i+n],t,n),r===q&&(r=this._$AH[n]),o||=!M(r)||r!==this._$AH[n],r===j?e=j:e!==j&&(e+=(r??"")+a[n+1]),this._$AH[n]=r}o&&!s&&this.j(e)}j(e){e===j?this.element.removeAttribute(this.name):this.element.setAttribute(this.name,e??"")}}class ee extends Q{constructor(){super(...arguments),this.type=3}j(e){this.element[this.name]=e===j?void 0:e}}class te extends Q{constructor(){super(...arguments),this.type=4}j(e){this.element.toggleAttribute(this.name,!!e&&e!==j)}}class ie extends Q{constructor(e,t,i,s,a){super(e,t,i,s,a),this.type=5}_$AI(e,t=this){if((e=K(this,e,t,0)??j)===q)return;const i=this._$AH,s=e===j&&i!==j||e.capture!==i.capture||e.once!==i.once||e.passive!==i.passive,a=e!==j&&(i===j||s);s&&this.element.removeEventListener(this.name,this,i),a&&this.element.addEventListener(this.name,this,e),this._$AH=e}handleEvent(e){"function"==typeof this._$AH?this._$AH.call(this.options?.host??this.element,e):this._$AH.handleEvent(e)}}class se{constructor(e,t,i){this.element=e,this.type=6,this._$AN=void 0,this._$AM=t,this.options=i}get _$AU(){return this._$AM._$AU}_$AI(e){K(this,e)}}const ae={I:J},oe=w.litHtmlPolyfillSupport;oe?.(W,J),(w.litHtmlVersions??=[]).push("3.3.3");const ne=globalThis;let re=class extends ${constructor(){super(...arguments),this.renderOptions={host:this},this._$Do=void 0}createRenderRoot(){const e=super.createRenderRoot();return this.renderOptions.renderBefore??=e.firstChild,e}update(e){const t=this.render();this.hasUpdated||(this.renderOptions.isConnected=this.isConnected),super.update(e),this._$Do=((e,t,i)=>{const s=i?.renderBefore??t;let a=s._$litPart$;if(void 0===a){const e=i?.renderBefore??null;s._$litPart$=a=new J(t.insertBefore(R(),e),e,void 0,i??{})}return a._$AI(e),a})(t,this.renderRoot,this.renderOptions)}connectedCallback(){super.connectedCallback(),this._$Do?.setConnected(!0)}disconnectedCallback(){super.disconnectedCallback(),this._$Do?.setConnected(!1)}render(){return q}};re._$litElement$=!0,re.finalized=!0,ne.litElementHydrateSupport?.({LitElement:re});const le=ne.litElementPolyfillSupport;le?.({LitElement:re}),(ne.litElementVersions??=[]).push("4.2.2");const de={attribute:!0,type:String,converter:f,reflect:!1,hasChanged:y},ce=(e=de,t,i)=>{const{kind:s,metadata:a}=i;let o=globalThis.litPropertyMetadata.get(a);if(void 0===o&&globalThis.litPropertyMetadata.set(a,o=new Map),"setter"===s&&((e=Object.create(e)).wrapped=!0),o.set(i.name,e),"accessor"===s){const{name:s}=i;return{set(i){const a=t.get.call(this);t.set.call(this,i),this.requestUpdate(s,a,e,!0,i)},init(t){return void 0!==t&&this.C(s,void 0,e,t),t}}}if("setter"===s){const{name:s}=i;return function(i){const a=this[s];t.call(this,i),this.requestUpdate(s,a,e,!0,i)}}throw Error("Unsupported decorator location: "+s)};function he(e){return(t,i)=>"object"==typeof i?ce(e,t,i):((e,t,i)=>{const s=t.hasOwnProperty(i);return t.constructor.createProperty(i,e),s?Object.getOwnPropertyDescriptor(t,i):void 0})(e,t,i)}function pe(e){return he({...e,state:!0,attribute:!1})}const ge=e=>e,ue=e=>customElements.get(e)?ge:(e=>(t,i)=>{void 0!==i?i.addInitializer(()=>{customElements.define(e,t)}):customElements.define(e,t)})(e);class me{constructor(e){this.hass=e}listDevices(){return this.hass.connection.sendMessagePromise({type:"hair/devices"})}getDevice(e){return this.hass.connection.sendMessagePromise({type:"hair/device",device_id:e})}createDevice(e){return this.hass.connection.sendMessagePromise({type:"hair/device/create",...e})}updateDevice(e,t){return this.hass.connection.sendMessagePromise({type:"hair/device/update",device_id:e,...t})}deleteDevice(e){return this.hass.connection.sendMessagePromise({type:"hair/device/delete",device_id:e})}duplicateDevice(e,t){return this.hass.connection.sendMessagePromise({type:"hair/device/duplicate",device_id:e,new_name:t})}deleteCommand(e,t){return this.hass.connection.sendMessagePromise({type:"hair/command/delete",device_id:e,command_id:t})}setCommandTxForceRaw(e,t,i){return this.hass.connection.sendMessagePromise({type:"hair/command/set-tx-force-raw",device_id:e,command_id:t,tx_force_raw:i})}reorderCommands(e,t){return this.hass.connection.sendMessagePromise({type:"hair/device/reorder-commands",device_id:e,command_ids:t})}reorderDevices(e){return this.hass.connection.sendMessagePromise({type:"hair/devices/reorder",device_ids:e})}sendCommand(e,t){return this.hass.connection.sendMessagePromise({type:"hair/command/send",device_id:e,command_id:t})}listTemplates(e){return this.hass.connection.sendMessagePromise({type:"hair/templates",device_type:e})}listCaptureProviders(){return this.hass.connection.sendMessagePromise({type:"hair/capture/providers"})}listReceivers(){return this.hass.connection.sendMessagePromise({type:"hair/receivers"})}getSnifferStatus(){return this.hass.connection.sendMessagePromise({type:"hair/sniffer/status"})}getCodeBrands(){return this.hass.connection.sendMessagePromise({type:"hair/codes/brands"})}importCodeRemote(e,t){const i={type:"hair/codes/import-remote",codebook_id:e};return t&&(i.name=t),this.hass.connection.sendMessagePromise(i)}async startCapture(e,t,i){let s=null;const a=await this.hass.connection.subscribeMessage(e=>{e.type?.startsWith("capture_")?i(e):e.session_id&&(s=e)},{type:"hair/capture/start",device_id:e,timeout:t});if(await Promise.resolve(),null===s)throw new Error("Capture session did not start");return{session:s,unsubscribe:a}}cancelCapture(e){return this.hass.connection.sendMessagePromise({type:"hair/capture/cancel",session_id:e})}saveCapturedCommand(e){return this.hass.connection.sendMessagePromise({type:"hair/capture/save",...e})}getActionOptions(e){return this.hass.connection.sendMessagePromise({type:"hair/device/action-options",device_type:e})}updateMapping(e,t,i){return this.hass.connection.sendMessagePromise({type:"hair/device/update-mapping",device_id:e,command_name:t,action_key:i})}getUnknownDevices(e){return this.hass.connection.sendMessagePromise({type:"hair/unknown/devices",...e})}getUnknownDevice(e){return this.hass.connection.sendMessagePromise({type:"hair/unknown/device",device_id:e})}dismissUnknown(e){return this.hass.connection.sendMessagePromise({type:"hair/unknown/dismiss",device_id:e})}undismissUnknown(e){return this.hass.connection.sendMessagePromise({type:"hair/unknown/undismiss",device_id:e})}assignSignal(e){return this.hass.connection.sendMessagePromise({type:"hair/unknown/assign",...e})}assignToNewDevice(e){return this.hass.connection.sendMessagePromise({type:"hair/unknown/assign-new-device",...e})}deleteSignal(e,t){return this.hass.connection.sendMessagePromise({type:"hair/unknown/signal/delete",device_id:e,signal_id:t})}testSignal(e,t){const i={type:"hair/unknown/test",signal_id:e};return t&&(i.emitter_entity_id=t),this.hass.connection.sendMessagePromise(i)}renameUnknown(e,t){return this.hass.connection.sendMessagePromise({type:"hair/unknown/rename",device_id:e,label:t})}clearUnknowns(e){return this.hass.connection.sendMessagePromise({type:"hair/unknown/clear",...e?{source:e}:{}})}setSignalAlias(e,t,i){return this.hass.connection.sendMessagePromise({type:"hair/unknown/signal/set-alias",device_id:e,signal_id:t,alias:i})}reorderUnknownDevices(e,t){return this.hass.connection.sendMessagePromise({type:"hair/unknown/reorder",source:e,device_ids:t})}reorderUnknownSignals(e,t){return this.hass.connection.sendMessagePromise({type:"hair/unknown/signal/reorder",device_id:e,signal_ids:t})}createRemote(e){return this.hass.connection.sendMessagePromise({type:"hair/clip/create-remote",name:e})}createSignal(e){return this.hass.connection.sendMessagePromise({type:"hair/clip/create-signal",...e})}editSignalPronto(e){return this.hass.connection.sendMessagePromise({type:"hair/unknown/signal/edit-pronto",...e})}validatePronto(e){return this.hass.connection.sendMessagePromise({type:"hair/clip/validate-pronto",pronto:e})}snapPreview(e){return this.hass.connection.sendMessagePromise({type:"hair/unknown/signal/snap-preview",...e})}updateCommand(e){return this.hass.connection.sendMessagePromise({type:"hair/command/update",...e})}deleteRemote(e){return this.hass.connection.sendMessagePromise({type:"hair/clip/delete-remote",device_id:e})}listPluckVendors(){return this.hass.connection.sendMessagePromise({type:"hair/pluck/list-vendors"})}runPluck(e){return this.hass.connection.sendMessagePromise({type:"hair/pluck/run",...e})}createPluckedBlaster(e){return this.hass.connection.sendMessagePromise({type:"hair/pluck/create-blaster",...e})}createPluckedSignal(e){return this.hass.connection.sendMessagePromise({type:"hair/pluck/create-signal",...e})}deletePluckedBlaster(e){return this.hass.connection.sendMessagePromise({type:"hair/pluck/delete-blaster",device_id:e})}async subscribeUnknownSignals(e){return this.hass.connection.subscribeEvents(t=>e(t.data),"hair_signal_detected")}async subscribeSignalRemoved(e){return this.hass.connection.subscribeEvents(t=>e(t.data),"hair_signal_removed")}async subscribeDismissActivity(e){return this.hass.connection.subscribeEvents(t=>e(t.data),"hair_dismiss_activity")}listTriggers(){return this.hass.connection.sendMessagePromise({type:"hair/triggers"})}createTrigger(e){return this.hass.connection.sendMessagePromise({type:"hair/trigger/create",...e})}updateTrigger(e,t){return this.hass.connection.sendMessagePromise({type:"hair/trigger/update",trigger_id:e,...t})}deleteTrigger(e){return this.hass.connection.sendMessagePromise({type:"hair/trigger/delete",trigger_id:e})}async subscribeTriggerFired(e){return this.hass.connection.subscribeMessage(e,{type:"hair/trigger/subscribe"})}}const ve=e=>(...t)=>({_$litDirective$:e,values:t});let _e=class{constructor(e){}get _$AU(){return this._$AM._$AU}_$AT(e,t,i){this._$Ct=e,this._$AM=t,this._$Ci=i}_$AS(e,t){return this.update(e,t)}update(e,t){return this.render(...t)}};const{I:be}=ae,fe=e=>e,ye=()=>document.createComment(""),xe=(e,t,i)=>{const s=e._$AA.parentNode,a=void 0===t?e._$AB:t._$AA;if(void 0===i){const t=s.insertBefore(ye(),a),o=s.insertBefore(ye(),a);i=new be(t,o,e,e.options)}else{const t=i._$AB.nextSibling,o=i._$AM,n=o!==e;if(n){let t;i._$AQ?.(e),i._$AM=e,void 0!==i._$AP&&(t=e._$AU)!==o._$AU&&i._$AP(t)}if(t!==a||n){let e=i._$AA;for(;e!==t;){const t=fe(e).nextSibling;fe(s).insertBefore(e,a),e=t}}}return i},$e=(e,t,i=e)=>(e._$AI(t,i),e),we={},ke=(e,t=we)=>e._$AH=t,De=e=>{e._$AR(),e._$AA.remove()},Se=ve(class extends _e{constructor(){super(...arguments),this.key=j}render(e,t){return this.key=e,t}update(e,[t,i]){return t!==this.key&&(ke(e),this.key=t),i}}),Ce=(e,t,i)=>{const s=new Map;for(let a=t;a<=i;a++)s.set(e[a],a);return s},Te=ve(class extends _e{constructor(e){if(super(e),2!==e.type)throw Error("repeat() can only be used in text expressions")}dt(e,t,i){let s;void 0===i?i=t:void 0!==t&&(s=t);const a=[],o=[];let n=0;for(const t of e)a[n]=s?s(t,n):n,o[n]=i(t,n),n++;return{values:o,keys:a}}render(e,t,i){return this.dt(e,t,i).values}update(e,[t,i,s]){const a=(e=>e._$AH)(e),{values:o,keys:n}=this.dt(t,i,s);if(!Array.isArray(a))return this.ut=n,o;const r=this.ut??=[],l=[];let d,c,h=0,p=a.length-1,g=0,u=o.length-1;for(;h<=p&&g<=u;)if(null===a[h])h++;else if(null===a[p])p--;else if(r[h]===n[g])l[g]=$e(a[h],o[g]),h++,g++;else if(r[p]===n[u])l[u]=$e(a[p],o[u]),p--,u--;else if(r[h]===n[u])l[u]=$e(a[h],o[u]),xe(e,l[u+1],a[h]),h++,u--;else if(r[p]===n[g])l[g]=$e(a[p],o[g]),xe(e,a[h],a[p]),p--,g++;else if(void 0===d&&(d=Ce(n,g,u),c=Ce(r,h,p)),d.has(r[h]))if(d.has(r[p])){const t=c.get(n[g]),i=void 0!==t?a[t]:null;if(null===i){const t=xe(e,a[h]);$e(t,o[g]),l[g]=t}else l[g]=$e(i,o[g]),xe(e,a[h],i),a[t]=null;g++}else De(a[p]),p--;else De(a[h]),h++;for(;g<=u;){const t=xe(e,l[u+1]);$e(t,o[g]),l[g++]=t}for(;h<=p;){const e=a[h++];null!==e&&De(e)}return this.ut=n,ke(e,l),q}});function Ee(e,t,i){return(t=function(e){var t=function(e,t){if("object"!=typeof e||!e)return e;var i=e[Symbol.toPrimitive];if(void 0!==i){var s=i.call(e,t);if("object"!=typeof s)return s;throw new TypeError("@@toPrimitive must return a primitive value.")}return String(e)}(e,"string");return"symbol"==typeof t?t:t+""}(t))in e?Object.defineProperty(e,t,{value:i,enumerable:!0,configurable:!0,writable:!0}):e[t]=i,e}function Ae(){return Ae=Object.assign?Object.assign.bind():function(e){for(var t=1;t<arguments.length;t++){var i=arguments[t];for(var s in i)({}).hasOwnProperty.call(i,s)&&(e[s]=i[s])}return e},Ae.apply(null,arguments)}function Ie(e,t){var i=Object.keys(e);if(Object.getOwnPropertySymbols){var s=Object.getOwnPropertySymbols(e);t&&(s=s.filter(function(t){return Object.getOwnPropertyDescriptor(e,t).enumerable})),i.push.apply(i,s)}return i}function Re(e){for(var t=1;t<arguments.length;t++){var i=null!=arguments[t]?arguments[t]:{};t%2?Ie(Object(i),!0).forEach(function(t){Ee(e,t,i[t])}):Object.getOwnPropertyDescriptors?Object.defineProperties(e,Object.getOwnPropertyDescriptors(i)):Ie(Object(i)).forEach(function(t){Object.defineProperty(e,t,Object.getOwnPropertyDescriptor(i,t))})}return e}function Me(e){return Me="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e},Me(e)}function Pe(e){if("undefined"!=typeof window&&window.navigator)return!!navigator.userAgent.match(e)}var He=Pe(/(?:Trident.*rv[ :]?11\.|msie|iemobile|Windows Phone)/i),Ne=Pe(/Edge/i),ze=Pe(/firefox/i),Ve=Pe(/safari/i)&&!Pe(/chrome/i)&&!Pe(/android/i),Le=Pe(/iP(ad|od|hone)/i),Oe=Pe(/chrome/i)&&Pe(/android/i),Ue={capture:!1,passive:!1};function Be(e,t,i){e.addEventListener(t,i,!He&&Ue)}function Fe(e,t,i){e.removeEventListener(t,i,!He&&Ue)}function qe(e,t){if(t){if(">"===t[0]&&(t=t.substring(1)),e)try{if(e.matches)return e.matches(t);if(e.msMatchesSelector)return e.msMatchesSelector(t);if(e.webkitMatchesSelector)return e.webkitMatchesSelector(t)}catch(e){return!1}return!1}}function je(e){return e.host&&e!==document&&e.host.nodeType&&e.host!==e?e.host:e.parentNode}function Xe(e,t,i,s){if(e){i=i||document;do{if(null!=t&&(">"===t[0]?e.parentNode===i&&qe(e,t):qe(e,t))||s&&e===i)return e;if(e===i)break}while(e=je(e))}return null}var Ze,Ye=/\s+/g;function We(e,t,i){if(e&&t)if(e.classList)e.classList[i?"add":"remove"](t);else{var s=(" "+e.className+" ").replace(Ye," ").replace(" "+t+" "," ");e.className=(s+(i?" "+t:"")).replace(Ye," ")}}function Ke(e,t,i){var s=e&&e.style;if(s){if(void 0===i)return document.defaultView&&document.defaultView.getComputedStyle?i=document.defaultView.getComputedStyle(e,""):e.currentStyle&&(i=e.currentStyle),void 0===t?i:i[t];t in s||-1!==t.indexOf("webkit")||(t="-webkit-"+t),s[t]=i+("string"==typeof i?"":"px")}}function Ge(e,t){var i="";if("string"==typeof e)i=e;else do{var s=Ke(e,"transform");s&&"none"!==s&&(i=s+" "+i)}while(!t&&(e=e.parentNode));var a=window.DOMMatrix||window.WebKitCSSMatrix||window.CSSMatrix||window.MSCSSMatrix;return a&&new a(i)}function Je(e,t,i){if(e){var s=e.getElementsByTagName(t),a=0,o=s.length;if(i)for(;a<o;a++)i(s[a],a);return s}return[]}function Qe(){return document.scrollingElement||document.documentElement}function et(e,t,i,s,a){if(e.getBoundingClientRect||e===window){var o,n,r,l,d,c,h;if(e!==window&&e.parentNode&&e!==Qe()?(n=(o=e.getBoundingClientRect()).top,r=o.left,l=o.bottom,d=o.right,c=o.height,h=o.width):(n=0,r=0,l=window.innerHeight,d=window.innerWidth,c=window.innerHeight,h=window.innerWidth),(t||i)&&e!==window&&(a=a||e.parentNode,!He))do{if(a&&a.getBoundingClientRect&&("none"!==Ke(a,"transform")||i&&"static"!==Ke(a,"position"))){var p=a.getBoundingClientRect();n-=p.top+parseInt(Ke(a,"border-top-width")),r-=p.left+parseInt(Ke(a,"border-left-width")),l=n+o.height,d=r+o.width;break}}while(a=a.parentNode);if(s&&e!==window){var g=Ge(a||e),u=g&&g.a,m=g&&g.d;g&&(l=(n/=m)+(c/=m),d=(r/=u)+(h/=u))}return{top:n,left:r,bottom:l,right:d,width:h,height:c}}}function tt(e,t,i){for(var s=nt(e,!0),a=et(e)[t];s;){if(!(a>=et(s)[i]))return s;if(s===Qe())break;s=nt(s,!1)}return!1}function it(e,t,i,s){for(var a=0,o=0,n=e.children;o<n.length;){if("none"!==n[o].style.display&&n[o]!==di.ghost&&(s||n[o]!==di.dragged)&&Xe(n[o],i.draggable,e,!1)){if(a===t)return n[o];a++}o++}return null}function st(e,t){for(var i=e.lastElementChild;i&&(i===di.ghost||"none"===Ke(i,"display")||t&&!qe(i,t));)i=i.previousElementSibling;return i||null}function at(e,t){var i=0;if(!e||!e.parentNode)return-1;for(;e=e.previousElementSibling;)"TEMPLATE"===e.nodeName.toUpperCase()||e===di.clone||t&&!qe(e,t)||i++;return i}function ot(e){var t=0,i=0,s=Qe();if(e)do{var a=Ge(e),o=a.a,n=a.d;t+=e.scrollLeft*o,i+=e.scrollTop*n}while(e!==s&&(e=e.parentNode));return[t,i]}function nt(e,t){if(!e||!e.getBoundingClientRect)return Qe();var i=e,s=!1;do{if(i.clientWidth<i.scrollWidth||i.clientHeight<i.scrollHeight){var a=Ke(i);if(i.clientWidth<i.scrollWidth&&("auto"==a.overflowX||"scroll"==a.overflowX)||i.clientHeight<i.scrollHeight&&("auto"==a.overflowY||"scroll"==a.overflowY)){if(!i.getBoundingClientRect||i===document.body)return Qe();if(s||t)return i;s=!0}}}while(i=i.parentNode);return Qe()}function rt(e,t){return Math.round(e.top)===Math.round(t.top)&&Math.round(e.left)===Math.round(t.left)&&Math.round(e.height)===Math.round(t.height)&&Math.round(e.width)===Math.round(t.width)}function lt(e,t){return function(){if(!Ze){var i=arguments;1===i.length?e.call(this,i[0]):e.apply(this,i),Ze=setTimeout(function(){Ze=void 0},t)}}}function dt(e,t,i){e.scrollLeft+=t,e.scrollTop+=i}function ct(e){var t=window.Polymer,i=window.jQuery||window.Zepto;return t&&t.dom?t.dom(e).cloneNode(!0):i?i(e).clone(!0)[0]:e.cloneNode(!0)}function ht(e,t,i){var s={};return Array.from(e.children).forEach(function(a){var o,n,r,l;if(Xe(a,t.draggable,e,!1)&&!a.animated&&a!==i){var d=et(a);s.left=Math.min(null!==(o=s.left)&&void 0!==o?o:1/0,d.left),s.top=Math.min(null!==(n=s.top)&&void 0!==n?n:1/0,d.top),s.right=Math.max(null!==(r=s.right)&&void 0!==r?r:-1/0,d.right),s.bottom=Math.max(null!==(l=s.bottom)&&void 0!==l?l:-1/0,d.bottom)}}),s.width=s.right-s.left,s.height=s.bottom-s.top,s.x=s.left,s.y=s.top,s}var pt="Sortable"+(new Date).getTime();var gt=[],ut={initializeByDefault:!0},mt={mount:function(e){for(var t in ut)ut.hasOwnProperty(t)&&!(t in e)&&(e[t]=ut[t]);gt.forEach(function(t){if(t.pluginName===e.pluginName)throw"Sortable: Cannot mount plugin ".concat(e.pluginName," more than once")}),gt.push(e)},pluginEvent:function(e,t,i){var s=this;this.eventCanceled=!1,i.cancel=function(){s.eventCanceled=!0};var a=e+"Global";gt.forEach(function(s){t[s.pluginName]&&(t[s.pluginName][a]&&t[s.pluginName][a](Re({sortable:t},i)),t.options[s.pluginName]&&t[s.pluginName][e]&&t[s.pluginName][e](Re({sortable:t},i)))})},initializePlugins:function(e,t,i,s){for(var a in gt.forEach(function(s){var a=s.pluginName;if(e.options[a]||s.initializeByDefault){var o=new s(e,t,e.options);o.sortable=e,o.options=e.options,e[a]=o,Ae(i,o.defaults)}}),e.options)if(e.options.hasOwnProperty(a)){var o=this.modifyOption(e,a,e.options[a]);void 0!==o&&(e.options[a]=o)}},getEventProperties:function(e,t){var i={};return gt.forEach(function(s){"function"==typeof s.eventProperties&&Ae(i,s.eventProperties.call(t[s.pluginName],e))}),i},modifyOption:function(e,t,i){var s;return gt.forEach(function(a){e[a.pluginName]&&a.optionListeners&&"function"==typeof a.optionListeners[t]&&(s=a.optionListeners[t].call(e[a.pluginName],i))}),s}},vt=["evt"],_t=function(e,t){var i=arguments.length>2&&void 0!==arguments[2]?arguments[2]:{},s=i.evt,a=function(e,t){if(null==e)return{};var i,s,a=function(e,t){if(null==e)return{};var i={};for(var s in e)if({}.hasOwnProperty.call(e,s)){if(-1!==t.indexOf(s))continue;i[s]=e[s]}return i}(e,t);if(Object.getOwnPropertySymbols){var o=Object.getOwnPropertySymbols(e);for(s=0;s<o.length;s++)i=o[s],-1===t.indexOf(i)&&{}.propertyIsEnumerable.call(e,i)&&(a[i]=e[i])}return a}(i,vt);mt.pluginEvent.bind(di)(e,t,Re({dragEl:ft,parentEl:yt,ghostEl:xt,rootEl:$t,nextEl:wt,lastDownEl:kt,cloneEl:Dt,cloneHidden:St,dragStarted:Lt,putSortable:Rt,activeSortable:di.active,originalEvent:s,oldIndex:Ct,oldDraggableIndex:Et,newIndex:Tt,newDraggableIndex:At,hideGhostForTarget:oi,unhideGhostForTarget:ni,cloneNowHidden:function(){St=!0},cloneNowShown:function(){St=!1},dispatchSortableEvent:function(e){bt({sortable:t,name:e,originalEvent:s})}},a))};function bt(e){!function(e){var t=e.sortable,i=e.rootEl,s=e.name,a=e.targetEl,o=e.cloneEl,n=e.toEl,r=e.fromEl,l=e.oldIndex,d=e.newIndex,c=e.oldDraggableIndex,h=e.newDraggableIndex,p=e.originalEvent,g=e.putSortable,u=e.extraEventProperties;if(t=t||i&&i[pt]){var m,v=t.options,_="on"+s.charAt(0).toUpperCase()+s.substr(1);!window.CustomEvent||He||Ne?(m=document.createEvent("Event")).initEvent(s,!0,!0):m=new CustomEvent(s,{bubbles:!0,cancelable:!0}),m.to=n||i,m.from=r||i,m.item=a||i,m.clone=o,m.oldIndex=l,m.newIndex=d,m.oldDraggableIndex=c,m.newDraggableIndex=h,m.originalEvent=p,m.pullMode=g?g.lastPutMode:void 0;var b=Re(Re({},u),mt.getEventProperties(s,t));for(var f in b)m[f]=b[f];i&&i.dispatchEvent(m),v[_]&&v[_].call(t,m)}}(Re({putSortable:Rt,cloneEl:Dt,targetEl:ft,rootEl:$t,oldIndex:Ct,oldDraggableIndex:Et,newIndex:Tt,newDraggableIndex:At},e))}var ft,yt,xt,$t,wt,kt,Dt,St,Ct,Tt,Et,At,It,Rt,Mt,Pt,Ht,Nt,zt,Vt,Lt,Ot,Ut,Bt,Ft,qt=!1,jt=!1,Xt=[],Zt=!1,Yt=!1,Wt=[],Kt=!1,Gt=[],Jt="undefined"!=typeof document,Qt=Le,ei=Ne||He?"cssFloat":"float",ti=Jt&&!Oe&&!Le&&"draggable"in document.createElement("div"),ii=function(){if(Jt){if(He)return!1;var e=document.createElement("x");return e.style.cssText="pointer-events:auto","auto"===e.style.pointerEvents}}(),si=function(e,t){var i=Ke(e),s=parseInt(i.width)-parseInt(i.paddingLeft)-parseInt(i.paddingRight)-parseInt(i.borderLeftWidth)-parseInt(i.borderRightWidth),a=it(e,0,t),o=it(e,1,t),n=a&&Ke(a),r=o&&Ke(o),l=n&&parseInt(n.marginLeft)+parseInt(n.marginRight)+et(a).width,d=r&&parseInt(r.marginLeft)+parseInt(r.marginRight)+et(o).width;if("flex"===i.display)return"column"===i.flexDirection||"column-reverse"===i.flexDirection?"vertical":"horizontal";if("grid"===i.display)return i.gridTemplateColumns.split(" ").length<=1?"vertical":"horizontal";if(a&&n.float&&"none"!==n.float){var c="left"===n.float?"left":"right";return!o||"both"!==r.clear&&r.clear!==c?"horizontal":"vertical"}return a&&("block"===n.display||"flex"===n.display||"table"===n.display||"grid"===n.display||l>=s&&"none"===i[ei]||o&&"none"===i[ei]&&l+d>s)?"vertical":"horizontal"},ai=function(e){function t(e,i){return function(s,a,o,n){var r=s.options.group.name&&a.options.group.name&&s.options.group.name===a.options.group.name;if(null==e&&(i||r))return!0;if(null==e||!1===e)return!1;if(i&&"clone"===e)return e;if("function"==typeof e)return t(e(s,a,o,n),i)(s,a,o,n);var l=(i?s:a).options.group.name;return!0===e||"string"==typeof e&&e===l||e.join&&e.indexOf(l)>-1}}var i={},s=e.group;s&&"object"==Me(s)||(s={name:s}),i.name=s.name,i.checkPull=t(s.pull,!0),i.checkPut=t(s.put),i.revertClone=s.revertClone,e.group=i},oi=function(){!ii&&xt&&Ke(xt,"display","none")},ni=function(){!ii&&xt&&Ke(xt,"display","")};Jt&&!Oe&&document.addEventListener("click",function(e){if(jt)return e.preventDefault(),e.stopPropagation&&e.stopPropagation(),e.stopImmediatePropagation&&e.stopImmediatePropagation(),jt=!1,!1},!0);var ri=function(e){if(ft){var t=function(e,t){var i;return Xt.some(function(s){var a=s[pt].options.emptyInsertThreshold;if(a&&!st(s)){var o=et(s),n=e>=o.left-a&&e<=o.right+a,r=t>=o.top-a&&t<=o.bottom+a;return n&&r?i=s:void 0}}),i}((e=e.touches?e.touches[0]:e).clientX,e.clientY);if(t){var i={};for(var s in e)e.hasOwnProperty(s)&&(i[s]=e[s]);i.target=i.rootEl=t,i.preventDefault=void 0,i.stopPropagation=void 0,t[pt]._onDragOver(i)}}},li=function(e){ft&&ft.parentNode[pt]._isOutsideThisEl(e.target)};function di(e,t){if(!e||!e.nodeType||1!==e.nodeType)throw"Sortable: `el` must be an HTMLElement, not ".concat({}.toString.call(e));this.el=e,this.options=t=Ae({},t),e[pt]=this;var i,s,a={group:null,sort:!0,disabled:!1,store:null,handle:null,draggable:/^[uo]l$/i.test(e.nodeName)?">li":">*",swapThreshold:1,invertSwap:!1,invertedSwapThreshold:null,removeCloneOnHide:!0,direction:function(){return si(e,this.options)},ghostClass:"sortable-ghost",chosenClass:"sortable-chosen",dragClass:"sortable-drag",ignore:"a, img",filter:null,preventOnFilter:!0,animation:0,easing:null,setData:function(e,t){e.setData("Text",t.textContent)},dropBubble:!1,dragoverBubble:!1,dataIdAttr:"data-id",delay:0,delayOnTouchOnly:!1,touchStartThreshold:(Number.parseInt?Number:window).parseInt(window.devicePixelRatio,10)||1,forceFallback:!1,fallbackClass:"sortable-fallback",fallbackOnBody:!1,fallbackTolerance:0,fallbackOffset:{x:0,y:0},supportPointer:!1!==di.supportPointer&&"PointerEvent"in window&&(!Ve||Le),emptyInsertThreshold:5};for(var o in mt.initializePlugins(this,e,a),a)!(o in t)&&(t[o]=a[o]);for(var n in ai(t),this)"_"===n.charAt(0)&&"function"==typeof this[n]&&(this[n]=this[n].bind(this));this.nativeDraggable=!t.forceFallback&&ti,this.nativeDraggable&&(this.options.touchStartThreshold=1),t.supportPointer?Be(e,"pointerdown",this._onTapStart):(Be(e,"mousedown",this._onTapStart),Be(e,"touchstart",this._onTapStart)),this.nativeDraggable&&(Be(e,"dragover",this),Be(e,"dragenter",this)),Xt.push(this.el),t.store&&t.store.get&&this.sort(t.store.get(this)||[]),Ae(this,(s=[],{captureAnimationState:function(){s=[],this.options.animation&&[].slice.call(this.el.children).forEach(function(e){if("none"!==Ke(e,"display")&&e!==di.ghost){s.push({target:e,rect:et(e)});var t=Re({},s[s.length-1].rect);if(e.thisAnimationDuration){var i=Ge(e,!0);i&&(t.top-=i.f,t.left-=i.e)}e.fromRect=t}})},addAnimationState:function(e){s.push(e)},removeAnimationState:function(e){s.splice(function(e,t){for(var i in e)if(e.hasOwnProperty(i))for(var s in t)if(t.hasOwnProperty(s)&&t[s]===e[i][s])return Number(i);return-1}(s,{target:e}),1)},animateAll:function(e){var t=this;if(!this.options.animation)return clearTimeout(i),void("function"==typeof e&&e());var a=!1,o=0;s.forEach(function(e){var i=0,s=e.target,n=s.fromRect,r=et(s),l=s.prevFromRect,d=s.prevToRect,c=e.rect,h=Ge(s,!0);h&&(r.top-=h.f,r.left-=h.e),s.toRect=r,s.thisAnimationDuration&&rt(l,r)&&!rt(n,r)&&(c.top-r.top)/(c.left-r.left)===(n.top-r.top)/(n.left-r.left)&&(i=function(e,t,i,s){return Math.sqrt(Math.pow(t.top-e.top,2)+Math.pow(t.left-e.left,2))/Math.sqrt(Math.pow(t.top-i.top,2)+Math.pow(t.left-i.left,2))*s.animation}(c,l,d,t.options)),rt(r,n)||(s.prevFromRect=n,s.prevToRect=r,i||(i=t.options.animation),t.animate(s,c,r,i)),i&&(a=!0,o=Math.max(o,i),clearTimeout(s.animationResetTimer),s.animationResetTimer=setTimeout(function(){s.animationTime=0,s.prevFromRect=null,s.fromRect=null,s.prevToRect=null,s.thisAnimationDuration=null},i),s.thisAnimationDuration=i)}),clearTimeout(i),a?i=setTimeout(function(){"function"==typeof e&&e()},o):"function"==typeof e&&e(),s=[]},animate:function(e,t,i,s){if(s){Ke(e,"transition",""),Ke(e,"transform","");var a=Ge(this.el),o=a&&a.a,n=a&&a.d,r=(t.left-i.left)/(o||1),l=(t.top-i.top)/(n||1);e.animatingX=!!r,e.animatingY=!!l,Ke(e,"transform","translate3d("+r+"px,"+l+"px,0)"),this.forRepaintDummy=function(e){return e.offsetWidth}(e),Ke(e,"transition","transform "+s+"ms"+(this.options.easing?" "+this.options.easing:"")),Ke(e,"transform","translate3d(0,0,0)"),"number"==typeof e.animated&&clearTimeout(e.animated),e.animated=setTimeout(function(){Ke(e,"transition",""),Ke(e,"transform",""),e.animated=!1,e.animatingX=!1,e.animatingY=!1},s)}}}))}function ci(e,t,i,s,a,o,n,r){var l,d,c=e[pt],h=c.options.onMove;return!window.CustomEvent||He||Ne?(l=document.createEvent("Event")).initEvent("move",!0,!0):l=new CustomEvent("move",{bubbles:!0,cancelable:!0}),l.to=t,l.from=e,l.dragged=i,l.draggedRect=s,l.related=a||t,l.relatedRect=o||et(t),l.willInsertAfter=r,l.originalEvent=n,e.dispatchEvent(l),h&&(d=h.call(c,l,n)),d}function hi(e){e.draggable=!1}function pi(){Kt=!1}function gi(e){for(var t=e.tagName+e.className+e.src+e.href+e.textContent,i=t.length,s=0;i--;)s+=t.charCodeAt(i);return s.toString(36)}function ui(e){return setTimeout(e,0)}function mi(e){return clearTimeout(e)}di.prototype={constructor:di,_isOutsideThisEl:function(e){this.el.contains(e)||e===this.el||(Ot=null)},_getDirection:function(e,t){return"function"==typeof this.options.direction?this.options.direction.call(this,e,t,ft):this.options.direction},_onTapStart:function(e){if(e.cancelable){var t=this,i=this.el,s=this.options,a=s.preventOnFilter,o=e.type,n=e.touches&&e.touches[0]||e.pointerType&&"touch"===e.pointerType&&e,r=(n||e).target,l=e.target.shadowRoot&&(e.path&&e.path[0]||e.composedPath&&e.composedPath()[0])||r,d=s.filter;if(function(e){Gt.length=0;for(var t=e.getElementsByTagName("input"),i=t.length;i--;){var s=t[i];s.checked&&Gt.push(s)}}(i),!ft&&!(/mousedown|pointerdown/.test(o)&&0!==e.button||s.disabled)&&!l.isContentEditable&&(this.nativeDraggable||!Ve||!r||"SELECT"!==r.tagName.toUpperCase())&&!((r=Xe(r,s.draggable,i,!1))&&r.animated||kt===r)){if(Ct=at(r),Et=at(r,s.draggable),"function"==typeof d){if(d.call(this,e,r,this))return bt({sortable:t,rootEl:l,name:"filter",targetEl:r,toEl:i,fromEl:i}),_t("filter",t,{evt:e}),void(a&&e.preventDefault())}else if(d&&(d=d.split(",").some(function(s){if(s=Xe(l,s.trim(),i,!1))return bt({sortable:t,rootEl:s,name:"filter",targetEl:r,fromEl:i,toEl:i}),_t("filter",t,{evt:e}),!0})))return void(a&&e.preventDefault());s.handle&&!Xe(l,s.handle,i,!1)||this._prepareDragStart(e,n,r)}}},_prepareDragStart:function(e,t,i){var s,a=this,o=a.el,n=a.options,r=o.ownerDocument;if(i&&!ft&&i.parentNode===o){var l=et(i);if($t=o,yt=(ft=i).parentNode,wt=ft.nextSibling,kt=i,It=n.group,di.dragged=ft,Mt={target:ft,clientX:(t||e).clientX,clientY:(t||e).clientY},zt=Mt.clientX-l.left,Vt=Mt.clientY-l.top,this._lastX=(t||e).clientX,this._lastY=(t||e).clientY,ft.style["will-change"]="all",s=function(){_t("delayEnded",a,{evt:e}),di.eventCanceled?a._onDrop():(a._disableDelayedDragEvents(),!ze&&a.nativeDraggable&&(ft.draggable=!0),a._triggerDragStart(e,t),bt({sortable:a,name:"choose",originalEvent:e}),We(ft,n.chosenClass,!0))},n.ignore.split(",").forEach(function(e){Je(ft,e.trim(),hi)}),Be(r,"dragover",ri),Be(r,"mousemove",ri),Be(r,"touchmove",ri),n.supportPointer?(Be(r,"pointerup",a._onDrop),!this.nativeDraggable&&Be(r,"pointercancel",a._onDrop)):(Be(r,"mouseup",a._onDrop),Be(r,"touchend",a._onDrop),Be(r,"touchcancel",a._onDrop)),ze&&this.nativeDraggable&&(this.options.touchStartThreshold=4,ft.draggable=!0),_t("delayStart",this,{evt:e}),!n.delay||n.delayOnTouchOnly&&!t||this.nativeDraggable&&(Ne||He))s();else{if(di.eventCanceled)return void this._onDrop();n.supportPointer?(Be(r,"pointerup",a._disableDelayedDrag),Be(r,"pointercancel",a._disableDelayedDrag)):(Be(r,"mouseup",a._disableDelayedDrag),Be(r,"touchend",a._disableDelayedDrag),Be(r,"touchcancel",a._disableDelayedDrag)),Be(r,"mousemove",a._delayedDragTouchMoveHandler),Be(r,"touchmove",a._delayedDragTouchMoveHandler),n.supportPointer&&Be(r,"pointermove",a._delayedDragTouchMoveHandler),a._dragStartTimer=setTimeout(s,n.delay)}}},_delayedDragTouchMoveHandler:function(e){var t=e.touches?e.touches[0]:e;Math.max(Math.abs(t.clientX-this._lastX),Math.abs(t.clientY-this._lastY))>=Math.floor(this.options.touchStartThreshold/(this.nativeDraggable&&window.devicePixelRatio||1))&&this._disableDelayedDrag()},_disableDelayedDrag:function(){ft&&hi(ft),clearTimeout(this._dragStartTimer),this._disableDelayedDragEvents()},_disableDelayedDragEvents:function(){var e=this.el.ownerDocument;Fe(e,"mouseup",this._disableDelayedDrag),Fe(e,"touchend",this._disableDelayedDrag),Fe(e,"touchcancel",this._disableDelayedDrag),Fe(e,"pointerup",this._disableDelayedDrag),Fe(e,"pointercancel",this._disableDelayedDrag),Fe(e,"mousemove",this._delayedDragTouchMoveHandler),Fe(e,"touchmove",this._delayedDragTouchMoveHandler),Fe(e,"pointermove",this._delayedDragTouchMoveHandler)},_triggerDragStart:function(e,t){t=t||"touch"==e.pointerType&&e,!this.nativeDraggable||t?this.options.supportPointer?Be(document,"pointermove",this._onTouchMove):Be(document,t?"touchmove":"mousemove",this._onTouchMove):(Be(ft,"dragend",this),Be($t,"dragstart",this._onDragStart));try{document.selection?ui(function(){document.selection.empty()}):window.getSelection().removeAllRanges()}catch(e){}},_dragStarted:function(e,t){if(qt=!1,$t&&ft){_t("dragStarted",this,{evt:t}),this.nativeDraggable&&Be(document,"dragover",li);var i=this.options;!e&&We(ft,i.dragClass,!1),We(ft,i.ghostClass,!0),di.active=this,e&&this._appendGhost(),bt({sortable:this,name:"start",originalEvent:t})}else this._nulling()},_emulateDragOver:function(){if(Pt){this._lastX=Pt.clientX,this._lastY=Pt.clientY,oi();for(var e=document.elementFromPoint(Pt.clientX,Pt.clientY),t=e;e&&e.shadowRoot&&(e=e.shadowRoot.elementFromPoint(Pt.clientX,Pt.clientY))!==t;)t=e;if(ft.parentNode[pt]._isOutsideThisEl(e),t)do{if(t[pt]&&t[pt]._onDragOver({clientX:Pt.clientX,clientY:Pt.clientY,target:e,rootEl:t})&&!this.options.dragoverBubble)break;e=t}while(t=je(t));ni()}},_onTouchMove:function(e){if(Mt){var t=this.options,i=t.fallbackTolerance,s=t.fallbackOffset,a=e.touches?e.touches[0]:e,o=xt&&Ge(xt,!0),n=xt&&o&&o.a,r=xt&&o&&o.d,l=Qt&&Ft&&ot(Ft),d=(a.clientX-Mt.clientX+s.x)/(n||1)+(l?l[0]-Wt[0]:0)/(n||1),c=(a.clientY-Mt.clientY+s.y)/(r||1)+(l?l[1]-Wt[1]:0)/(r||1);if(!di.active&&!qt){if(i&&Math.max(Math.abs(a.clientX-this._lastX),Math.abs(a.clientY-this._lastY))<i)return;this._onDragStart(e,!0)}if(xt){o?(o.e+=d-(Ht||0),o.f+=c-(Nt||0)):o={a:1,b:0,c:0,d:1,e:d,f:c};var h="matrix(".concat(o.a,",").concat(o.b,",").concat(o.c,",").concat(o.d,",").concat(o.e,",").concat(o.f,")");Ke(xt,"webkitTransform",h),Ke(xt,"mozTransform",h),Ke(xt,"msTransform",h),Ke(xt,"transform",h),Ht=d,Nt=c,Pt=a}e.cancelable&&e.preventDefault()}},_appendGhost:function(){if(!xt){var e=this.options.fallbackOnBody?document.body:$t,t=et(ft,!0,Qt,!0,e),i=this.options;if(Qt){for(Ft=e;"static"===Ke(Ft,"position")&&"none"===Ke(Ft,"transform")&&Ft!==document;)Ft=Ft.parentNode;Ft!==document.body&&Ft!==document.documentElement?(Ft===document&&(Ft=Qe()),t.top+=Ft.scrollTop,t.left+=Ft.scrollLeft):Ft=Qe(),Wt=ot(Ft)}We(xt=ft.cloneNode(!0),i.ghostClass,!1),We(xt,i.fallbackClass,!0),We(xt,i.dragClass,!0),Ke(xt,"transition",""),Ke(xt,"transform",""),Ke(xt,"box-sizing","border-box"),Ke(xt,"margin",0),Ke(xt,"top",t.top),Ke(xt,"left",t.left),Ke(xt,"width",t.width),Ke(xt,"height",t.height),Ke(xt,"opacity","0.8"),Ke(xt,"position",Qt?"absolute":"fixed"),Ke(xt,"zIndex","100000"),Ke(xt,"pointerEvents","none"),di.ghost=xt,e.appendChild(xt),Ke(xt,"transform-origin",zt/parseInt(xt.style.width)*100+"% "+Vt/parseInt(xt.style.height)*100+"%")}},_onDragStart:function(e,t){var i=this,s=e.dataTransfer,a=i.options;_t("dragStart",this,{evt:e}),di.eventCanceled?this._onDrop():(_t("setupClone",this),di.eventCanceled||((Dt=ct(ft)).removeAttribute("id"),Dt.draggable=!1,Dt.style["will-change"]="",this._hideClone(),We(Dt,this.options.chosenClass,!1),di.clone=Dt),i.cloneId=ui(function(){_t("clone",i),di.eventCanceled||(i.options.removeCloneOnHide||$t.insertBefore(Dt,ft),i._hideClone(),bt({sortable:i,name:"clone"}))}),!t&&We(ft,a.dragClass,!0),t?(jt=!0,i._loopId=setInterval(i._emulateDragOver,50)):(Fe(document,"mouseup",i._onDrop),Fe(document,"touchend",i._onDrop),Fe(document,"touchcancel",i._onDrop),s&&(s.effectAllowed="move",a.setData&&a.setData.call(i,s,ft)),Be(document,"drop",i),Ke(ft,"transform","translateZ(0)")),qt=!0,i._dragStartId=ui(i._dragStarted.bind(i,t,e)),Be(document,"selectstart",i),Lt=!0,window.getSelection().removeAllRanges(),Ve&&Ke(document.body,"user-select","none"))},_onDragOver:function(e){var t,i,s,a,o=this.el,n=e.target,r=this.options,l=r.group,d=di.active,c=It===l,h=r.sort,p=Rt||d,g=this,u=!1;if(!Kt){if(void 0!==e.preventDefault&&e.cancelable&&e.preventDefault(),n=Xe(n,r.draggable,o,!0),E("dragOver"),di.eventCanceled)return u;if(ft.contains(e.target)||n.animated&&n.animatingX&&n.animatingY||g._ignoreWhileAnimating===n)return I(!1);if(jt=!1,d&&!r.disabled&&(c?h||(s=yt!==$t):Rt===this||(this.lastPutMode=It.checkPull(this,d,ft,e))&&l.checkPut(this,d,ft,e))){if(a="vertical"===this._getDirection(e,n),t=et(ft),E("dragOverValid"),di.eventCanceled)return u;if(s)return yt=$t,A(),this._hideClone(),E("revert"),di.eventCanceled||(wt?$t.insertBefore(ft,wt):$t.appendChild(ft)),I(!0);var m=st(o,r.draggable);if(!m||function(e,t,i){var s=et(st(i.el,i.options.draggable)),a=ht(i.el,i.options,xt);return t?e.clientX>a.right+10||e.clientY>s.bottom&&e.clientX>s.left:e.clientY>a.bottom+10||e.clientX>s.right&&e.clientY>s.top}(e,a,this)&&!m.animated){if(m===ft)return I(!1);if(m&&o===e.target&&(n=m),n&&(i=et(n)),!1!==ci($t,o,ft,t,n,i,e,!!n))return A(),m&&m.nextSibling?o.insertBefore(ft,m.nextSibling):o.appendChild(ft),yt=o,R(),I(!0)}else if(m&&function(e,t,i){var s=et(it(i.el,0,i.options,!0)),a=ht(i.el,i.options,xt);return t?e.clientX<a.left-10||e.clientY<s.top&&e.clientX<s.right:e.clientY<a.top-10||e.clientY<s.bottom&&e.clientX<s.left}(e,a,this)){var v=it(o,0,r,!0);if(v===ft)return I(!1);if(i=et(n=v),!1!==ci($t,o,ft,t,n,i,e,!1))return A(),o.insertBefore(ft,v),yt=o,R(),I(!0)}else if(n.parentNode===o){i=et(n);var _,b,f,y=ft.parentNode!==o,x=!function(e,t,i){var s=i?e.left:e.top,a=i?e.right:e.bottom,o=i?e.width:e.height,n=i?t.left:t.top,r=i?t.right:t.bottom,l=i?t.width:t.height;return s===n||a===r||s+o/2===n+l/2}(ft.animated&&ft.toRect||t,n.animated&&n.toRect||i,a),$=a?"top":"left",w=tt(n,"top","top")||tt(ft,"top","top"),k=w?w.scrollTop:void 0;if(Ot!==n&&(b=i[$],Zt=!1,Yt=!x&&r.invertSwap||y),_=function(e,t,i,s,a,o,n,r){var l=s?e.clientY:e.clientX,d=s?i.height:i.width,c=s?i.top:i.left,h=s?i.bottom:i.right,p=!1;if(!n)if(r&&Bt<d*a){if(!Zt&&(1===Ut?l>c+d*o/2:l<h-d*o/2)&&(Zt=!0),Zt)p=!0;else if(1===Ut?l<c+Bt:l>h-Bt)return-Ut}else if(l>c+d*(1-a)/2&&l<h-d*(1-a)/2)return function(e){return at(ft)<at(e)?1:-1}(t);return(p=p||n)&&(l<c+d*o/2||l>h-d*o/2)?l>c+d/2?1:-1:0}(e,n,i,a,x?1:r.swapThreshold,null==r.invertedSwapThreshold?r.swapThreshold:r.invertedSwapThreshold,Yt,Ot===n),0!==_){var D=at(ft);do{D-=_,f=yt.children[D]}while(f&&("none"===Ke(f,"display")||f===xt))}if(0===_||f===n)return I(!1);Ot=n,Ut=_;var S=n.nextElementSibling,C=!1,T=ci($t,o,ft,t,n,i,e,C=1===_);if(!1!==T)return 1!==T&&-1!==T||(C=1===T),Kt=!0,setTimeout(pi,30),A(),C&&!S?o.appendChild(ft):n.parentNode.insertBefore(ft,C?S:n),w&&dt(w,0,k-w.scrollTop),yt=ft.parentNode,void 0===b||Yt||(Bt=Math.abs(b-et(n)[$])),R(),I(!0)}if(o.contains(ft))return I(!1)}return!1}function E(r,l){_t(r,g,Re({evt:e,isOwner:c,axis:a?"vertical":"horizontal",revert:s,dragRect:t,targetRect:i,canSort:h,fromSortable:p,target:n,completed:I,onMove:function(i,s){return ci($t,o,ft,t,i,et(i),e,s)},changed:R},l))}function A(){E("dragOverAnimationCapture"),g.captureAnimationState(),g!==p&&p.captureAnimationState()}function I(t){return E("dragOverCompleted",{insertion:t}),t&&(c?d._hideClone():d._showClone(g),g!==p&&(We(ft,Rt?Rt.options.ghostClass:d.options.ghostClass,!1),We(ft,r.ghostClass,!0)),Rt!==g&&g!==di.active?Rt=g:g===di.active&&Rt&&(Rt=null),p===g&&(g._ignoreWhileAnimating=n),g.animateAll(function(){E("dragOverAnimationComplete"),g._ignoreWhileAnimating=null}),g!==p&&(p.animateAll(),p._ignoreWhileAnimating=null)),(n===ft&&!ft.animated||n===o&&!n.animated)&&(Ot=null),r.dragoverBubble||e.rootEl||n===document||(ft.parentNode[pt]._isOutsideThisEl(e.target),!t&&ri(e)),!r.dragoverBubble&&e.stopPropagation&&e.stopPropagation(),u=!0}function R(){Tt=at(ft),At=at(ft,r.draggable),bt({sortable:g,name:"change",toEl:o,newIndex:Tt,newDraggableIndex:At,originalEvent:e})}},_ignoreWhileAnimating:null,_offMoveEvents:function(){Fe(document,"mousemove",this._onTouchMove),Fe(document,"touchmove",this._onTouchMove),Fe(document,"pointermove",this._onTouchMove),Fe(document,"dragover",ri),Fe(document,"mousemove",ri),Fe(document,"touchmove",ri)},_offUpEvents:function(){var e=this.el.ownerDocument;Fe(e,"mouseup",this._onDrop),Fe(e,"touchend",this._onDrop),Fe(e,"pointerup",this._onDrop),Fe(e,"pointercancel",this._onDrop),Fe(e,"touchcancel",this._onDrop),Fe(document,"selectstart",this)},_onDrop:function(e){var t=this.el,i=this.options;Tt=at(ft),At=at(ft,i.draggable),_t("drop",this,{evt:e}),yt=ft&&ft.parentNode,Tt=at(ft),At=at(ft,i.draggable),di.eventCanceled||(qt=!1,Yt=!1,Zt=!1,clearInterval(this._loopId),clearTimeout(this._dragStartTimer),mi(this.cloneId),mi(this._dragStartId),this.nativeDraggable&&(Fe(document,"drop",this),Fe(t,"dragstart",this._onDragStart)),this._offMoveEvents(),this._offUpEvents(),Ve&&Ke(document.body,"user-select",""),Ke(ft,"transform",""),e&&(Lt&&(e.cancelable&&e.preventDefault(),!i.dropBubble&&e.stopPropagation()),xt&&xt.parentNode&&xt.parentNode.removeChild(xt),($t===yt||Rt&&"clone"!==Rt.lastPutMode)&&Dt&&Dt.parentNode&&Dt.parentNode.removeChild(Dt),ft&&(this.nativeDraggable&&Fe(ft,"dragend",this),hi(ft),ft.style["will-change"]="",Lt&&!qt&&We(ft,Rt?Rt.options.ghostClass:this.options.ghostClass,!1),We(ft,this.options.chosenClass,!1),bt({sortable:this,name:"unchoose",toEl:yt,newIndex:null,newDraggableIndex:null,originalEvent:e}),$t!==yt?(Tt>=0&&(bt({rootEl:yt,name:"add",toEl:yt,fromEl:$t,originalEvent:e}),bt({sortable:this,name:"remove",toEl:yt,originalEvent:e}),bt({rootEl:yt,name:"sort",toEl:yt,fromEl:$t,originalEvent:e}),bt({sortable:this,name:"sort",toEl:yt,originalEvent:e})),Rt&&Rt.save()):Tt!==Ct&&Tt>=0&&(bt({sortable:this,name:"update",toEl:yt,originalEvent:e}),bt({sortable:this,name:"sort",toEl:yt,originalEvent:e})),di.active&&(null!=Tt&&-1!==Tt||(Tt=Ct,At=Et),bt({sortable:this,name:"end",toEl:yt,originalEvent:e}),this.save())))),this._nulling()},_nulling:function(){_t("nulling",this),$t=ft=yt=xt=wt=Dt=kt=St=Mt=Pt=Lt=Tt=At=Ct=Et=Ot=Ut=Rt=It=di.dragged=di.ghost=di.clone=di.active=null;var e=this.el;Gt.forEach(function(t){e.contains(t)&&(t.checked=!0)}),Gt.length=Ht=Nt=0},handleEvent:function(e){switch(e.type){case"drop":case"dragend":this._onDrop(e);break;case"dragenter":case"dragover":ft&&(this._onDragOver(e),function(e){e.dataTransfer&&(e.dataTransfer.dropEffect="move"),e.cancelable&&e.preventDefault()}(e));break;case"selectstart":e.preventDefault()}},toArray:function(){for(var e,t=[],i=this.el.children,s=0,a=i.length,o=this.options;s<a;s++)Xe(e=i[s],o.draggable,this.el,!1)&&t.push(e.getAttribute(o.dataIdAttr)||gi(e));return t},sort:function(e,t){var i={},s=this.el;this.toArray().forEach(function(e,t){var a=s.children[t];Xe(a,this.options.draggable,s,!1)&&(i[e]=a)},this),t&&this.captureAnimationState(),e.forEach(function(e){i[e]&&(s.removeChild(i[e]),s.appendChild(i[e]))}),t&&this.animateAll()},save:function(){var e=this.options.store;e&&e.set&&e.set(this)},closest:function(e,t){return Xe(e,t||this.options.draggable,this.el,!1)},option:function(e,t){var i=this.options;if(void 0===t)return i[e];var s=mt.modifyOption(this,e,t);i[e]=void 0!==s?s:t,"group"===e&&ai(i)},destroy:function(){_t("destroy",this);var e=this.el;e[pt]=null,Fe(e,"mousedown",this._onTapStart),Fe(e,"touchstart",this._onTapStart),Fe(e,"pointerdown",this._onTapStart),this.nativeDraggable&&(Fe(e,"dragover",this),Fe(e,"dragenter",this)),Array.prototype.forEach.call(e.querySelectorAll("[draggable]"),function(e){e.removeAttribute("draggable")}),this._onDrop(),this._disableDelayedDragEvents(),Xt.splice(Xt.indexOf(this.el),1),this.el=e=null},_hideClone:function(){if(!St){if(_t("hideClone",this),di.eventCanceled)return;Ke(Dt,"display","none"),this.options.removeCloneOnHide&&Dt.parentNode&&Dt.parentNode.removeChild(Dt),St=!0}},_showClone:function(e){if("clone"===e.lastPutMode){if(St){if(_t("showClone",this),di.eventCanceled)return;ft.parentNode!=$t||this.options.group.revertClone?wt?$t.insertBefore(Dt,wt):$t.appendChild(Dt):$t.insertBefore(Dt,ft),this.options.group.revertClone&&this.animate(ft,Dt),Ke(Dt,"display",""),St=!1}}else this._hideClone()}},Jt&&Be(document,"touchmove",function(e){(di.active||qt)&&e.cancelable&&e.preventDefault()}),di.utils={on:Be,off:Fe,css:Ke,find:Je,is:function(e,t){return!!Xe(e,t,e,!1)},extend:function(e,t){if(e&&t)for(var i in t)t.hasOwnProperty(i)&&(e[i]=t[i]);return e},throttle:lt,closest:Xe,toggleClass:We,clone:ct,index:at,nextTick:ui,cancelNextTick:mi,detectDirection:si,getChild:it,expando:pt},di.get=function(e){return e[pt]},di.mount=function(){for(var e=arguments.length,t=new Array(e),i=0;i<e;i++)t[i]=arguments[i];t[0].constructor===Array&&(t=t[0]),t.forEach(function(e){if(!e.prototype||!e.prototype.constructor)throw"Sortable: Mounted plugin must be a constructor function, not ".concat({}.toString.call(e));e.utils&&(di.utils=Re(Re({},di.utils),e.utils)),mt.mount(e)})},di.create=function(e,t){return new di(e,t)},di.version="1.15.7";var vi,_i,bi,fi,yi,xi,$i=[],wi=!1;function ki(){$i.forEach(function(e){clearInterval(e.pid)}),$i=[]}function Di(){clearInterval(xi)}var Si=lt(function(e,t,i,s){if(t.scroll){var a,o=(e.touches?e.touches[0]:e).clientX,n=(e.touches?e.touches[0]:e).clientY,r=t.scrollSensitivity,l=t.scrollSpeed,d=Qe(),c=!1;_i!==i&&(_i=i,ki(),vi=t.scroll,a=t.scrollFn,!0===vi&&(vi=nt(i,!0)));var h=0,p=vi;do{var g=p,u=et(g),m=u.top,v=u.bottom,_=u.left,b=u.right,f=u.width,y=u.height,x=void 0,$=void 0,w=g.scrollWidth,k=g.scrollHeight,D=Ke(g),S=g.scrollLeft,C=g.scrollTop;g===d?(x=f<w&&("auto"===D.overflowX||"scroll"===D.overflowX||"visible"===D.overflowX),$=y<k&&("auto"===D.overflowY||"scroll"===D.overflowY||"visible"===D.overflowY)):(x=f<w&&("auto"===D.overflowX||"scroll"===D.overflowX),$=y<k&&("auto"===D.overflowY||"scroll"===D.overflowY));var T=x&&(Math.abs(b-o)<=r&&S+f<w)-(Math.abs(_-o)<=r&&!!S),E=$&&(Math.abs(v-n)<=r&&C+y<k)-(Math.abs(m-n)<=r&&!!C);if(!$i[h])for(var A=0;A<=h;A++)$i[A]||($i[A]={});$i[h].vx==T&&$i[h].vy==E&&$i[h].el===g||($i[h].el=g,$i[h].vx=T,$i[h].vy=E,clearInterval($i[h].pid),0==T&&0==E||(c=!0,$i[h].pid=setInterval(function(){s&&0===this.layer&&di.active._onTouchMove(yi);var t=$i[this.layer].vy?$i[this.layer].vy*l:0,i=$i[this.layer].vx?$i[this.layer].vx*l:0;"function"==typeof a&&"continue"!==a.call(di.dragged.parentNode[pt],i,t,e,yi,$i[this.layer].el)||dt($i[this.layer].el,i,t)}.bind({layer:h}),24))),h++}while(t.bubbleScroll&&p!==d&&(p=nt(p,!1)));wi=c}},30),Ci=function(e){var t=e.originalEvent,i=e.putSortable,s=e.dragEl,a=e.activeSortable,o=e.dispatchSortableEvent,n=e.hideGhostForTarget,r=e.unhideGhostForTarget;if(t){var l=i||a;n();var d=t.changedTouches&&t.changedTouches.length?t.changedTouches[0]:t,c=document.elementFromPoint(d.clientX,d.clientY);r(),l&&!l.el.contains(c)&&(o("spill"),this.onSpill({dragEl:s,putSortable:i}))}};function Ti(){}function Ei(){}Ti.prototype={startIndex:null,dragStart:function(e){var t=e.oldDraggableIndex;this.startIndex=t},onSpill:function(e){var t=e.dragEl,i=e.putSortable;this.sortable.captureAnimationState(),i&&i.captureAnimationState();var s=it(this.sortable.el,this.startIndex,this.options);s?this.sortable.el.insertBefore(t,s):this.sortable.el.appendChild(t),this.sortable.animateAll(),i&&i.animateAll()},drop:Ci},Ae(Ti,{pluginName:"revertOnSpill"}),Ei.prototype={onSpill:function(e){var t=e.dragEl,i=e.putSortable||this.sortable;i.captureAnimationState(),t.parentNode&&t.parentNode.removeChild(t),i.animateAll()},drop:Ci},Ae(Ei,{pluginName:"removeOnSpill"}),di.mount(new function(){function e(){for(var e in this.defaults={scroll:!0,forceAutoScrollFallback:!1,scrollSensitivity:30,scrollSpeed:10,bubbleScroll:!0},this)"_"===e.charAt(0)&&"function"==typeof this[e]&&(this[e]=this[e].bind(this))}return e.prototype={dragStarted:function(e){var t=e.originalEvent;this.sortable.nativeDraggable?Be(document,"dragover",this._handleAutoScroll):this.options.supportPointer?Be(document,"pointermove",this._handleFallbackAutoScroll):t.touches?Be(document,"touchmove",this._handleFallbackAutoScroll):Be(document,"mousemove",this._handleFallbackAutoScroll)},dragOverCompleted:function(e){var t=e.originalEvent;this.options.dragOverBubble||t.rootEl||this._handleAutoScroll(t)},drop:function(){this.sortable.nativeDraggable?Fe(document,"dragover",this._handleAutoScroll):(Fe(document,"pointermove",this._handleFallbackAutoScroll),Fe(document,"touchmove",this._handleFallbackAutoScroll),Fe(document,"mousemove",this._handleFallbackAutoScroll)),Di(),ki(),clearTimeout(Ze),Ze=void 0},nulling:function(){yi=_i=vi=wi=xi=bi=fi=null,$i.length=0},_handleFallbackAutoScroll:function(e){this._handleAutoScroll(e,!0)},_handleAutoScroll:function(e,t){var i=this,s=(e.touches?e.touches[0]:e).clientX,a=(e.touches?e.touches[0]:e).clientY,o=document.elementFromPoint(s,a);if(yi=e,t||this.options.forceAutoScrollFallback||Ne||He||Ve){Si(e,this.options,o,t);var n=nt(o,!0);!wi||xi&&s===bi&&a===fi||(xi&&Di(),xi=setInterval(function(){var o=nt(document.elementFromPoint(s,a),!0);o!==n&&(n=o,ki()),Si(e,i.options,o,t)},10),bi=s,fi=a)}else{if(!this.options.bubbleScroll||nt(o,!0)===Qe())return void ki();Si(e,this.options,nt(o,!1),!1)}}},Ae(e,{pluginName:"scroll",initializeByDefault:!0})}),di.mount(Ei,Ti);let Ai=class extends re{constructor(){super(...arguments),this.templateName="",this.command=null,this.busy=!1,this.actionLabel=null,this.hasTrigger=!1,this.showActionMapping=!0,this._editingName=!1,this._draftName=""}_commandLabel(){const e=this.command;return e.protocol&&e.code?`${e.protocol}: ${e.code}`:e.raw_timings?.length?`RAW: ${e.raw_timings.length} timings`:e.protocol??"IR"}_prontoSlArray(e){const t=e.trim().split(/\s+/);if(t.length<6)return null;const i=parseInt(t[2],16)+parseInt(t[3],16),s=t.slice(4);if(s.length<2*i)return null;const a=[];for(let e=0;e<2*i;e++){const t=parseInt(s[e],16);a.push(t>=48)}return a.length>0?a:null}_renderDiamonds(){const e=this.command;if(!e||"PRONTO"!==e.protocol?.toUpperCase()||!e.code)return null;const t=this._prontoSlArray(e.code);return t?F`<span class="diamonds">${t.map(e=>e?F`<span class="diamond long">◆</span>`:F`<span class="diamond short">◇</span>`)}</span>`:null}_emit(e){this.dispatchEvent(new CustomEvent(e,{detail:{templateName:this.templateName,command:this.command},bubbles:!0,composed:!0}))}_startRename(e){this.command&&!this.busy&&(e.stopPropagation(),this._draftName=this.command.name,this._editingName=!0,this.updateComplete.then(()=>{const e=this.shadowRoot?.querySelector(".name-input");e?.focus(),e?.select()}))}_commitRename(){if(!this._editingName)return;const e=this._draftName.trim();this._editingName=!1,this.command&&e&&e!==this.command.name&&this.dispatchEvent(new CustomEvent("rename-command",{detail:{command:this.command,name:e},bubbles:!0,composed:!0}))}_onRenameKeydown(e){"Enter"===e.key?(e.preventDefault(),this._commitRename()):"Escape"===e.key&&(this._editingName=!1)}render(){const e=null!==this.command,t=e?this._renderDiamonds():null;return F`
+function e(e,t,i,s){var o,a=arguments.length,r=a<3?t:null===s?s=Object.getOwnPropertyDescriptor(t,i):s;if("object"==typeof Reflect&&"function"==typeof Reflect.decorate)r=Reflect.decorate(e,t,i,s);else for(var n=e.length-1;n>=0;n--)(o=e[n])&&(r=(a<3?o(r):a>3?o(t,i,r):o(t,i))||r);return a>3&&r&&Object.defineProperty(t,i,r),r}"function"==typeof SuppressedError&&SuppressedError;const t=globalThis,i=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow)&&"adoptedStyleSheets"in Document.prototype&&"replace"in CSSStyleSheet.prototype,s=Symbol(),o=new WeakMap;let a=class{constructor(e,t,i){if(this._$cssResult$=!0,i!==s)throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");this.cssText=e,this.t=t}get styleSheet(){let e=this.o;const t=this.t;if(i&&void 0===e){const i=void 0!==t&&1===t.length;i&&(e=o.get(t)),void 0===e&&((this.o=e=new CSSStyleSheet).replaceSync(this.cssText),i&&o.set(t,e))}return e}toString(){return this.cssText}};const r=(e,...t)=>{const i=1===e.length?e[0]:t.reduce((t,i,s)=>t+(e=>{if(!0===e._$cssResult$)return e.cssText;if("number"==typeof e)return e;throw Error("Value passed to 'css' function must be a 'css' function result: "+e+". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.")})(i)+e[s+1],e[0]);return new a(i,e,s)},n=i?e=>e:e=>e instanceof CSSStyleSheet?(e=>{let t="";for(const i of e.cssRules)t+=i.cssText;return(e=>new a("string"==typeof e?e:e+"",void 0,s))(t)})(e):e,{is:l,defineProperty:d,getOwnPropertyDescriptor:c,getOwnPropertyNames:h,getOwnPropertySymbols:p,getPrototypeOf:g}=Object,u=globalThis,m=u.trustedTypes,v=m?m.emptyScript:"",_=u.reactiveElementPolyfillSupport,b=(e,t)=>e,f={toAttribute(e,t){switch(t){case Boolean:e=e?v:null;break;case Object:case Array:e=null==e?e:JSON.stringify(e)}return e},fromAttribute(e,t){let i=e;switch(t){case Boolean:i=null!==e;break;case Number:i=null===e?null:Number(e);break;case Object:case Array:try{i=JSON.parse(e)}catch(e){i=null}}return i}},y=(e,t)=>!l(e,t),x={attribute:!0,type:String,converter:f,reflect:!1,useDefault:!1,hasChanged:y};Symbol.metadata??=Symbol("metadata"),u.litPropertyMetadata??=new WeakMap;let $=class extends HTMLElement{static addInitializer(e){this._$Ei(),(this.l??=[]).push(e)}static get observedAttributes(){return this.finalize(),this._$Eh&&[...this._$Eh.keys()]}static createProperty(e,t=x){if(t.state&&(t.attribute=!1),this._$Ei(),this.prototype.hasOwnProperty(e)&&((t=Object.create(t)).wrapped=!0),this.elementProperties.set(e,t),!t.noAccessor){const i=Symbol(),s=this.getPropertyDescriptor(e,i,t);void 0!==s&&d(this.prototype,e,s)}}static getPropertyDescriptor(e,t,i){const{get:s,set:o}=c(this.prototype,e)??{get(){return this[t]},set(e){this[t]=e}};return{get:s,set(t){const a=s?.call(this);o?.call(this,t),this.requestUpdate(e,a,i)},configurable:!0,enumerable:!0}}static getPropertyOptions(e){return this.elementProperties.get(e)??x}static _$Ei(){if(this.hasOwnProperty(b("elementProperties")))return;const e=g(this);e.finalize(),void 0!==e.l&&(this.l=[...e.l]),this.elementProperties=new Map(e.elementProperties)}static finalize(){if(this.hasOwnProperty(b("finalized")))return;if(this.finalized=!0,this._$Ei(),this.hasOwnProperty(b("properties"))){const e=this.properties,t=[...h(e),...p(e)];for(const i of t)this.createProperty(i,e[i])}const e=this[Symbol.metadata];if(null!==e){const t=litPropertyMetadata.get(e);if(void 0!==t)for(const[e,i]of t)this.elementProperties.set(e,i)}this._$Eh=new Map;for(const[e,t]of this.elementProperties){const i=this._$Eu(e,t);void 0!==i&&this._$Eh.set(i,e)}this.elementStyles=this.finalizeStyles(this.styles)}static finalizeStyles(e){const t=[];if(Array.isArray(e)){const i=new Set(e.flat(1/0).reverse());for(const e of i)t.unshift(n(e))}else void 0!==e&&t.push(n(e));return t}static _$Eu(e,t){const i=t.attribute;return!1===i?void 0:"string"==typeof i?i:"string"==typeof e?e.toLowerCase():void 0}constructor(){super(),this._$Ep=void 0,this.isUpdatePending=!1,this.hasUpdated=!1,this._$Em=null,this._$Ev()}_$Ev(){this._$ES=new Promise(e=>this.enableUpdating=e),this._$AL=new Map,this._$E_(),this.requestUpdate(),this.constructor.l?.forEach(e=>e(this))}addController(e){(this._$EO??=new Set).add(e),void 0!==this.renderRoot&&this.isConnected&&e.hostConnected?.()}removeController(e){this._$EO?.delete(e)}_$E_(){const e=new Map,t=this.constructor.elementProperties;for(const i of t.keys())this.hasOwnProperty(i)&&(e.set(i,this[i]),delete this[i]);e.size>0&&(this._$Ep=e)}createRenderRoot(){const e=this.shadowRoot??this.attachShadow(this.constructor.shadowRootOptions);return((e,s)=>{if(i)e.adoptedStyleSheets=s.map(e=>e instanceof CSSStyleSheet?e:e.styleSheet);else for(const i of s){const s=document.createElement("style"),o=t.litNonce;void 0!==o&&s.setAttribute("nonce",o),s.textContent=i.cssText,e.appendChild(s)}})(e,this.constructor.elementStyles),e}connectedCallback(){this.renderRoot??=this.createRenderRoot(),this.enableUpdating(!0),this._$EO?.forEach(e=>e.hostConnected?.())}enableUpdating(e){}disconnectedCallback(){this._$EO?.forEach(e=>e.hostDisconnected?.())}attributeChangedCallback(e,t,i){this._$AK(e,i)}_$ET(e,t){const i=this.constructor.elementProperties.get(e),s=this.constructor._$Eu(e,i);if(void 0!==s&&!0===i.reflect){const o=(void 0!==i.converter?.toAttribute?i.converter:f).toAttribute(t,i.type);this._$Em=e,null==o?this.removeAttribute(s):this.setAttribute(s,o),this._$Em=null}}_$AK(e,t){const i=this.constructor,s=i._$Eh.get(e);if(void 0!==s&&this._$Em!==s){const e=i.getPropertyOptions(s),o="function"==typeof e.converter?{fromAttribute:e.converter}:void 0!==e.converter?.fromAttribute?e.converter:f;this._$Em=s;const a=o.fromAttribute(t,e.type);this[s]=a??this._$Ej?.get(s)??a,this._$Em=null}}requestUpdate(e,t,i,s=!1,o){if(void 0!==e){const a=this.constructor;if(!1===s&&(o=this[e]),i??=a.getPropertyOptions(e),!((i.hasChanged??y)(o,t)||i.useDefault&&i.reflect&&o===this._$Ej?.get(e)&&!this.hasAttribute(a._$Eu(e,i))))return;this.C(e,t,i)}!1===this.isUpdatePending&&(this._$ES=this._$EP())}C(e,t,{useDefault:i,reflect:s,wrapped:o},a){i&&!(this._$Ej??=new Map).has(e)&&(this._$Ej.set(e,a??t??this[e]),!0!==o||void 0!==a)||(this._$AL.has(e)||(this.hasUpdated||i||(t=void 0),this._$AL.set(e,t)),!0===s&&this._$Em!==e&&(this._$Eq??=new Set).add(e))}async _$EP(){this.isUpdatePending=!0;try{await this._$ES}catch(e){Promise.reject(e)}const e=this.scheduleUpdate();return null!=e&&await e,!this.isUpdatePending}scheduleUpdate(){return this.performUpdate()}performUpdate(){if(!this.isUpdatePending)return;if(!this.hasUpdated){if(this.renderRoot??=this.createRenderRoot(),this._$Ep){for(const[e,t]of this._$Ep)this[e]=t;this._$Ep=void 0}const e=this.constructor.elementProperties;if(e.size>0)for(const[t,i]of e){const{wrapped:e}=i,s=this[t];!0!==e||this._$AL.has(t)||void 0===s||this.C(t,void 0,i,s)}}let e=!1;const t=this._$AL;try{e=this.shouldUpdate(t),e?(this.willUpdate(t),this._$EO?.forEach(e=>e.hostUpdate?.()),this.update(t)):this._$EM()}catch(t){throw e=!1,this._$EM(),t}e&&this._$AE(t)}willUpdate(e){}_$AE(e){this._$EO?.forEach(e=>e.hostUpdated?.()),this.hasUpdated||(this.hasUpdated=!0,this.firstUpdated(e)),this.updated(e)}_$EM(){this._$AL=new Map,this.isUpdatePending=!1}get updateComplete(){return this.getUpdateComplete()}getUpdateComplete(){return this._$ES}shouldUpdate(e){return!0}update(e){this._$Eq&&=this._$Eq.forEach(e=>this._$ET(e,this[e])),this._$EM()}updated(e){}firstUpdated(e){}};$.elementStyles=[],$.shadowRootOptions={mode:"open"},$[b("elementProperties")]=new Map,$[b("finalized")]=new Map,_?.({ReactiveElement:$}),(u.reactiveElementVersions??=[]).push("2.1.2");const w=globalThis,k=e=>e,D=w.trustedTypes,S=D?D.createPolicy("lit-html",{createHTML:e=>e}):void 0,C="$lit$",T=`lit$${Math.random().toFixed(9).slice(2)}$`,E="?"+T,A=`<${E}>`,I=document,P=()=>I.createComment(""),R=e=>null===e||"object"!=typeof e&&"function"!=typeof e,M=Array.isArray,H="[ \t\n\f\r]",N=/<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g,z=/-->/g,L=/>/g,V=RegExp(`>|${H}(?:([^\\s"'>=/]+)(${H}*=${H}*(?:[^ \t\n\f\r"'\`<>=]|("|')|))|$)`,"g"),O=/'/g,U=/"/g,F=/^(?:script|style|textarea|title)$/i,B=(e,...t)=>({_$litType$:1,strings:e,values:t}),j=Symbol.for("lit-noChange"),q=Symbol.for("lit-nothing"),X=new WeakMap,Z=I.createTreeWalker(I,129);function Y(e,t){if(!M(e)||!e.hasOwnProperty("raw"))throw Error("invalid template strings array");return void 0!==S?S.createHTML(t):t}class W{constructor({strings:e,_$litType$:t},i){let s;this.parts=[];let o=0,a=0;const r=e.length-1,n=this.parts,[l,d]=((e,t)=>{const i=e.length-1,s=[];let o,a=2===t?"<svg>":3===t?"<math>":"",r=N;for(let t=0;t<i;t++){const i=e[t];let n,l,d=-1,c=0;for(;c<i.length&&(r.lastIndex=c,l=r.exec(i),null!==l);)c=r.lastIndex,r===N?"!--"===l[1]?r=z:void 0!==l[1]?r=L:void 0!==l[2]?(F.test(l[2])&&(o=RegExp("</"+l[2],"g")),r=V):void 0!==l[3]&&(r=V):r===V?">"===l[0]?(r=o??N,d=-1):void 0===l[1]?d=-2:(d=r.lastIndex-l[2].length,n=l[1],r=void 0===l[3]?V:'"'===l[3]?U:O):r===U||r===O?r=V:r===z||r===L?r=N:(r=V,o=void 0);const h=r===V&&e[t+1].startsWith("/>")?" ":"";a+=r===N?i+A:d>=0?(s.push(n),i.slice(0,d)+C+i.slice(d)+T+h):i+T+(-2===d?t:h)}return[Y(e,a+(e[i]||"<?>")+(2===t?"</svg>":3===t?"</math>":"")),s]})(e,t);if(this.el=W.createElement(l,i),Z.currentNode=this.el.content,2===t||3===t){const e=this.el.content.firstChild;e.replaceWith(...e.childNodes)}for(;null!==(s=Z.nextNode())&&n.length<r;){if(1===s.nodeType){if(s.hasAttributes())for(const e of s.getAttributeNames())if(e.endsWith(C)){const t=d[a++],i=s.getAttribute(e).split(T),r=/([.?@])?(.*)/.exec(t);n.push({type:1,index:o,name:r[2],strings:i,ctor:"."===r[1]?ee:"?"===r[1]?te:"@"===r[1]?ie:Q}),s.removeAttribute(e)}else e.startsWith(T)&&(n.push({type:6,index:o}),s.removeAttribute(e));if(F.test(s.tagName)){const e=s.textContent.split(T),t=e.length-1;if(t>0){s.textContent=D?D.emptyScript:"";for(let i=0;i<t;i++)s.append(e[i],P()),Z.nextNode(),n.push({type:2,index:++o});s.append(e[t],P())}}}else if(8===s.nodeType)if(s.data===E)n.push({type:2,index:o});else{let e=-1;for(;-1!==(e=s.data.indexOf(T,e+1));)n.push({type:7,index:o}),e+=T.length-1}o++}}static createElement(e,t){const i=I.createElement("template");return i.innerHTML=e,i}}function K(e,t,i=e,s){if(t===j)return t;let o=void 0!==s?i._$Co?.[s]:i._$Cl;const a=R(t)?void 0:t._$litDirective$;return o?.constructor!==a&&(o?._$AO?.(!1),void 0===a?o=void 0:(o=new a(e),o._$AT(e,i,s)),void 0!==s?(i._$Co??=[])[s]=o:i._$Cl=o),void 0!==o&&(t=K(e,o._$AS(e,t.values),o,s)),t}class G{constructor(e,t){this._$AV=[],this._$AN=void 0,this._$AD=e,this._$AM=t}get parentNode(){return this._$AM.parentNode}get _$AU(){return this._$AM._$AU}u(e){const{el:{content:t},parts:i}=this._$AD,s=(e?.creationScope??I).importNode(t,!0);Z.currentNode=s;let o=Z.nextNode(),a=0,r=0,n=i[0];for(;void 0!==n;){if(a===n.index){let t;2===n.type?t=new J(o,o.nextSibling,this,e):1===n.type?t=new n.ctor(o,n.name,n.strings,this,e):6===n.type&&(t=new se(o,this,e)),this._$AV.push(t),n=i[++r]}a!==n?.index&&(o=Z.nextNode(),a++)}return Z.currentNode=I,s}p(e){let t=0;for(const i of this._$AV)void 0!==i&&(void 0!==i.strings?(i._$AI(e,i,t),t+=i.strings.length-2):i._$AI(e[t])),t++}}class J{get _$AU(){return this._$AM?._$AU??this._$Cv}constructor(e,t,i,s){this.type=2,this._$AH=q,this._$AN=void 0,this._$AA=e,this._$AB=t,this._$AM=i,this.options=s,this._$Cv=s?.isConnected??!0}get parentNode(){let e=this._$AA.parentNode;const t=this._$AM;return void 0!==t&&11===e?.nodeType&&(e=t.parentNode),e}get startNode(){return this._$AA}get endNode(){return this._$AB}_$AI(e,t=this){e=K(this,e,t),R(e)?e===q||null==e||""===e?(this._$AH!==q&&this._$AR(),this._$AH=q):e!==this._$AH&&e!==j&&this._(e):void 0!==e._$litType$?this.$(e):void 0!==e.nodeType?this.T(e):(e=>M(e)||"function"==typeof e?.[Symbol.iterator])(e)?this.k(e):this._(e)}O(e){return this._$AA.parentNode.insertBefore(e,this._$AB)}T(e){this._$AH!==e&&(this._$AR(),this._$AH=this.O(e))}_(e){this._$AH!==q&&R(this._$AH)?this._$AA.nextSibling.data=e:this.T(I.createTextNode(e)),this._$AH=e}$(e){const{values:t,_$litType$:i}=e,s="number"==typeof i?this._$AC(e):(void 0===i.el&&(i.el=W.createElement(Y(i.h,i.h[0]),this.options)),i);if(this._$AH?._$AD===s)this._$AH.p(t);else{const e=new G(s,this),i=e.u(this.options);e.p(t),this.T(i),this._$AH=e}}_$AC(e){let t=X.get(e.strings);return void 0===t&&X.set(e.strings,t=new W(e)),t}k(e){M(this._$AH)||(this._$AH=[],this._$AR());const t=this._$AH;let i,s=0;for(const o of e)s===t.length?t.push(i=new J(this.O(P()),this.O(P()),this,this.options)):i=t[s],i._$AI(o),s++;s<t.length&&(this._$AR(i&&i._$AB.nextSibling,s),t.length=s)}_$AR(e=this._$AA.nextSibling,t){for(this._$AP?.(!1,!0,t);e!==this._$AB;){const t=k(e).nextSibling;k(e).remove(),e=t}}setConnected(e){void 0===this._$AM&&(this._$Cv=e,this._$AP?.(e))}}class Q{get tagName(){return this.element.tagName}get _$AU(){return this._$AM._$AU}constructor(e,t,i,s,o){this.type=1,this._$AH=q,this._$AN=void 0,this.element=e,this.name=t,this._$AM=s,this.options=o,i.length>2||""!==i[0]||""!==i[1]?(this._$AH=Array(i.length-1).fill(new String),this.strings=i):this._$AH=q}_$AI(e,t=this,i,s){const o=this.strings;let a=!1;if(void 0===o)e=K(this,e,t,0),a=!R(e)||e!==this._$AH&&e!==j,a&&(this._$AH=e);else{const s=e;let r,n;for(e=o[0],r=0;r<o.length-1;r++)n=K(this,s[i+r],t,r),n===j&&(n=this._$AH[r]),a||=!R(n)||n!==this._$AH[r],n===q?e=q:e!==q&&(e+=(n??"")+o[r+1]),this._$AH[r]=n}a&&!s&&this.j(e)}j(e){e===q?this.element.removeAttribute(this.name):this.element.setAttribute(this.name,e??"")}}class ee extends Q{constructor(){super(...arguments),this.type=3}j(e){this.element[this.name]=e===q?void 0:e}}class te extends Q{constructor(){super(...arguments),this.type=4}j(e){this.element.toggleAttribute(this.name,!!e&&e!==q)}}class ie extends Q{constructor(e,t,i,s,o){super(e,t,i,s,o),this.type=5}_$AI(e,t=this){if((e=K(this,e,t,0)??q)===j)return;const i=this._$AH,s=e===q&&i!==q||e.capture!==i.capture||e.once!==i.once||e.passive!==i.passive,o=e!==q&&(i===q||s);s&&this.element.removeEventListener(this.name,this,i),o&&this.element.addEventListener(this.name,this,e),this._$AH=e}handleEvent(e){"function"==typeof this._$AH?this._$AH.call(this.options?.host??this.element,e):this._$AH.handleEvent(e)}}class se{constructor(e,t,i){this.element=e,this.type=6,this._$AN=void 0,this._$AM=t,this.options=i}get _$AU(){return this._$AM._$AU}_$AI(e){K(this,e)}}const oe={I:J},ae=w.litHtmlPolyfillSupport;ae?.(W,J),(w.litHtmlVersions??=[]).push("3.3.3");const re=globalThis;let ne=class extends ${constructor(){super(...arguments),this.renderOptions={host:this},this._$Do=void 0}createRenderRoot(){const e=super.createRenderRoot();return this.renderOptions.renderBefore??=e.firstChild,e}update(e){const t=this.render();this.hasUpdated||(this.renderOptions.isConnected=this.isConnected),super.update(e),this._$Do=((e,t,i)=>{const s=i?.renderBefore??t;let o=s._$litPart$;if(void 0===o){const e=i?.renderBefore??null;s._$litPart$=o=new J(t.insertBefore(P(),e),e,void 0,i??{})}return o._$AI(e),o})(t,this.renderRoot,this.renderOptions)}connectedCallback(){super.connectedCallback(),this._$Do?.setConnected(!0)}disconnectedCallback(){super.disconnectedCallback(),this._$Do?.setConnected(!1)}render(){return j}};ne._$litElement$=!0,ne.finalized=!0,re.litElementHydrateSupport?.({LitElement:ne});const le=re.litElementPolyfillSupport;le?.({LitElement:ne}),(re.litElementVersions??=[]).push("4.2.2");const de={attribute:!0,type:String,converter:f,reflect:!1,hasChanged:y},ce=(e=de,t,i)=>{const{kind:s,metadata:o}=i;let a=globalThis.litPropertyMetadata.get(o);if(void 0===a&&globalThis.litPropertyMetadata.set(o,a=new Map),"setter"===s&&((e=Object.create(e)).wrapped=!0),a.set(i.name,e),"accessor"===s){const{name:s}=i;return{set(i){const o=t.get.call(this);t.set.call(this,i),this.requestUpdate(s,o,e,!0,i)},init(t){return void 0!==t&&this.C(s,void 0,e,t),t}}}if("setter"===s){const{name:s}=i;return function(i){const o=this[s];t.call(this,i),this.requestUpdate(s,o,e,!0,i)}}throw Error("Unsupported decorator location: "+s)};function he(e){return(t,i)=>"object"==typeof i?ce(e,t,i):((e,t,i)=>{const s=t.hasOwnProperty(i);return t.constructor.createProperty(i,e),s?Object.getOwnPropertyDescriptor(t,i):void 0})(e,t,i)}function pe(e){return he({...e,state:!0,attribute:!1})}const ge=e=>e,ue=e=>customElements.get(e)?ge:(e=>(t,i)=>{void 0!==i?i.addInitializer(()=>{customElements.define(e,t)}):customElements.define(e,t)})(e);class me{constructor(e){this.hass=e}listDevices(){return this.hass.connection.sendMessagePromise({type:"hair/devices"})}getDevice(e){return this.hass.connection.sendMessagePromise({type:"hair/device",device_id:e})}createDevice(e){return this.hass.connection.sendMessagePromise({type:"hair/device/create",...e})}updateDevice(e,t){return this.hass.connection.sendMessagePromise({type:"hair/device/update",device_id:e,...t})}deleteDevice(e){return this.hass.connection.sendMessagePromise({type:"hair/device/delete",device_id:e})}duplicateDevice(e,t){return this.hass.connection.sendMessagePromise({type:"hair/device/duplicate",device_id:e,new_name:t})}deleteCommand(e,t){return this.hass.connection.sendMessagePromise({type:"hair/command/delete",device_id:e,command_id:t})}setCommandTxForceRaw(e,t,i){return this.hass.connection.sendMessagePromise({type:"hair/command/set-tx-force-raw",device_id:e,command_id:t,tx_force_raw:i})}reorderCommands(e,t){return this.hass.connection.sendMessagePromise({type:"hair/device/reorder-commands",device_id:e,command_ids:t})}reorderDevices(e){return this.hass.connection.sendMessagePromise({type:"hair/devices/reorder",device_ids:e})}sendCommand(e,t){return this.hass.connection.sendMessagePromise({type:"hair/command/send",device_id:e,command_id:t})}listTemplates(e){return this.hass.connection.sendMessagePromise({type:"hair/templates",device_type:e})}listCaptureProviders(){return this.hass.connection.sendMessagePromise({type:"hair/capture/providers"})}listReceivers(){return this.hass.connection.sendMessagePromise({type:"hair/receivers"})}getSnifferStatus(){return this.hass.connection.sendMessagePromise({type:"hair/sniffer/status"})}getCodeBrands(){return this.hass.connection.sendMessagePromise({type:"hair/codes/brands"})}importCodeRemote(e,t){const i={type:"hair/codes/import-remote",codebook_id:e};return t&&(i.name=t),this.hass.connection.sendMessagePromise(i)}async startCapture(e,t,i){let s=null;const o=await this.hass.connection.subscribeMessage(e=>{e.type?.startsWith("capture_")?i(e):e.session_id&&(s=e)},{type:"hair/capture/start",device_id:e,timeout:t});if(await Promise.resolve(),null===s)throw new Error("Capture session did not start");return{session:s,unsubscribe:o}}cancelCapture(e){return this.hass.connection.sendMessagePromise({type:"hair/capture/cancel",session_id:e})}saveCapturedCommand(e){return this.hass.connection.sendMessagePromise({type:"hair/capture/save",...e})}getActionOptions(e){return this.hass.connection.sendMessagePromise({type:"hair/device/action-options",device_type:e})}updateMapping(e,t,i){return this.hass.connection.sendMessagePromise({type:"hair/device/update-mapping",device_id:e,command_name:t,action_key:i})}getUnknownDevices(e){return this.hass.connection.sendMessagePromise({type:"hair/unknown/devices",...e})}getUnknownDevice(e){return this.hass.connection.sendMessagePromise({type:"hair/unknown/device",device_id:e})}dismissUnknown(e){return this.hass.connection.sendMessagePromise({type:"hair/unknown/dismiss",device_id:e})}undismissUnknown(e){return this.hass.connection.sendMessagePromise({type:"hair/unknown/undismiss",device_id:e})}assignSignal(e){return this.hass.connection.sendMessagePromise({type:"hair/unknown/assign",...e})}assignToNewDevice(e){return this.hass.connection.sendMessagePromise({type:"hair/unknown/assign-new-device",...e})}deleteSignal(e,t){return this.hass.connection.sendMessagePromise({type:"hair/unknown/signal/delete",device_id:e,signal_id:t})}testSignal(e,t){const i={type:"hair/unknown/test",signal_id:e};return t&&(i.emitter_entity_id=t),this.hass.connection.sendMessagePromise(i)}renameUnknown(e,t){return this.hass.connection.sendMessagePromise({type:"hair/unknown/rename",device_id:e,label:t})}clearUnknowns(e){return this.hass.connection.sendMessagePromise({type:"hair/unknown/clear",...e?{source:e}:{}})}setSignalAlias(e,t,i){return this.hass.connection.sendMessagePromise({type:"hair/unknown/signal/set-alias",device_id:e,signal_id:t,alias:i})}reorderUnknownDevices(e,t){return this.hass.connection.sendMessagePromise({type:"hair/unknown/reorder",source:e,device_ids:t})}reorderUnknownSignals(e,t){return this.hass.connection.sendMessagePromise({type:"hair/unknown/signal/reorder",device_id:e,signal_ids:t})}createRemote(e){return this.hass.connection.sendMessagePromise({type:"hair/clip/create-remote",name:e})}createSignal(e){return this.hass.connection.sendMessagePromise({type:"hair/clip/create-signal",...e})}editSignalPronto(e){return this.hass.connection.sendMessagePromise({type:"hair/unknown/signal/edit-pronto",...e})}validatePronto(e){return this.hass.connection.sendMessagePromise({type:"hair/clip/validate-pronto",pronto:e})}snapPreview(e){return this.hass.connection.sendMessagePromise({type:"hair/unknown/signal/snap-preview",...e})}updateCommand(e){return this.hass.connection.sendMessagePromise({type:"hair/command/update",...e})}deleteRemote(e){return this.hass.connection.sendMessagePromise({type:"hair/clip/delete-remote",device_id:e})}listPluckVendors(){return this.hass.connection.sendMessagePromise({type:"hair/pluck/list-vendors"})}runPluck(e){return this.hass.connection.sendMessagePromise({type:"hair/pluck/run",...e})}createPluckedBlaster(e){return this.hass.connection.sendMessagePromise({type:"hair/pluck/create-blaster",...e})}createPluckedSignal(e){return this.hass.connection.sendMessagePromise({type:"hair/pluck/create-signal",...e})}deletePluckedBlaster(e){return this.hass.connection.sendMessagePromise({type:"hair/pluck/delete-blaster",device_id:e})}async subscribeUnknownSignals(e){return this.hass.connection.subscribeEvents(t=>e(t.data),"hair_signal_detected")}async subscribeSignalRemoved(e){return this.hass.connection.subscribeEvents(t=>e(t.data),"hair_signal_removed")}async subscribeSignalUpdated(e){return this.hass.connection.subscribeEvents(t=>e(t.data),"hair_signal_updated")}async subscribeDismissActivity(e){return this.hass.connection.subscribeEvents(t=>e(t.data),"hair_dismiss_activity")}listTriggers(){return this.hass.connection.sendMessagePromise({type:"hair/triggers"})}createTrigger(e){return this.hass.connection.sendMessagePromise({type:"hair/trigger/create",...e})}updateTrigger(e,t){return this.hass.connection.sendMessagePromise({type:"hair/trigger/update",trigger_id:e,...t})}deleteTrigger(e){return this.hass.connection.sendMessagePromise({type:"hair/trigger/delete",trigger_id:e})}async subscribeTriggerFired(e){return this.hass.connection.subscribeMessage(e,{type:"hair/trigger/subscribe"})}}const ve=e=>(...t)=>({_$litDirective$:e,values:t});let _e=class{constructor(e){}get _$AU(){return this._$AM._$AU}_$AT(e,t,i){this._$Ct=e,this._$AM=t,this._$Ci=i}_$AS(e,t){return this.update(e,t)}update(e,t){return this.render(...t)}};const{I:be}=oe,fe=e=>e,ye=()=>document.createComment(""),xe=(e,t,i)=>{const s=e._$AA.parentNode,o=void 0===t?e._$AB:t._$AA;if(void 0===i){const t=s.insertBefore(ye(),o),a=s.insertBefore(ye(),o);i=new be(t,a,e,e.options)}else{const t=i._$AB.nextSibling,a=i._$AM,r=a!==e;if(r){let t;i._$AQ?.(e),i._$AM=e,void 0!==i._$AP&&(t=e._$AU)!==a._$AU&&i._$AP(t)}if(t!==o||r){let e=i._$AA;for(;e!==t;){const t=fe(e).nextSibling;fe(s).insertBefore(e,o),e=t}}}return i},$e=(e,t,i=e)=>(e._$AI(t,i),e),we={},ke=(e,t=we)=>e._$AH=t,De=e=>{e._$AR(),e._$AA.remove()},Se=ve(class extends _e{constructor(){super(...arguments),this.key=q}render(e,t){return this.key=e,t}update(e,[t,i]){return t!==this.key&&(ke(e),this.key=t),i}}),Ce=(e,t,i)=>{const s=new Map;for(let o=t;o<=i;o++)s.set(e[o],o);return s},Te=ve(class extends _e{constructor(e){if(super(e),2!==e.type)throw Error("repeat() can only be used in text expressions")}dt(e,t,i){let s;void 0===i?i=t:void 0!==t&&(s=t);const o=[],a=[];let r=0;for(const t of e)o[r]=s?s(t,r):r,a[r]=i(t,r),r++;return{values:a,keys:o}}render(e,t,i){return this.dt(e,t,i).values}update(e,[t,i,s]){const o=(e=>e._$AH)(e),{values:a,keys:r}=this.dt(t,i,s);if(!Array.isArray(o))return this.ut=r,a;const n=this.ut??=[],l=[];let d,c,h=0,p=o.length-1,g=0,u=a.length-1;for(;h<=p&&g<=u;)if(null===o[h])h++;else if(null===o[p])p--;else if(n[h]===r[g])l[g]=$e(o[h],a[g]),h++,g++;else if(n[p]===r[u])l[u]=$e(o[p],a[u]),p--,u--;else if(n[h]===r[u])l[u]=$e(o[h],a[u]),xe(e,l[u+1],o[h]),h++,u--;else if(n[p]===r[g])l[g]=$e(o[p],a[g]),xe(e,o[h],o[p]),p--,g++;else if(void 0===d&&(d=Ce(r,g,u),c=Ce(n,h,p)),d.has(n[h]))if(d.has(n[p])){const t=c.get(r[g]),i=void 0!==t?o[t]:null;if(null===i){const t=xe(e,o[h]);$e(t,a[g]),l[g]=t}else l[g]=$e(i,a[g]),xe(e,o[h],i),o[t]=null;g++}else De(o[p]),p--;else De(o[h]),h++;for(;g<=u;){const t=xe(e,l[u+1]);$e(t,a[g]),l[g++]=t}for(;h<=p;){const e=o[h++];null!==e&&De(e)}return this.ut=r,ke(e,l),j}});function Ee(e,t,i){return(t=function(e){var t=function(e,t){if("object"!=typeof e||!e)return e;var i=e[Symbol.toPrimitive];if(void 0!==i){var s=i.call(e,t);if("object"!=typeof s)return s;throw new TypeError("@@toPrimitive must return a primitive value.")}return String(e)}(e,"string");return"symbol"==typeof t?t:t+""}(t))in e?Object.defineProperty(e,t,{value:i,enumerable:!0,configurable:!0,writable:!0}):e[t]=i,e}function Ae(){return Ae=Object.assign?Object.assign.bind():function(e){for(var t=1;t<arguments.length;t++){var i=arguments[t];for(var s in i)({}).hasOwnProperty.call(i,s)&&(e[s]=i[s])}return e},Ae.apply(null,arguments)}function Ie(e,t){var i=Object.keys(e);if(Object.getOwnPropertySymbols){var s=Object.getOwnPropertySymbols(e);t&&(s=s.filter(function(t){return Object.getOwnPropertyDescriptor(e,t).enumerable})),i.push.apply(i,s)}return i}function Pe(e){for(var t=1;t<arguments.length;t++){var i=null!=arguments[t]?arguments[t]:{};t%2?Ie(Object(i),!0).forEach(function(t){Ee(e,t,i[t])}):Object.getOwnPropertyDescriptors?Object.defineProperties(e,Object.getOwnPropertyDescriptors(i)):Ie(Object(i)).forEach(function(t){Object.defineProperty(e,t,Object.getOwnPropertyDescriptor(i,t))})}return e}function Re(e){return Re="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e},Re(e)}function Me(e){if("undefined"!=typeof window&&window.navigator)return!!navigator.userAgent.match(e)}var He=Me(/(?:Trident.*rv[ :]?11\.|msie|iemobile|Windows Phone)/i),Ne=Me(/Edge/i),ze=Me(/firefox/i),Le=Me(/safari/i)&&!Me(/chrome/i)&&!Me(/android/i),Ve=Me(/iP(ad|od|hone)/i),Oe=Me(/chrome/i)&&Me(/android/i),Ue={capture:!1,passive:!1};function Fe(e,t,i){e.addEventListener(t,i,!He&&Ue)}function Be(e,t,i){e.removeEventListener(t,i,!He&&Ue)}function je(e,t){if(t){if(">"===t[0]&&(t=t.substring(1)),e)try{if(e.matches)return e.matches(t);if(e.msMatchesSelector)return e.msMatchesSelector(t);if(e.webkitMatchesSelector)return e.webkitMatchesSelector(t)}catch(e){return!1}return!1}}function qe(e){return e.host&&e!==document&&e.host.nodeType&&e.host!==e?e.host:e.parentNode}function Xe(e,t,i,s){if(e){i=i||document;do{if(null!=t&&(">"===t[0]?e.parentNode===i&&je(e,t):je(e,t))||s&&e===i)return e;if(e===i)break}while(e=qe(e))}return null}var Ze,Ye=/\s+/g;function We(e,t,i){if(e&&t)if(e.classList)e.classList[i?"add":"remove"](t);else{var s=(" "+e.className+" ").replace(Ye," ").replace(" "+t+" "," ");e.className=(s+(i?" "+t:"")).replace(Ye," ")}}function Ke(e,t,i){var s=e&&e.style;if(s){if(void 0===i)return document.defaultView&&document.defaultView.getComputedStyle?i=document.defaultView.getComputedStyle(e,""):e.currentStyle&&(i=e.currentStyle),void 0===t?i:i[t];t in s||-1!==t.indexOf("webkit")||(t="-webkit-"+t),s[t]=i+("string"==typeof i?"":"px")}}function Ge(e,t){var i="";if("string"==typeof e)i=e;else do{var s=Ke(e,"transform");s&&"none"!==s&&(i=s+" "+i)}while(!t&&(e=e.parentNode));var o=window.DOMMatrix||window.WebKitCSSMatrix||window.CSSMatrix||window.MSCSSMatrix;return o&&new o(i)}function Je(e,t,i){if(e){var s=e.getElementsByTagName(t),o=0,a=s.length;if(i)for(;o<a;o++)i(s[o],o);return s}return[]}function Qe(){return document.scrollingElement||document.documentElement}function et(e,t,i,s,o){if(e.getBoundingClientRect||e===window){var a,r,n,l,d,c,h;if(e!==window&&e.parentNode&&e!==Qe()?(r=(a=e.getBoundingClientRect()).top,n=a.left,l=a.bottom,d=a.right,c=a.height,h=a.width):(r=0,n=0,l=window.innerHeight,d=window.innerWidth,c=window.innerHeight,h=window.innerWidth),(t||i)&&e!==window&&(o=o||e.parentNode,!He))do{if(o&&o.getBoundingClientRect&&("none"!==Ke(o,"transform")||i&&"static"!==Ke(o,"position"))){var p=o.getBoundingClientRect();r-=p.top+parseInt(Ke(o,"border-top-width")),n-=p.left+parseInt(Ke(o,"border-left-width")),l=r+a.height,d=n+a.width;break}}while(o=o.parentNode);if(s&&e!==window){var g=Ge(o||e),u=g&&g.a,m=g&&g.d;g&&(l=(r/=m)+(c/=m),d=(n/=u)+(h/=u))}return{top:r,left:n,bottom:l,right:d,width:h,height:c}}}function tt(e,t,i){for(var s=rt(e,!0),o=et(e)[t];s;){if(!(o>=et(s)[i]))return s;if(s===Qe())break;s=rt(s,!1)}return!1}function it(e,t,i,s){for(var o=0,a=0,r=e.children;a<r.length;){if("none"!==r[a].style.display&&r[a]!==di.ghost&&(s||r[a]!==di.dragged)&&Xe(r[a],i.draggable,e,!1)){if(o===t)return r[a];o++}a++}return null}function st(e,t){for(var i=e.lastElementChild;i&&(i===di.ghost||"none"===Ke(i,"display")||t&&!je(i,t));)i=i.previousElementSibling;return i||null}function ot(e,t){var i=0;if(!e||!e.parentNode)return-1;for(;e=e.previousElementSibling;)"TEMPLATE"===e.nodeName.toUpperCase()||e===di.clone||t&&!je(e,t)||i++;return i}function at(e){var t=0,i=0,s=Qe();if(e)do{var o=Ge(e),a=o.a,r=o.d;t+=e.scrollLeft*a,i+=e.scrollTop*r}while(e!==s&&(e=e.parentNode));return[t,i]}function rt(e,t){if(!e||!e.getBoundingClientRect)return Qe();var i=e,s=!1;do{if(i.clientWidth<i.scrollWidth||i.clientHeight<i.scrollHeight){var o=Ke(i);if(i.clientWidth<i.scrollWidth&&("auto"==o.overflowX||"scroll"==o.overflowX)||i.clientHeight<i.scrollHeight&&("auto"==o.overflowY||"scroll"==o.overflowY)){if(!i.getBoundingClientRect||i===document.body)return Qe();if(s||t)return i;s=!0}}}while(i=i.parentNode);return Qe()}function nt(e,t){return Math.round(e.top)===Math.round(t.top)&&Math.round(e.left)===Math.round(t.left)&&Math.round(e.height)===Math.round(t.height)&&Math.round(e.width)===Math.round(t.width)}function lt(e,t){return function(){if(!Ze){var i=arguments;1===i.length?e.call(this,i[0]):e.apply(this,i),Ze=setTimeout(function(){Ze=void 0},t)}}}function dt(e,t,i){e.scrollLeft+=t,e.scrollTop+=i}function ct(e){var t=window.Polymer,i=window.jQuery||window.Zepto;return t&&t.dom?t.dom(e).cloneNode(!0):i?i(e).clone(!0)[0]:e.cloneNode(!0)}function ht(e,t,i){var s={};return Array.from(e.children).forEach(function(o){var a,r,n,l;if(Xe(o,t.draggable,e,!1)&&!o.animated&&o!==i){var d=et(o);s.left=Math.min(null!==(a=s.left)&&void 0!==a?a:1/0,d.left),s.top=Math.min(null!==(r=s.top)&&void 0!==r?r:1/0,d.top),s.right=Math.max(null!==(n=s.right)&&void 0!==n?n:-1/0,d.right),s.bottom=Math.max(null!==(l=s.bottom)&&void 0!==l?l:-1/0,d.bottom)}}),s.width=s.right-s.left,s.height=s.bottom-s.top,s.x=s.left,s.y=s.top,s}var pt="Sortable"+(new Date).getTime();var gt=[],ut={initializeByDefault:!0},mt={mount:function(e){for(var t in ut)ut.hasOwnProperty(t)&&!(t in e)&&(e[t]=ut[t]);gt.forEach(function(t){if(t.pluginName===e.pluginName)throw"Sortable: Cannot mount plugin ".concat(e.pluginName," more than once")}),gt.push(e)},pluginEvent:function(e,t,i){var s=this;this.eventCanceled=!1,i.cancel=function(){s.eventCanceled=!0};var o=e+"Global";gt.forEach(function(s){t[s.pluginName]&&(t[s.pluginName][o]&&t[s.pluginName][o](Pe({sortable:t},i)),t.options[s.pluginName]&&t[s.pluginName][e]&&t[s.pluginName][e](Pe({sortable:t},i)))})},initializePlugins:function(e,t,i,s){for(var o in gt.forEach(function(s){var o=s.pluginName;if(e.options[o]||s.initializeByDefault){var a=new s(e,t,e.options);a.sortable=e,a.options=e.options,e[o]=a,Ae(i,a.defaults)}}),e.options)if(e.options.hasOwnProperty(o)){var a=this.modifyOption(e,o,e.options[o]);void 0!==a&&(e.options[o]=a)}},getEventProperties:function(e,t){var i={};return gt.forEach(function(s){"function"==typeof s.eventProperties&&Ae(i,s.eventProperties.call(t[s.pluginName],e))}),i},modifyOption:function(e,t,i){var s;return gt.forEach(function(o){e[o.pluginName]&&o.optionListeners&&"function"==typeof o.optionListeners[t]&&(s=o.optionListeners[t].call(e[o.pluginName],i))}),s}},vt=["evt"],_t=function(e,t){var i=arguments.length>2&&void 0!==arguments[2]?arguments[2]:{},s=i.evt,o=function(e,t){if(null==e)return{};var i,s,o=function(e,t){if(null==e)return{};var i={};for(var s in e)if({}.hasOwnProperty.call(e,s)){if(-1!==t.indexOf(s))continue;i[s]=e[s]}return i}(e,t);if(Object.getOwnPropertySymbols){var a=Object.getOwnPropertySymbols(e);for(s=0;s<a.length;s++)i=a[s],-1===t.indexOf(i)&&{}.propertyIsEnumerable.call(e,i)&&(o[i]=e[i])}return o}(i,vt);mt.pluginEvent.bind(di)(e,t,Pe({dragEl:ft,parentEl:yt,ghostEl:xt,rootEl:$t,nextEl:wt,lastDownEl:kt,cloneEl:Dt,cloneHidden:St,dragStarted:Vt,putSortable:Pt,activeSortable:di.active,originalEvent:s,oldIndex:Ct,oldDraggableIndex:Et,newIndex:Tt,newDraggableIndex:At,hideGhostForTarget:ai,unhideGhostForTarget:ri,cloneNowHidden:function(){St=!0},cloneNowShown:function(){St=!1},dispatchSortableEvent:function(e){bt({sortable:t,name:e,originalEvent:s})}},o))};function bt(e){!function(e){var t=e.sortable,i=e.rootEl,s=e.name,o=e.targetEl,a=e.cloneEl,r=e.toEl,n=e.fromEl,l=e.oldIndex,d=e.newIndex,c=e.oldDraggableIndex,h=e.newDraggableIndex,p=e.originalEvent,g=e.putSortable,u=e.extraEventProperties;if(t=t||i&&i[pt]){var m,v=t.options,_="on"+s.charAt(0).toUpperCase()+s.substr(1);!window.CustomEvent||He||Ne?(m=document.createEvent("Event")).initEvent(s,!0,!0):m=new CustomEvent(s,{bubbles:!0,cancelable:!0}),m.to=r||i,m.from=n||i,m.item=o||i,m.clone=a,m.oldIndex=l,m.newIndex=d,m.oldDraggableIndex=c,m.newDraggableIndex=h,m.originalEvent=p,m.pullMode=g?g.lastPutMode:void 0;var b=Pe(Pe({},u),mt.getEventProperties(s,t));for(var f in b)m[f]=b[f];i&&i.dispatchEvent(m),v[_]&&v[_].call(t,m)}}(Pe({putSortable:Pt,cloneEl:Dt,targetEl:ft,rootEl:$t,oldIndex:Ct,oldDraggableIndex:Et,newIndex:Tt,newDraggableIndex:At},e))}var ft,yt,xt,$t,wt,kt,Dt,St,Ct,Tt,Et,At,It,Pt,Rt,Mt,Ht,Nt,zt,Lt,Vt,Ot,Ut,Ft,Bt,jt=!1,qt=!1,Xt=[],Zt=!1,Yt=!1,Wt=[],Kt=!1,Gt=[],Jt="undefined"!=typeof document,Qt=Ve,ei=Ne||He?"cssFloat":"float",ti=Jt&&!Oe&&!Ve&&"draggable"in document.createElement("div"),ii=function(){if(Jt){if(He)return!1;var e=document.createElement("x");return e.style.cssText="pointer-events:auto","auto"===e.style.pointerEvents}}(),si=function(e,t){var i=Ke(e),s=parseInt(i.width)-parseInt(i.paddingLeft)-parseInt(i.paddingRight)-parseInt(i.borderLeftWidth)-parseInt(i.borderRightWidth),o=it(e,0,t),a=it(e,1,t),r=o&&Ke(o),n=a&&Ke(a),l=r&&parseInt(r.marginLeft)+parseInt(r.marginRight)+et(o).width,d=n&&parseInt(n.marginLeft)+parseInt(n.marginRight)+et(a).width;if("flex"===i.display)return"column"===i.flexDirection||"column-reverse"===i.flexDirection?"vertical":"horizontal";if("grid"===i.display)return i.gridTemplateColumns.split(" ").length<=1?"vertical":"horizontal";if(o&&r.float&&"none"!==r.float){var c="left"===r.float?"left":"right";return!a||"both"!==n.clear&&n.clear!==c?"horizontal":"vertical"}return o&&("block"===r.display||"flex"===r.display||"table"===r.display||"grid"===r.display||l>=s&&"none"===i[ei]||a&&"none"===i[ei]&&l+d>s)?"vertical":"horizontal"},oi=function(e){function t(e,i){return function(s,o,a,r){var n=s.options.group.name&&o.options.group.name&&s.options.group.name===o.options.group.name;if(null==e&&(i||n))return!0;if(null==e||!1===e)return!1;if(i&&"clone"===e)return e;if("function"==typeof e)return t(e(s,o,a,r),i)(s,o,a,r);var l=(i?s:o).options.group.name;return!0===e||"string"==typeof e&&e===l||e.join&&e.indexOf(l)>-1}}var i={},s=e.group;s&&"object"==Re(s)||(s={name:s}),i.name=s.name,i.checkPull=t(s.pull,!0),i.checkPut=t(s.put),i.revertClone=s.revertClone,e.group=i},ai=function(){!ii&&xt&&Ke(xt,"display","none")},ri=function(){!ii&&xt&&Ke(xt,"display","")};Jt&&!Oe&&document.addEventListener("click",function(e){if(qt)return e.preventDefault(),e.stopPropagation&&e.stopPropagation(),e.stopImmediatePropagation&&e.stopImmediatePropagation(),qt=!1,!1},!0);var ni=function(e){if(ft){var t=function(e,t){var i;return Xt.some(function(s){var o=s[pt].options.emptyInsertThreshold;if(o&&!st(s)){var a=et(s),r=e>=a.left-o&&e<=a.right+o,n=t>=a.top-o&&t<=a.bottom+o;return r&&n?i=s:void 0}}),i}((e=e.touches?e.touches[0]:e).clientX,e.clientY);if(t){var i={};for(var s in e)e.hasOwnProperty(s)&&(i[s]=e[s]);i.target=i.rootEl=t,i.preventDefault=void 0,i.stopPropagation=void 0,t[pt]._onDragOver(i)}}},li=function(e){ft&&ft.parentNode[pt]._isOutsideThisEl(e.target)};function di(e,t){if(!e||!e.nodeType||1!==e.nodeType)throw"Sortable: `el` must be an HTMLElement, not ".concat({}.toString.call(e));this.el=e,this.options=t=Ae({},t),e[pt]=this;var i,s,o={group:null,sort:!0,disabled:!1,store:null,handle:null,draggable:/^[uo]l$/i.test(e.nodeName)?">li":">*",swapThreshold:1,invertSwap:!1,invertedSwapThreshold:null,removeCloneOnHide:!0,direction:function(){return si(e,this.options)},ghostClass:"sortable-ghost",chosenClass:"sortable-chosen",dragClass:"sortable-drag",ignore:"a, img",filter:null,preventOnFilter:!0,animation:0,easing:null,setData:function(e,t){e.setData("Text",t.textContent)},dropBubble:!1,dragoverBubble:!1,dataIdAttr:"data-id",delay:0,delayOnTouchOnly:!1,touchStartThreshold:(Number.parseInt?Number:window).parseInt(window.devicePixelRatio,10)||1,forceFallback:!1,fallbackClass:"sortable-fallback",fallbackOnBody:!1,fallbackTolerance:0,fallbackOffset:{x:0,y:0},supportPointer:!1!==di.supportPointer&&"PointerEvent"in window&&(!Le||Ve),emptyInsertThreshold:5};for(var a in mt.initializePlugins(this,e,o),o)!(a in t)&&(t[a]=o[a]);for(var r in oi(t),this)"_"===r.charAt(0)&&"function"==typeof this[r]&&(this[r]=this[r].bind(this));this.nativeDraggable=!t.forceFallback&&ti,this.nativeDraggable&&(this.options.touchStartThreshold=1),t.supportPointer?Fe(e,"pointerdown",this._onTapStart):(Fe(e,"mousedown",this._onTapStart),Fe(e,"touchstart",this._onTapStart)),this.nativeDraggable&&(Fe(e,"dragover",this),Fe(e,"dragenter",this)),Xt.push(this.el),t.store&&t.store.get&&this.sort(t.store.get(this)||[]),Ae(this,(s=[],{captureAnimationState:function(){s=[],this.options.animation&&[].slice.call(this.el.children).forEach(function(e){if("none"!==Ke(e,"display")&&e!==di.ghost){s.push({target:e,rect:et(e)});var t=Pe({},s[s.length-1].rect);if(e.thisAnimationDuration){var i=Ge(e,!0);i&&(t.top-=i.f,t.left-=i.e)}e.fromRect=t}})},addAnimationState:function(e){s.push(e)},removeAnimationState:function(e){s.splice(function(e,t){for(var i in e)if(e.hasOwnProperty(i))for(var s in t)if(t.hasOwnProperty(s)&&t[s]===e[i][s])return Number(i);return-1}(s,{target:e}),1)},animateAll:function(e){var t=this;if(!this.options.animation)return clearTimeout(i),void("function"==typeof e&&e());var o=!1,a=0;s.forEach(function(e){var i=0,s=e.target,r=s.fromRect,n=et(s),l=s.prevFromRect,d=s.prevToRect,c=e.rect,h=Ge(s,!0);h&&(n.top-=h.f,n.left-=h.e),s.toRect=n,s.thisAnimationDuration&&nt(l,n)&&!nt(r,n)&&(c.top-n.top)/(c.left-n.left)===(r.top-n.top)/(r.left-n.left)&&(i=function(e,t,i,s){return Math.sqrt(Math.pow(t.top-e.top,2)+Math.pow(t.left-e.left,2))/Math.sqrt(Math.pow(t.top-i.top,2)+Math.pow(t.left-i.left,2))*s.animation}(c,l,d,t.options)),nt(n,r)||(s.prevFromRect=r,s.prevToRect=n,i||(i=t.options.animation),t.animate(s,c,n,i)),i&&(o=!0,a=Math.max(a,i),clearTimeout(s.animationResetTimer),s.animationResetTimer=setTimeout(function(){s.animationTime=0,s.prevFromRect=null,s.fromRect=null,s.prevToRect=null,s.thisAnimationDuration=null},i),s.thisAnimationDuration=i)}),clearTimeout(i),o?i=setTimeout(function(){"function"==typeof e&&e()},a):"function"==typeof e&&e(),s=[]},animate:function(e,t,i,s){if(s){Ke(e,"transition",""),Ke(e,"transform","");var o=Ge(this.el),a=o&&o.a,r=o&&o.d,n=(t.left-i.left)/(a||1),l=(t.top-i.top)/(r||1);e.animatingX=!!n,e.animatingY=!!l,Ke(e,"transform","translate3d("+n+"px,"+l+"px,0)"),this.forRepaintDummy=function(e){return e.offsetWidth}(e),Ke(e,"transition","transform "+s+"ms"+(this.options.easing?" "+this.options.easing:"")),Ke(e,"transform","translate3d(0,0,0)"),"number"==typeof e.animated&&clearTimeout(e.animated),e.animated=setTimeout(function(){Ke(e,"transition",""),Ke(e,"transform",""),e.animated=!1,e.animatingX=!1,e.animatingY=!1},s)}}}))}function ci(e,t,i,s,o,a,r,n){var l,d,c=e[pt],h=c.options.onMove;return!window.CustomEvent||He||Ne?(l=document.createEvent("Event")).initEvent("move",!0,!0):l=new CustomEvent("move",{bubbles:!0,cancelable:!0}),l.to=t,l.from=e,l.dragged=i,l.draggedRect=s,l.related=o||t,l.relatedRect=a||et(t),l.willInsertAfter=n,l.originalEvent=r,e.dispatchEvent(l),h&&(d=h.call(c,l,r)),d}function hi(e){e.draggable=!1}function pi(){Kt=!1}function gi(e){for(var t=e.tagName+e.className+e.src+e.href+e.textContent,i=t.length,s=0;i--;)s+=t.charCodeAt(i);return s.toString(36)}function ui(e){return setTimeout(e,0)}function mi(e){return clearTimeout(e)}di.prototype={constructor:di,_isOutsideThisEl:function(e){this.el.contains(e)||e===this.el||(Ot=null)},_getDirection:function(e,t){return"function"==typeof this.options.direction?this.options.direction.call(this,e,t,ft):this.options.direction},_onTapStart:function(e){if(e.cancelable){var t=this,i=this.el,s=this.options,o=s.preventOnFilter,a=e.type,r=e.touches&&e.touches[0]||e.pointerType&&"touch"===e.pointerType&&e,n=(r||e).target,l=e.target.shadowRoot&&(e.path&&e.path[0]||e.composedPath&&e.composedPath()[0])||n,d=s.filter;if(function(e){Gt.length=0;for(var t=e.getElementsByTagName("input"),i=t.length;i--;){var s=t[i];s.checked&&Gt.push(s)}}(i),!ft&&!(/mousedown|pointerdown/.test(a)&&0!==e.button||s.disabled)&&!l.isContentEditable&&(this.nativeDraggable||!Le||!n||"SELECT"!==n.tagName.toUpperCase())&&!((n=Xe(n,s.draggable,i,!1))&&n.animated||kt===n)){if(Ct=ot(n),Et=ot(n,s.draggable),"function"==typeof d){if(d.call(this,e,n,this))return bt({sortable:t,rootEl:l,name:"filter",targetEl:n,toEl:i,fromEl:i}),_t("filter",t,{evt:e}),void(o&&e.preventDefault())}else if(d&&(d=d.split(",").some(function(s){if(s=Xe(l,s.trim(),i,!1))return bt({sortable:t,rootEl:s,name:"filter",targetEl:n,fromEl:i,toEl:i}),_t("filter",t,{evt:e}),!0})))return void(o&&e.preventDefault());s.handle&&!Xe(l,s.handle,i,!1)||this._prepareDragStart(e,r,n)}}},_prepareDragStart:function(e,t,i){var s,o=this,a=o.el,r=o.options,n=a.ownerDocument;if(i&&!ft&&i.parentNode===a){var l=et(i);if($t=a,yt=(ft=i).parentNode,wt=ft.nextSibling,kt=i,It=r.group,di.dragged=ft,Rt={target:ft,clientX:(t||e).clientX,clientY:(t||e).clientY},zt=Rt.clientX-l.left,Lt=Rt.clientY-l.top,this._lastX=(t||e).clientX,this._lastY=(t||e).clientY,ft.style["will-change"]="all",s=function(){_t("delayEnded",o,{evt:e}),di.eventCanceled?o._onDrop():(o._disableDelayedDragEvents(),!ze&&o.nativeDraggable&&(ft.draggable=!0),o._triggerDragStart(e,t),bt({sortable:o,name:"choose",originalEvent:e}),We(ft,r.chosenClass,!0))},r.ignore.split(",").forEach(function(e){Je(ft,e.trim(),hi)}),Fe(n,"dragover",ni),Fe(n,"mousemove",ni),Fe(n,"touchmove",ni),r.supportPointer?(Fe(n,"pointerup",o._onDrop),!this.nativeDraggable&&Fe(n,"pointercancel",o._onDrop)):(Fe(n,"mouseup",o._onDrop),Fe(n,"touchend",o._onDrop),Fe(n,"touchcancel",o._onDrop)),ze&&this.nativeDraggable&&(this.options.touchStartThreshold=4,ft.draggable=!0),_t("delayStart",this,{evt:e}),!r.delay||r.delayOnTouchOnly&&!t||this.nativeDraggable&&(Ne||He))s();else{if(di.eventCanceled)return void this._onDrop();r.supportPointer?(Fe(n,"pointerup",o._disableDelayedDrag),Fe(n,"pointercancel",o._disableDelayedDrag)):(Fe(n,"mouseup",o._disableDelayedDrag),Fe(n,"touchend",o._disableDelayedDrag),Fe(n,"touchcancel",o._disableDelayedDrag)),Fe(n,"mousemove",o._delayedDragTouchMoveHandler),Fe(n,"touchmove",o._delayedDragTouchMoveHandler),r.supportPointer&&Fe(n,"pointermove",o._delayedDragTouchMoveHandler),o._dragStartTimer=setTimeout(s,r.delay)}}},_delayedDragTouchMoveHandler:function(e){var t=e.touches?e.touches[0]:e;Math.max(Math.abs(t.clientX-this._lastX),Math.abs(t.clientY-this._lastY))>=Math.floor(this.options.touchStartThreshold/(this.nativeDraggable&&window.devicePixelRatio||1))&&this._disableDelayedDrag()},_disableDelayedDrag:function(){ft&&hi(ft),clearTimeout(this._dragStartTimer),this._disableDelayedDragEvents()},_disableDelayedDragEvents:function(){var e=this.el.ownerDocument;Be(e,"mouseup",this._disableDelayedDrag),Be(e,"touchend",this._disableDelayedDrag),Be(e,"touchcancel",this._disableDelayedDrag),Be(e,"pointerup",this._disableDelayedDrag),Be(e,"pointercancel",this._disableDelayedDrag),Be(e,"mousemove",this._delayedDragTouchMoveHandler),Be(e,"touchmove",this._delayedDragTouchMoveHandler),Be(e,"pointermove",this._delayedDragTouchMoveHandler)},_triggerDragStart:function(e,t){t=t||"touch"==e.pointerType&&e,!this.nativeDraggable||t?this.options.supportPointer?Fe(document,"pointermove",this._onTouchMove):Fe(document,t?"touchmove":"mousemove",this._onTouchMove):(Fe(ft,"dragend",this),Fe($t,"dragstart",this._onDragStart));try{document.selection?ui(function(){document.selection.empty()}):window.getSelection().removeAllRanges()}catch(e){}},_dragStarted:function(e,t){if(jt=!1,$t&&ft){_t("dragStarted",this,{evt:t}),this.nativeDraggable&&Fe(document,"dragover",li);var i=this.options;!e&&We(ft,i.dragClass,!1),We(ft,i.ghostClass,!0),di.active=this,e&&this._appendGhost(),bt({sortable:this,name:"start",originalEvent:t})}else this._nulling()},_emulateDragOver:function(){if(Mt){this._lastX=Mt.clientX,this._lastY=Mt.clientY,ai();for(var e=document.elementFromPoint(Mt.clientX,Mt.clientY),t=e;e&&e.shadowRoot&&(e=e.shadowRoot.elementFromPoint(Mt.clientX,Mt.clientY))!==t;)t=e;if(ft.parentNode[pt]._isOutsideThisEl(e),t)do{if(t[pt]&&t[pt]._onDragOver({clientX:Mt.clientX,clientY:Mt.clientY,target:e,rootEl:t})&&!this.options.dragoverBubble)break;e=t}while(t=qe(t));ri()}},_onTouchMove:function(e){if(Rt){var t=this.options,i=t.fallbackTolerance,s=t.fallbackOffset,o=e.touches?e.touches[0]:e,a=xt&&Ge(xt,!0),r=xt&&a&&a.a,n=xt&&a&&a.d,l=Qt&&Bt&&at(Bt),d=(o.clientX-Rt.clientX+s.x)/(r||1)+(l?l[0]-Wt[0]:0)/(r||1),c=(o.clientY-Rt.clientY+s.y)/(n||1)+(l?l[1]-Wt[1]:0)/(n||1);if(!di.active&&!jt){if(i&&Math.max(Math.abs(o.clientX-this._lastX),Math.abs(o.clientY-this._lastY))<i)return;this._onDragStart(e,!0)}if(xt){a?(a.e+=d-(Ht||0),a.f+=c-(Nt||0)):a={a:1,b:0,c:0,d:1,e:d,f:c};var h="matrix(".concat(a.a,",").concat(a.b,",").concat(a.c,",").concat(a.d,",").concat(a.e,",").concat(a.f,")");Ke(xt,"webkitTransform",h),Ke(xt,"mozTransform",h),Ke(xt,"msTransform",h),Ke(xt,"transform",h),Ht=d,Nt=c,Mt=o}e.cancelable&&e.preventDefault()}},_appendGhost:function(){if(!xt){var e=this.options.fallbackOnBody?document.body:$t,t=et(ft,!0,Qt,!0,e),i=this.options;if(Qt){for(Bt=e;"static"===Ke(Bt,"position")&&"none"===Ke(Bt,"transform")&&Bt!==document;)Bt=Bt.parentNode;Bt!==document.body&&Bt!==document.documentElement?(Bt===document&&(Bt=Qe()),t.top+=Bt.scrollTop,t.left+=Bt.scrollLeft):Bt=Qe(),Wt=at(Bt)}We(xt=ft.cloneNode(!0),i.ghostClass,!1),We(xt,i.fallbackClass,!0),We(xt,i.dragClass,!0),Ke(xt,"transition",""),Ke(xt,"transform",""),Ke(xt,"box-sizing","border-box"),Ke(xt,"margin",0),Ke(xt,"top",t.top),Ke(xt,"left",t.left),Ke(xt,"width",t.width),Ke(xt,"height",t.height),Ke(xt,"opacity","0.8"),Ke(xt,"position",Qt?"absolute":"fixed"),Ke(xt,"zIndex","100000"),Ke(xt,"pointerEvents","none"),di.ghost=xt,e.appendChild(xt),Ke(xt,"transform-origin",zt/parseInt(xt.style.width)*100+"% "+Lt/parseInt(xt.style.height)*100+"%")}},_onDragStart:function(e,t){var i=this,s=e.dataTransfer,o=i.options;_t("dragStart",this,{evt:e}),di.eventCanceled?this._onDrop():(_t("setupClone",this),di.eventCanceled||((Dt=ct(ft)).removeAttribute("id"),Dt.draggable=!1,Dt.style["will-change"]="",this._hideClone(),We(Dt,this.options.chosenClass,!1),di.clone=Dt),i.cloneId=ui(function(){_t("clone",i),di.eventCanceled||(i.options.removeCloneOnHide||$t.insertBefore(Dt,ft),i._hideClone(),bt({sortable:i,name:"clone"}))}),!t&&We(ft,o.dragClass,!0),t?(qt=!0,i._loopId=setInterval(i._emulateDragOver,50)):(Be(document,"mouseup",i._onDrop),Be(document,"touchend",i._onDrop),Be(document,"touchcancel",i._onDrop),s&&(s.effectAllowed="move",o.setData&&o.setData.call(i,s,ft)),Fe(document,"drop",i),Ke(ft,"transform","translateZ(0)")),jt=!0,i._dragStartId=ui(i._dragStarted.bind(i,t,e)),Fe(document,"selectstart",i),Vt=!0,window.getSelection().removeAllRanges(),Le&&Ke(document.body,"user-select","none"))},_onDragOver:function(e){var t,i,s,o,a=this.el,r=e.target,n=this.options,l=n.group,d=di.active,c=It===l,h=n.sort,p=Pt||d,g=this,u=!1;if(!Kt){if(void 0!==e.preventDefault&&e.cancelable&&e.preventDefault(),r=Xe(r,n.draggable,a,!0),E("dragOver"),di.eventCanceled)return u;if(ft.contains(e.target)||r.animated&&r.animatingX&&r.animatingY||g._ignoreWhileAnimating===r)return I(!1);if(qt=!1,d&&!n.disabled&&(c?h||(s=yt!==$t):Pt===this||(this.lastPutMode=It.checkPull(this,d,ft,e))&&l.checkPut(this,d,ft,e))){if(o="vertical"===this._getDirection(e,r),t=et(ft),E("dragOverValid"),di.eventCanceled)return u;if(s)return yt=$t,A(),this._hideClone(),E("revert"),di.eventCanceled||(wt?$t.insertBefore(ft,wt):$t.appendChild(ft)),I(!0);var m=st(a,n.draggable);if(!m||function(e,t,i){var s=et(st(i.el,i.options.draggable)),o=ht(i.el,i.options,xt);return t?e.clientX>o.right+10||e.clientY>s.bottom&&e.clientX>s.left:e.clientY>o.bottom+10||e.clientX>s.right&&e.clientY>s.top}(e,o,this)&&!m.animated){if(m===ft)return I(!1);if(m&&a===e.target&&(r=m),r&&(i=et(r)),!1!==ci($t,a,ft,t,r,i,e,!!r))return A(),m&&m.nextSibling?a.insertBefore(ft,m.nextSibling):a.appendChild(ft),yt=a,P(),I(!0)}else if(m&&function(e,t,i){var s=et(it(i.el,0,i.options,!0)),o=ht(i.el,i.options,xt);return t?e.clientX<o.left-10||e.clientY<s.top&&e.clientX<s.right:e.clientY<o.top-10||e.clientY<s.bottom&&e.clientX<s.left}(e,o,this)){var v=it(a,0,n,!0);if(v===ft)return I(!1);if(i=et(r=v),!1!==ci($t,a,ft,t,r,i,e,!1))return A(),a.insertBefore(ft,v),yt=a,P(),I(!0)}else if(r.parentNode===a){i=et(r);var _,b,f,y=ft.parentNode!==a,x=!function(e,t,i){var s=i?e.left:e.top,o=i?e.right:e.bottom,a=i?e.width:e.height,r=i?t.left:t.top,n=i?t.right:t.bottom,l=i?t.width:t.height;return s===r||o===n||s+a/2===r+l/2}(ft.animated&&ft.toRect||t,r.animated&&r.toRect||i,o),$=o?"top":"left",w=tt(r,"top","top")||tt(ft,"top","top"),k=w?w.scrollTop:void 0;if(Ot!==r&&(b=i[$],Zt=!1,Yt=!x&&n.invertSwap||y),_=function(e,t,i,s,o,a,r,n){var l=s?e.clientY:e.clientX,d=s?i.height:i.width,c=s?i.top:i.left,h=s?i.bottom:i.right,p=!1;if(!r)if(n&&Ft<d*o){if(!Zt&&(1===Ut?l>c+d*a/2:l<h-d*a/2)&&(Zt=!0),Zt)p=!0;else if(1===Ut?l<c+Ft:l>h-Ft)return-Ut}else if(l>c+d*(1-o)/2&&l<h-d*(1-o)/2)return function(e){return ot(ft)<ot(e)?1:-1}(t);return(p=p||r)&&(l<c+d*a/2||l>h-d*a/2)?l>c+d/2?1:-1:0}(e,r,i,o,x?1:n.swapThreshold,null==n.invertedSwapThreshold?n.swapThreshold:n.invertedSwapThreshold,Yt,Ot===r),0!==_){var D=ot(ft);do{D-=_,f=yt.children[D]}while(f&&("none"===Ke(f,"display")||f===xt))}if(0===_||f===r)return I(!1);Ot=r,Ut=_;var S=r.nextElementSibling,C=!1,T=ci($t,a,ft,t,r,i,e,C=1===_);if(!1!==T)return 1!==T&&-1!==T||(C=1===T),Kt=!0,setTimeout(pi,30),A(),C&&!S?a.appendChild(ft):r.parentNode.insertBefore(ft,C?S:r),w&&dt(w,0,k-w.scrollTop),yt=ft.parentNode,void 0===b||Yt||(Ft=Math.abs(b-et(r)[$])),P(),I(!0)}if(a.contains(ft))return I(!1)}return!1}function E(n,l){_t(n,g,Pe({evt:e,isOwner:c,axis:o?"vertical":"horizontal",revert:s,dragRect:t,targetRect:i,canSort:h,fromSortable:p,target:r,completed:I,onMove:function(i,s){return ci($t,a,ft,t,i,et(i),e,s)},changed:P},l))}function A(){E("dragOverAnimationCapture"),g.captureAnimationState(),g!==p&&p.captureAnimationState()}function I(t){return E("dragOverCompleted",{insertion:t}),t&&(c?d._hideClone():d._showClone(g),g!==p&&(We(ft,Pt?Pt.options.ghostClass:d.options.ghostClass,!1),We(ft,n.ghostClass,!0)),Pt!==g&&g!==di.active?Pt=g:g===di.active&&Pt&&(Pt=null),p===g&&(g._ignoreWhileAnimating=r),g.animateAll(function(){E("dragOverAnimationComplete"),g._ignoreWhileAnimating=null}),g!==p&&(p.animateAll(),p._ignoreWhileAnimating=null)),(r===ft&&!ft.animated||r===a&&!r.animated)&&(Ot=null),n.dragoverBubble||e.rootEl||r===document||(ft.parentNode[pt]._isOutsideThisEl(e.target),!t&&ni(e)),!n.dragoverBubble&&e.stopPropagation&&e.stopPropagation(),u=!0}function P(){Tt=ot(ft),At=ot(ft,n.draggable),bt({sortable:g,name:"change",toEl:a,newIndex:Tt,newDraggableIndex:At,originalEvent:e})}},_ignoreWhileAnimating:null,_offMoveEvents:function(){Be(document,"mousemove",this._onTouchMove),Be(document,"touchmove",this._onTouchMove),Be(document,"pointermove",this._onTouchMove),Be(document,"dragover",ni),Be(document,"mousemove",ni),Be(document,"touchmove",ni)},_offUpEvents:function(){var e=this.el.ownerDocument;Be(e,"mouseup",this._onDrop),Be(e,"touchend",this._onDrop),Be(e,"pointerup",this._onDrop),Be(e,"pointercancel",this._onDrop),Be(e,"touchcancel",this._onDrop),Be(document,"selectstart",this)},_onDrop:function(e){var t=this.el,i=this.options;Tt=ot(ft),At=ot(ft,i.draggable),_t("drop",this,{evt:e}),yt=ft&&ft.parentNode,Tt=ot(ft),At=ot(ft,i.draggable),di.eventCanceled||(jt=!1,Yt=!1,Zt=!1,clearInterval(this._loopId),clearTimeout(this._dragStartTimer),mi(this.cloneId),mi(this._dragStartId),this.nativeDraggable&&(Be(document,"drop",this),Be(t,"dragstart",this._onDragStart)),this._offMoveEvents(),this._offUpEvents(),Le&&Ke(document.body,"user-select",""),Ke(ft,"transform",""),e&&(Vt&&(e.cancelable&&e.preventDefault(),!i.dropBubble&&e.stopPropagation()),xt&&xt.parentNode&&xt.parentNode.removeChild(xt),($t===yt||Pt&&"clone"!==Pt.lastPutMode)&&Dt&&Dt.parentNode&&Dt.parentNode.removeChild(Dt),ft&&(this.nativeDraggable&&Be(ft,"dragend",this),hi(ft),ft.style["will-change"]="",Vt&&!jt&&We(ft,Pt?Pt.options.ghostClass:this.options.ghostClass,!1),We(ft,this.options.chosenClass,!1),bt({sortable:this,name:"unchoose",toEl:yt,newIndex:null,newDraggableIndex:null,originalEvent:e}),$t!==yt?(Tt>=0&&(bt({rootEl:yt,name:"add",toEl:yt,fromEl:$t,originalEvent:e}),bt({sortable:this,name:"remove",toEl:yt,originalEvent:e}),bt({rootEl:yt,name:"sort",toEl:yt,fromEl:$t,originalEvent:e}),bt({sortable:this,name:"sort",toEl:yt,originalEvent:e})),Pt&&Pt.save()):Tt!==Ct&&Tt>=0&&(bt({sortable:this,name:"update",toEl:yt,originalEvent:e}),bt({sortable:this,name:"sort",toEl:yt,originalEvent:e})),di.active&&(null!=Tt&&-1!==Tt||(Tt=Ct,At=Et),bt({sortable:this,name:"end",toEl:yt,originalEvent:e}),this.save())))),this._nulling()},_nulling:function(){_t("nulling",this),$t=ft=yt=xt=wt=Dt=kt=St=Rt=Mt=Vt=Tt=At=Ct=Et=Ot=Ut=Pt=It=di.dragged=di.ghost=di.clone=di.active=null;var e=this.el;Gt.forEach(function(t){e.contains(t)&&(t.checked=!0)}),Gt.length=Ht=Nt=0},handleEvent:function(e){switch(e.type){case"drop":case"dragend":this._onDrop(e);break;case"dragenter":case"dragover":ft&&(this._onDragOver(e),function(e){e.dataTransfer&&(e.dataTransfer.dropEffect="move"),e.cancelable&&e.preventDefault()}(e));break;case"selectstart":e.preventDefault()}},toArray:function(){for(var e,t=[],i=this.el.children,s=0,o=i.length,a=this.options;s<o;s++)Xe(e=i[s],a.draggable,this.el,!1)&&t.push(e.getAttribute(a.dataIdAttr)||gi(e));return t},sort:function(e,t){var i={},s=this.el;this.toArray().forEach(function(e,t){var o=s.children[t];Xe(o,this.options.draggable,s,!1)&&(i[e]=o)},this),t&&this.captureAnimationState(),e.forEach(function(e){i[e]&&(s.removeChild(i[e]),s.appendChild(i[e]))}),t&&this.animateAll()},save:function(){var e=this.options.store;e&&e.set&&e.set(this)},closest:function(e,t){return Xe(e,t||this.options.draggable,this.el,!1)},option:function(e,t){var i=this.options;if(void 0===t)return i[e];var s=mt.modifyOption(this,e,t);i[e]=void 0!==s?s:t,"group"===e&&oi(i)},destroy:function(){_t("destroy",this);var e=this.el;e[pt]=null,Be(e,"mousedown",this._onTapStart),Be(e,"touchstart",this._onTapStart),Be(e,"pointerdown",this._onTapStart),this.nativeDraggable&&(Be(e,"dragover",this),Be(e,"dragenter",this)),Array.prototype.forEach.call(e.querySelectorAll("[draggable]"),function(e){e.removeAttribute("draggable")}),this._onDrop(),this._disableDelayedDragEvents(),Xt.splice(Xt.indexOf(this.el),1),this.el=e=null},_hideClone:function(){if(!St){if(_t("hideClone",this),di.eventCanceled)return;Ke(Dt,"display","none"),this.options.removeCloneOnHide&&Dt.parentNode&&Dt.parentNode.removeChild(Dt),St=!0}},_showClone:function(e){if("clone"===e.lastPutMode){if(St){if(_t("showClone",this),di.eventCanceled)return;ft.parentNode!=$t||this.options.group.revertClone?wt?$t.insertBefore(Dt,wt):$t.appendChild(Dt):$t.insertBefore(Dt,ft),this.options.group.revertClone&&this.animate(ft,Dt),Ke(Dt,"display",""),St=!1}}else this._hideClone()}},Jt&&Fe(document,"touchmove",function(e){(di.active||jt)&&e.cancelable&&e.preventDefault()}),di.utils={on:Fe,off:Be,css:Ke,find:Je,is:function(e,t){return!!Xe(e,t,e,!1)},extend:function(e,t){if(e&&t)for(var i in t)t.hasOwnProperty(i)&&(e[i]=t[i]);return e},throttle:lt,closest:Xe,toggleClass:We,clone:ct,index:ot,nextTick:ui,cancelNextTick:mi,detectDirection:si,getChild:it,expando:pt},di.get=function(e){return e[pt]},di.mount=function(){for(var e=arguments.length,t=new Array(e),i=0;i<e;i++)t[i]=arguments[i];t[0].constructor===Array&&(t=t[0]),t.forEach(function(e){if(!e.prototype||!e.prototype.constructor)throw"Sortable: Mounted plugin must be a constructor function, not ".concat({}.toString.call(e));e.utils&&(di.utils=Pe(Pe({},di.utils),e.utils)),mt.mount(e)})},di.create=function(e,t){return new di(e,t)},di.version="1.15.7";var vi,_i,bi,fi,yi,xi,$i=[],wi=!1;function ki(){$i.forEach(function(e){clearInterval(e.pid)}),$i=[]}function Di(){clearInterval(xi)}var Si=lt(function(e,t,i,s){if(t.scroll){var o,a=(e.touches?e.touches[0]:e).clientX,r=(e.touches?e.touches[0]:e).clientY,n=t.scrollSensitivity,l=t.scrollSpeed,d=Qe(),c=!1;_i!==i&&(_i=i,ki(),vi=t.scroll,o=t.scrollFn,!0===vi&&(vi=rt(i,!0)));var h=0,p=vi;do{var g=p,u=et(g),m=u.top,v=u.bottom,_=u.left,b=u.right,f=u.width,y=u.height,x=void 0,$=void 0,w=g.scrollWidth,k=g.scrollHeight,D=Ke(g),S=g.scrollLeft,C=g.scrollTop;g===d?(x=f<w&&("auto"===D.overflowX||"scroll"===D.overflowX||"visible"===D.overflowX),$=y<k&&("auto"===D.overflowY||"scroll"===D.overflowY||"visible"===D.overflowY)):(x=f<w&&("auto"===D.overflowX||"scroll"===D.overflowX),$=y<k&&("auto"===D.overflowY||"scroll"===D.overflowY));var T=x&&(Math.abs(b-a)<=n&&S+f<w)-(Math.abs(_-a)<=n&&!!S),E=$&&(Math.abs(v-r)<=n&&C+y<k)-(Math.abs(m-r)<=n&&!!C);if(!$i[h])for(var A=0;A<=h;A++)$i[A]||($i[A]={});$i[h].vx==T&&$i[h].vy==E&&$i[h].el===g||($i[h].el=g,$i[h].vx=T,$i[h].vy=E,clearInterval($i[h].pid),0==T&&0==E||(c=!0,$i[h].pid=setInterval(function(){s&&0===this.layer&&di.active._onTouchMove(yi);var t=$i[this.layer].vy?$i[this.layer].vy*l:0,i=$i[this.layer].vx?$i[this.layer].vx*l:0;"function"==typeof o&&"continue"!==o.call(di.dragged.parentNode[pt],i,t,e,yi,$i[this.layer].el)||dt($i[this.layer].el,i,t)}.bind({layer:h}),24))),h++}while(t.bubbleScroll&&p!==d&&(p=rt(p,!1)));wi=c}},30),Ci=function(e){var t=e.originalEvent,i=e.putSortable,s=e.dragEl,o=e.activeSortable,a=e.dispatchSortableEvent,r=e.hideGhostForTarget,n=e.unhideGhostForTarget;if(t){var l=i||o;r();var d=t.changedTouches&&t.changedTouches.length?t.changedTouches[0]:t,c=document.elementFromPoint(d.clientX,d.clientY);n(),l&&!l.el.contains(c)&&(a("spill"),this.onSpill({dragEl:s,putSortable:i}))}};function Ti(){}function Ei(){}Ti.prototype={startIndex:null,dragStart:function(e){var t=e.oldDraggableIndex;this.startIndex=t},onSpill:function(e){var t=e.dragEl,i=e.putSortable;this.sortable.captureAnimationState(),i&&i.captureAnimationState();var s=it(this.sortable.el,this.startIndex,this.options);s?this.sortable.el.insertBefore(t,s):this.sortable.el.appendChild(t),this.sortable.animateAll(),i&&i.animateAll()},drop:Ci},Ae(Ti,{pluginName:"revertOnSpill"}),Ei.prototype={onSpill:function(e){var t=e.dragEl,i=e.putSortable||this.sortable;i.captureAnimationState(),t.parentNode&&t.parentNode.removeChild(t),i.animateAll()},drop:Ci},Ae(Ei,{pluginName:"removeOnSpill"}),di.mount(new function(){function e(){for(var e in this.defaults={scroll:!0,forceAutoScrollFallback:!1,scrollSensitivity:30,scrollSpeed:10,bubbleScroll:!0},this)"_"===e.charAt(0)&&"function"==typeof this[e]&&(this[e]=this[e].bind(this))}return e.prototype={dragStarted:function(e){var t=e.originalEvent;this.sortable.nativeDraggable?Fe(document,"dragover",this._handleAutoScroll):this.options.supportPointer?Fe(document,"pointermove",this._handleFallbackAutoScroll):t.touches?Fe(document,"touchmove",this._handleFallbackAutoScroll):Fe(document,"mousemove",this._handleFallbackAutoScroll)},dragOverCompleted:function(e){var t=e.originalEvent;this.options.dragOverBubble||t.rootEl||this._handleAutoScroll(t)},drop:function(){this.sortable.nativeDraggable?Be(document,"dragover",this._handleAutoScroll):(Be(document,"pointermove",this._handleFallbackAutoScroll),Be(document,"touchmove",this._handleFallbackAutoScroll),Be(document,"mousemove",this._handleFallbackAutoScroll)),Di(),ki(),clearTimeout(Ze),Ze=void 0},nulling:function(){yi=_i=vi=wi=xi=bi=fi=null,$i.length=0},_handleFallbackAutoScroll:function(e){this._handleAutoScroll(e,!0)},_handleAutoScroll:function(e,t){var i=this,s=(e.touches?e.touches[0]:e).clientX,o=(e.touches?e.touches[0]:e).clientY,a=document.elementFromPoint(s,o);if(yi=e,t||this.options.forceAutoScrollFallback||Ne||He||Le){Si(e,this.options,a,t);var r=rt(a,!0);!wi||xi&&s===bi&&o===fi||(xi&&Di(),xi=setInterval(function(){var a=rt(document.elementFromPoint(s,o),!0);a!==r&&(r=a,ki()),Si(e,i.options,a,t)},10),bi=s,fi=o)}else{if(!this.options.bubbleScroll||rt(a,!0)===Qe())return void ki();Si(e,this.options,rt(a,!1),!1)}}},Ae(e,{pluginName:"scroll",initializeByDefault:!0})}),di.mount(Ei,Ti);let Ai=class extends ne{constructor(){super(...arguments),this.color="green",this.count=0}render(){if(this.count<1)return B``;if(1===this.count)return B`<span class="dot bare ${this.color}"></span>`;const e=this.count>=10;return B`<span
+            class="dot badge ${this.color} ${e?"multi-digit":""}"
+            ><span class="digit">${this.count}</span></span
+        >`}};Ai.styles=r`
+        /* The host generates no box; each dot is absolutely positioned against
+           the calling button (which sets position: relative). This keeps the
+           dot out of inline flow, so a numbered badge cannot pick up a
+           line-box strut and drift downward the way an inline-flex child does. */
+        :host {
+            display: contents;
+        }
+        .dot {
+            position: absolute;
+            pointer-events: none;
+            box-shadow: 0 0 0 1.5px var(--card-background-color);
+        }
+        /* Bare 8px dot for count === 1, centered on the button's top-right
+           corner: top/right -4 with an 8px box puts the centre on the corner. */
+        .dot.bare {
+            top: -4px;
+            right: -4px;
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+        }
+        /* Numbered 10px badge for count 2..9. Anchored at -5 (not -4) so the
+           larger box stays centered on the same corner point as the bare dot
+           instead of reading as sunk toward the label. */
+        .dot.badge {
+            top: -5px;
+            right: -5px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 10px;
+            height: 10px;
+            border-radius: 50%;
+            color: #ffffff;
+            /* 8px (not 7px) rasterises crisply at this size and reads as
+               centred; 7px snapped to the pixel grid and looked off. */
+            font-size: 8px;
+            font-weight: 500;
+            line-height: 1;
+            /* The action buttons set letter-spacing, which inherits here and
+               adds phantom space to the RIGHT of the single digit -- the flex
+               box then centres [digit + that space], shoving the digit left.
+               Reset it so the digit centres on its own advance. */
+            letter-spacing: normal;
+        }
+        /* A digit glyph has no descender, so flex-centring the line box leaves
+           the number riding ~0.5px above the badge's true centre. Nudge just
+           the digit down half a pixel so it sits dead-centre in the circle. */
+        .dot.badge .digit {
+            display: block;
+            transform: translateY(0.5px);
+        }
+        /* Double-digit stretch for count >= 10 (wider pill, pulled out a touch
+           further so it clears the corner). */
+        .dot.badge.multi-digit {
+            right: -6px;
+            min-width: 10px;
+            padding: 0 3px;
+            border-radius: 5px;
+        }
+        /* Colour variants */
+        .dot.green {
+            background: #2e7d32;
+        }
+        .dot.yellow {
+            background: #b89930;
+        }
+    `,e([he({type:String})],Ai.prototype,"color",void 0),e([he({type:Number})],Ai.prototype,"count",void 0),Ai=e([ue("ir-count-dot")],Ai);let Ii=class extends ne{constructor(){super(...arguments),this.templateName="",this.command=null,this.busy=!1,this.actionLabel=null,this.hasTrigger=!1,this.triggerCount=0,this.showActionMapping=!0,this._editingName=!1,this._draftName=""}_commandLabel(){const e=this.command;return e.protocol&&e.code?`${e.protocol}: ${e.code}`:e.raw_timings?.length?`RAW: ${e.raw_timings.length} timings`:e.protocol??"IR"}_prontoSlArray(e){const t=e.trim().split(/\s+/);if(t.length<6)return null;const i=parseInt(t[2],16)+parseInt(t[3],16),s=t.slice(4);if(s.length<2*i)return null;const o=[];for(let e=0;e<2*i;e++){const t=parseInt(s[e],16);o.push(t>=48)}return o.length>0?o:null}_renderDiamonds(){const e=this.command;if(!e||"PRONTO"!==e.protocol?.toUpperCase()||!e.code)return null;const t=this._prontoSlArray(e.code);return t?B`<span class="diamonds">${t.map(e=>e?B`<span class="diamond long">◆</span>`:B`<span class="diamond short">◇</span>`)}</span>`:null}_emit(e,t){const i=t?.currentTarget?.getBoundingClientRect()??null;this.dispatchEvent(new CustomEvent(e,{detail:{templateName:this.templateName,command:this.command,buttonRect:i},bubbles:!0,composed:!0}))}_startRename(e){this.command&&!this.busy&&(e.stopPropagation(),this._draftName=this.command.name,this._editingName=!0,this.updateComplete.then(()=>{const e=this.shadowRoot?.querySelector(".name-input");e?.focus(),e?.select()}))}_commitRename(){if(!this._editingName)return;const e=this._draftName.trim();this._editingName=!1,this.command&&e&&e!==this.command.name&&this.dispatchEvent(new CustomEvent("rename-command",{detail:{command:this.command,name:e},bubbles:!0,composed:!0}))}_onRenameKeydown(e){"Enter"===e.key?(e.preventDefault(),this._commitRename()):"Escape"===e.key&&(this._editingName=!1)}render(){const e=null!==this.command,t=e?this._renderDiamonds():null;return B`
             <div class="row" data-learned=${e?"true":"false"}>
                 <div class="status" aria-hidden="true">
                     <slot name="status"></slot>
                 </div>
                 <div class="info">
                     <div class="name">
-                        ${e?this._editingName?F`<input
+                        ${e?this._editingName?B`<input
                                       class="name-input"
                                       type="text"
                                       .value=${this._draftName}
                                       @input=${e=>this._draftName=e.target.value}
                                       @keydown=${this._onRenameKeydown}
                                       @blur=${this._commitRename}
-                                  />`:F`<span
+                                  />`:B`<span
                                       class="editable-name"
                                       title="Click to rename"
                                       @click=${this._startRename}
                                       >${this.templateName}<span class="rename-pencil"
                                           >&#9998;</span
                                       ></span
-                                  >`:F`${this.templateName}`}
-                        ${e&&this.command?.decoded_fingerprint?F`<button
+                                  >`:B`${this.templateName}`}
+                        ${e&&this.command?.decoded_fingerprint?B`<button
                                   class="tx-pill ${this.command.tx_force_raw?"tx-raw-on":""}"
                                   ?disabled=${this.busy}
                                   @click=${()=>this._emit("toggle-tx-raw")}
                                   title=${this.command.tx_force_raw?"Replaying the captured Pronto. Click to transmit clean decoded packet timings instead.":"Transmitting clean decoded packet timings. Click to replay the captured Pronto instead."}
                               >${this.command.tx_force_raw?"PRONTO":this.command.decoded_protocol??"AUTO"}</button>`:""}
-                        ${e&&this.command&&this.command.send_count>1?F`<span
+                        ${e&&this.command&&this.command.send_count>1?B`<span
                                   class="repeat-indicator"
                                   title="Sends this command ${this.command.send_count} times"
                                   ><ha-svg-icon
@@ -34,7 +105,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                   ></ha-svg-icon
                                   >${this.command.send_count}</span
                               >`:""}
-                        ${e&&this.command&&this.command.repeat_count>1&&this.command.decoded_protocol&&!this.command.tx_force_raw?F`<span
+                        ${e&&this.command&&this.command.repeat_count>1&&this.command.decoded_protocol&&!this.command.tx_force_raw?B`<span
                                   class="ditto-indicator"
                                   title="Appends ${this.command.repeat_count} NEC dittos"
                                   ><ha-svg-icon
@@ -44,11 +115,11 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                               >`:""}
                     </div>
                     <div class="meta">
-                        ${t||(e?F`${this._commandLabel()}`:F`<span class="muted">Not yet learned</span>`)}
+                        ${t||(e?B`${this._commandLabel()}`:B`<span class="muted">Not yet learned</span>`)}
                     </div>
                 </div>
                 <div class="actions">
-                    ${e?F`
+                    ${e?B`
                               <button
                                   class="icon-btn edit-btn"
                                   ?disabled=${this.busy}
@@ -58,7 +129,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                       class="edit-glyph"
                                       .path=${"M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"}
                                   ></ha-svg-icon></button>
-                              ${this.showActionMapping?F`<button
+                              ${this.showActionMapping?B`<button
                                   class="action-btn badge-btn"
                                   ?data-mapped=${!!this.actionLabel}
                                   ?disabled=${this.busy}
@@ -71,17 +142,20 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                   @click=${()=>this._emit("test")}
                               >Test</button>
                               <button
-                                  class="action-btn trigger-btn ${this.hasTrigger?"trigger-on":""}"
+                                  class="action-btn trigger-btn"
                                   ?disabled=${this.busy}
-                                  @click=${()=>this._emit("toggle-trigger")}
+                                  @click=${e=>this._emit("toggle-trigger",e)}
                                   title=${this.hasTrigger?"Edit trigger":"Create trigger"}
-                              >Trigger</button>
+                              >Trigger<ir-count-dot
+                                      color="yellow"
+                                      .count=${this.triggerCount||(this.hasTrigger?1:0)}
+                                  ></ir-count-dot></button>
                               <button
                                   class="action-btn delete-btn"
                                   ?disabled=${this.busy}
                                   @click=${()=>this._emit("delete")}
                               >Delete</button>
-                          `:F`
+                          `:B`
                               <button
                                   class="action-btn learn-btn"
                                   ?disabled=${this.busy}
@@ -90,7 +164,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                           `}
                 </div>
             </div>
-        `}};Ai.styles=n`
+        `}};Ii.styles=r`
         :host {
             display: block;
         }
@@ -295,19 +369,12 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
             background: rgba(var(--rgb-primary-color, 33, 150, 243), 0.12);
         }
         .action-btn.trigger-btn {
+            position: relative;
             color: #b89930;
             border-color: rgba(184, 153, 48, 0.3);
         }
         .action-btn.trigger-btn:hover {
             background: rgba(184, 153, 48, 0.08);
-        }
-        .action-btn.trigger-btn.trigger-on {
-            color: #fff;
-            background: #b89930;
-            border-color: #b89930;
-        }
-        .action-btn.trigger-btn.trigger-on:hover {
-            background: #a08328;
         }
         .action-btn.delete-btn {
             color: #e65100;
@@ -352,7 +419,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
             opacity: 0.5;
             cursor: default;
         }
-    `,e([he({attribute:!1})],Ai.prototype,"templateName",void 0),e([he({attribute:!1})],Ai.prototype,"command",void 0),e([he({type:Boolean})],Ai.prototype,"busy",void 0),e([he({attribute:!1})],Ai.prototype,"actionLabel",void 0),e([he({type:Boolean})],Ai.prototype,"hasTrigger",void 0),e([he({type:Boolean})],Ai.prototype,"showActionMapping",void 0),e([pe()],Ai.prototype,"_editingName",void 0),e([pe()],Ai.prototype,"_draftName",void 0),Ai=e([ue("ir-command-row")],Ai);let Ii=class extends re{constructor(){super(...arguments),this.commandName="",this.timeout=15,this._phase="listening",this._result=null,this._duplicate=null,this._error=null,this._timeRemaining=0,this._sessionId=null,this._unsubscribe=null,this._countdown=null}connectedCallback(){super.connectedCallback(),this._beginCapture()}disconnectedCallback(){super.disconnectedCallback(),this._stopCountdown(),this._unsubscribe&&(this._unsubscribe(),this._unsubscribe=null)}async _beginCapture(){this._phase="listening",this._result=null,this._duplicate=null,this._error=null,this._timeRemaining=this.timeout,this._startCountdown();try{const{session:e,unsubscribe:t}=await this.api.startCapture(this.device.id,this.timeout,e=>this._onCaptureEvent(e));this._sessionId=e.session_id,this._unsubscribe=t}catch(e){this._stopCountdown(),this._error=e.message,this._phase="error"}}_onCaptureEvent(e){switch(e.type){case"capture_listening":this._phase="listening";break;case"capture_received":this._stopCountdown(),this._result=e.result,e.duplicate_of?(this._duplicate=e.duplicate_of,this._phase="duplicate"):this._phase="captured";break;case"capture_timeout":this._stopCountdown(),this._phase="timeout";break;case"capture_error":this._stopCountdown(),this._error=e.error,this._phase="error";break;case"capture_cancelled":this._stopCountdown(),this._close()}}_startCountdown(){this._stopCountdown();const e=Date.now();this._countdown=window.setInterval(()=>{const t=(Date.now()-e)/1e3;this._timeRemaining=Math.max(0,Math.ceil(this.timeout-t)),this._timeRemaining<=0&&this._stopCountdown()},250)}_stopCountdown(){null!==this._countdown&&(clearInterval(this._countdown),this._countdown=null)}async _cancel(){if(this._sessionId)try{await this.api.cancelCapture(this._sessionId)}catch{}this._close()}async _testCommand(){if(!this._sessionId)return;const e=`__hair_test_${Date.now()}`;try{const t=await this.api.saveCapturedCommand({device_id:this.device.id,session_id:this._sessionId,command_name:e});await this.api.sendCommand(this.device.id,t.id),await this.api.deleteCommand(this.device.id,t.id)}catch(e){this._error=e.message,this._phase="error"}}async _save(e){if(this._sessionId)try{await this.api.saveCapturedCommand({device_id:this.device.id,session_id:this._sessionId,command_name:this.commandName}),this.dispatchEvent(new CustomEvent("command-saved",{detail:{saveAndNext:e,commandName:this.commandName},bubbles:!0,composed:!0})),this._close()}catch(e){this._error=e.message,this._phase="error"}}async _recapture(){this._unsubscribe&&(await this._unsubscribe(),this._unsubscribe=null),await this._beginCapture()}_close(){this.dispatchEvent(new CustomEvent("closed",{bubbles:!0,composed:!0}))}_renderListening(){return F`
+    `,e([he({attribute:!1})],Ii.prototype,"templateName",void 0),e([he({attribute:!1})],Ii.prototype,"command",void 0),e([he({type:Boolean})],Ii.prototype,"busy",void 0),e([he({attribute:!1})],Ii.prototype,"actionLabel",void 0),e([he({type:Boolean})],Ii.prototype,"hasTrigger",void 0),e([he({type:Number})],Ii.prototype,"triggerCount",void 0),e([he({type:Boolean})],Ii.prototype,"showActionMapping",void 0),e([pe()],Ii.prototype,"_editingName",void 0),e([pe()],Ii.prototype,"_draftName",void 0),Ii=e([ue("ir-command-row")],Ii);let Pi=class extends ne{constructor(){super(...arguments),this.commandName="",this.timeout=15,this._phase="listening",this._result=null,this._duplicate=null,this._error=null,this._timeRemaining=0,this._sessionId=null,this._unsubscribe=null,this._countdown=null}connectedCallback(){super.connectedCallback(),this._beginCapture()}disconnectedCallback(){super.disconnectedCallback(),this._stopCountdown(),this._unsubscribe&&(this._unsubscribe(),this._unsubscribe=null)}async _beginCapture(){this._phase="listening",this._result=null,this._duplicate=null,this._error=null,this._timeRemaining=this.timeout,this._startCountdown();try{const{session:e,unsubscribe:t}=await this.api.startCapture(this.device.id,this.timeout,e=>this._onCaptureEvent(e));this._sessionId=e.session_id,this._unsubscribe=t}catch(e){this._stopCountdown(),this._error=e.message,this._phase="error"}}_onCaptureEvent(e){switch(e.type){case"capture_listening":this._phase="listening";break;case"capture_received":this._stopCountdown(),this._result=e.result,e.duplicate_of?(this._duplicate=e.duplicate_of,this._phase="duplicate"):this._phase="captured";break;case"capture_timeout":this._stopCountdown(),this._phase="timeout";break;case"capture_error":this._stopCountdown(),this._error=e.error,this._phase="error";break;case"capture_cancelled":this._stopCountdown(),this._close()}}_startCountdown(){this._stopCountdown();const e=Date.now();this._countdown=window.setInterval(()=>{const t=(Date.now()-e)/1e3;this._timeRemaining=Math.max(0,Math.ceil(this.timeout-t)),this._timeRemaining<=0&&this._stopCountdown()},250)}_stopCountdown(){null!==this._countdown&&(clearInterval(this._countdown),this._countdown=null)}async _cancel(){if(this._sessionId)try{await this.api.cancelCapture(this._sessionId)}catch{}this._close()}async _testCommand(){if(!this._sessionId)return;const e=`__hair_test_${Date.now()}`;try{const t=await this.api.saveCapturedCommand({device_id:this.device.id,session_id:this._sessionId,command_name:e});await this.api.sendCommand(this.device.id,t.id),await this.api.deleteCommand(this.device.id,t.id)}catch(e){this._error=e.message,this._phase="error"}}async _save(e){if(this._sessionId)try{await this.api.saveCapturedCommand({device_id:this.device.id,session_id:this._sessionId,command_name:this.commandName}),this.dispatchEvent(new CustomEvent("command-saved",{detail:{saveAndNext:e,commandName:this.commandName},bubbles:!0,composed:!0})),this._close()}catch(e){this._error=e.message,this._phase="error"}}async _recapture(){this._unsubscribe&&(await this._unsubscribe(),this._unsubscribe=null),await this._beginCapture()}_close(){this.dispatchEvent(new CustomEvent("closed",{bubbles:!0,composed:!0}))}_renderListening(){return B`
             <div class="phase listening" aria-live="polite">
                 <div class="pulse" aria-hidden="true">
                     <span></span><span></span><span></span>
@@ -369,12 +436,12 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     <mwc-button @click=${this._cancel}>Cancel</mwc-button>
                 </div>
             </div>
-        `}_renderCaptured(){const e=this._result;return F`
+        `}_renderCaptured(){const e=this._result;return B`
             <div class="phase captured" aria-live="polite">
                 <div class="check" aria-hidden="true">✓</div>
                 <div class="title">Signal Captured!</div>
                 <div class="meta">
-                    Protocol: ${e.protocol??"Raw"}${e.code?F` · <code>${e.code}</code>`:""}
+                    Protocol: ${e.protocol??"Raw"}${e.code?B` · <code>${e.code}</code>`:""}
                 </div>
                 <ha-alert alert-type="info">
                     Did it work? Press Test to verify.
@@ -387,7 +454,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     </mwc-button>
                 </div>
             </div>
-        `}_renderTimeout(){return F`
+        `}_renderTimeout(){return B`
             <div class="phase error" aria-live="assertive">
                 <div class="title warn">⚠ No signal detected</div>
                 <ul class="tips">
@@ -400,7 +467,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     <mwc-button @click=${this._cancel}>Cancel</mwc-button>
                 </div>
             </div>
-        `}_renderDuplicate(){const e=this._result;return F`
+        `}_renderDuplicate(){const e=this._result;return B`
             <div class="phase warning" aria-live="assertive">
                 <div class="title warn">⚠ Duplicate Signal Detected</div>
                 <div class="instruction">
@@ -419,7 +486,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     </mwc-button>
                 </div>
             </div>
-        `}_renderError(){return F`
+        `}_renderError(){return B`
             <div class="phase error" aria-live="assertive">
                 <div class="title warn">⚠ Capture Error</div>
                 <div class="instruction">${this._error}</div>
@@ -430,7 +497,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     <mwc-button @click=${this._cancel}>Cancel</mwc-button>
                 </div>
             </div>
-        `}render(){return F`
+        `}render(){return B`
             <ha-dialog
                 open
                 heading=${`Learning: "${this.commandName}"`}
@@ -438,7 +505,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
             >
                 ${"listening"===this._phase?this._renderListening():"captured"===this._phase?this._renderCaptured():"timeout"===this._phase?this._renderTimeout():"duplicate"===this._phase?this._renderDuplicate():this._renderError()}
             </ha-dialog>
-        `}};Ii.styles=n`
+        `}};Pi.styles=r`
         .phase {
             min-width: 320px;
             padding: 8px 0;
@@ -515,7 +582,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
             padding-left: 22px;
             color: var(--primary-text-color);
         }
-    `,e([he({attribute:!1})],Ii.prototype,"api",void 0),e([he({attribute:!1})],Ii.prototype,"hass",void 0),e([he({attribute:!1})],Ii.prototype,"device",void 0),e([he({attribute:!1})],Ii.prototype,"commandName",void 0),e([he({attribute:!1})],Ii.prototype,"timeout",void 0),e([pe()],Ii.prototype,"_phase",void 0),e([pe()],Ii.prototype,"_result",void 0),e([pe()],Ii.prototype,"_duplicate",void 0),e([pe()],Ii.prototype,"_error",void 0),e([pe()],Ii.prototype,"_timeRemaining",void 0),e([pe()],Ii.prototype,"_sessionId",void 0),Ii=e([ue("ir-capture-dialog")],Ii);let Ri=class extends re{constructor(){super(...arguments),this.title="Confirm",this.message="Are you sure?",this.confirmLabel="Confirm",this.cancelLabel="Cancel",this.destructive=!1,this._busy=!1}_close(){this.dispatchEvent(new CustomEvent("closed",{bubbles:!0,composed:!0}))}_confirm(){this.dispatchEvent(new CustomEvent("confirmed",{bubbles:!0,composed:!0}))}render(){return F`
+    `,e([he({attribute:!1})],Pi.prototype,"api",void 0),e([he({attribute:!1})],Pi.prototype,"hass",void 0),e([he({attribute:!1})],Pi.prototype,"device",void 0),e([he({attribute:!1})],Pi.prototype,"commandName",void 0),e([he({attribute:!1})],Pi.prototype,"timeout",void 0),e([pe()],Pi.prototype,"_phase",void 0),e([pe()],Pi.prototype,"_result",void 0),e([pe()],Pi.prototype,"_duplicate",void 0),e([pe()],Pi.prototype,"_error",void 0),e([pe()],Pi.prototype,"_timeRemaining",void 0),e([pe()],Pi.prototype,"_sessionId",void 0),Pi=e([ue("ir-capture-dialog")],Pi);let Ri=class extends ne{constructor(){super(...arguments),this.title="Confirm",this.message="Are you sure?",this.confirmLabel="Confirm",this.cancelLabel="Cancel",this.destructive=!1,this._busy=!1}_close(){this.dispatchEvent(new CustomEvent("closed",{bubbles:!0,composed:!0}))}_confirm(){this.dispatchEvent(new CustomEvent("confirmed",{bubbles:!0,composed:!0}))}render(){return B`
             <div class="overlay" @click=${this._close}>
                 <div class="dialog" @click=${e=>e.stopPropagation()}>
                     <h3 class="heading">${this.title}</h3>
@@ -533,7 +600,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     </div>
                 </div>
             </div>
-        `}};Ri.styles=n`
+        `}};Ri.styles=r`
         .overlay {
             position: fixed;
             inset: 0;
@@ -597,15 +664,15 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
             background: #e65100;
             border-color: #e65100;
         }
-    `,e([he()],Ri.prototype,"title",void 0),e([he()],Ri.prototype,"message",void 0),e([he()],Ri.prototype,"confirmLabel",void 0),e([he()],Ri.prototype,"cancelLabel",void 0),e([he({type:Boolean})],Ri.prototype,"destructive",void 0),e([pe()],Ri.prototype,"_busy",void 0),Ri=e([ue("ir-confirm-dialog")],Ri);let Mi=class extends re{constructor(){super(...arguments),this.value=[],this.disabled=!1,this.excludeEntityIds=[],this._didAutoSelect=!1,this._receiverIds=new Set,this._receiversLoaded=!1}updated(e){if(super.updated(e),e.has("api")&&this.api&&!this._receiversLoaded&&(this._receiversLoaded=!0,this._loadReceivers()),!this._didAutoSelect)if(this.value.length>0)this._didAutoSelect=!0;else{const e=this._getEmitters();1===e.length&&(this._didAutoSelect=!0,this._fireChange([e[0].entity_id]))}}async _loadReceivers(){if(this.api)try{const e=await this.api.listReceivers();this._receiverIds=new Set(e.map(e=>e.entity_id))}catch{this._receiverIds=new Set}}_getEmitters(){const e=this.hass?.states??{},t=new Set(this.excludeEntityIds),i=[];for(const[s,a]of Object.entries(e))!s.startsWith("infrared.")||t.has(s)||this._receiverIds.has(s)||a.attributes.hair_observer||i.push({entity_id:s,name:a.attributes.friendly_name??s});return i}_emitterName(e){const t=this.hass?.states?.[e];return t?.attributes?.friendly_name??e}_onAdd(e){const t=e.target,i=t.value;i&&(t.value="",this.value.includes(i)||this._fireChange([...this.value,i]))}_onRemove(e){this._fireChange(this.value.filter(t=>t!==e))}_fireChange(e){this.value=e,this.dispatchEvent(new CustomEvent("emitters-changed",{detail:{value:e},bubbles:!0,composed:!0}))}render(){const e=this._getEmitters(),t=e.filter(e=>!this.value.includes(e.entity_id));return F`
+    `,e([he()],Ri.prototype,"title",void 0),e([he()],Ri.prototype,"message",void 0),e([he()],Ri.prototype,"confirmLabel",void 0),e([he()],Ri.prototype,"cancelLabel",void 0),e([he({type:Boolean})],Ri.prototype,"destructive",void 0),e([pe()],Ri.prototype,"_busy",void 0),Ri=e([ue("ir-confirm-dialog")],Ri);let Mi=class extends ne{constructor(){super(...arguments),this.value=[],this.disabled=!1,this.excludeEntityIds=[],this._didAutoSelect=!1,this._receiverIds=new Set,this._receiversLoaded=!1}updated(e){if(super.updated(e),e.has("api")&&this.api&&!this._receiversLoaded&&(this._receiversLoaded=!0,this._loadReceivers()),!this._didAutoSelect)if(this.value.length>0)this._didAutoSelect=!0;else{const e=this._getEmitters();1===e.length&&(this._didAutoSelect=!0,this._fireChange([e[0].entity_id]))}}async _loadReceivers(){if(this.api)try{const e=await this.api.listReceivers();this._receiverIds=new Set(e.map(e=>e.entity_id))}catch{this._receiverIds=new Set}}_getEmitters(){const e=this.hass?.states??{},t=new Set(this.excludeEntityIds),i=[];for(const[s,o]of Object.entries(e))!s.startsWith("infrared.")||t.has(s)||this._receiverIds.has(s)||o.attributes.hair_observer||i.push({entity_id:s,name:o.attributes.friendly_name??s});return i}_emitterName(e){const t=this.hass?.states?.[e];return t?.attributes?.friendly_name??e}_onAdd(e){const t=e.target,i=t.value;i&&(t.value="",this.value.includes(i)||this._fireChange([...this.value,i]))}_onRemove(e){this._fireChange(this.value.filter(t=>t!==e))}_fireChange(e){this.value=e,this.dispatchEvent(new CustomEvent("emitters-changed",{detail:{value:e},bubbles:!0,composed:!0}))}render(){const e=this._getEmitters(),t=e.filter(e=>!this.value.includes(e.entity_id));return B`
             <label>IR emitters</label>
 
-            ${this.value.length>0?F`
+            ${this.value.length>0?B`
                       <div class="chips">
-                          ${this.value.map(e=>F`
+                          ${this.value.map(e=>B`
                                   <span class="chip">
                                       <span class="chip-name">${this._emitterName(e)}</span>
-                                      ${this.disabled?"":F`<button
+                                      ${this.disabled?"":B`<button
                                                 class="chip-remove"
                                                 @click=${()=>this._onRemove(e)}
                                                 title="Remove"
@@ -615,20 +682,20 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                       </div>
                   `:""}
 
-            ${0===e.length?F`<div class="no-emitters">No IR emitters found.</div>`:t.length>0?F`
+            ${0===e.length?B`<div class="no-emitters">No IR emitters found.</div>`:t.length>0?B`
                         <select
                             @change=${this._onAdd}
                             ?disabled=${this.disabled}
                         >
                             <option value="">+ Add emitter...</option>
-                            ${t.map(e=>F`
+                            ${t.map(e=>B`
                                     <option value=${e.entity_id}>
                                         ${e.name}
                                     </option>
                                 `)}
                         </select>
-                    `:this.value.length>0?F`<div class="all-selected">All emitters selected.</div>`:""}
-        `}};Mi.styles=n`
+                    `:this.value.length>0?B`<div class="all-selected">All emitters selected.</div>`:""}
+        `}};Mi.styles=r`
         :host {
             display: block;
         }
@@ -698,31 +765,31 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
             color: var(--secondary-text-color);
             font-style: italic;
         }
-    `,e([he({attribute:!1})],Mi.prototype,"hass",void 0),e([he({attribute:!1})],Mi.prototype,"api",void 0),e([he({attribute:!1})],Mi.prototype,"value",void 0),e([he({type:Boolean})],Mi.prototype,"disabled",void 0),e([he({attribute:!1})],Mi.prototype,"excludeEntityIds",void 0),e([pe()],Mi.prototype,"_didAutoSelect",void 0),e([pe()],Mi.prototype,"_receiverIds",void 0),Mi=e([ue("ir-emitter-picker")],Mi);const Pi=[3e4,33e3,36e3,38e3,4e4,56e3],Hi=e=>Pi.reduce((t,i)=>Math.abs(i-e)<Math.abs(t-e)?i:t);let Ni=class extends re{constructor(){super(...arguments),this.signalId=null,this.commandId=null,this.initialPronto="",this.initialAlias="",this.initialSendCount=1,this.initialDitto=1,this.initialObservedRepeatCount=0,this.initialTxForceRaw=!1,this.initialDecodedProtocol=null,this.hasTrigger=!1,this.allowSnap=!1,this._pronto="",this._alias="",this._sendCount=1,this._ditto=1,this._busy=!1,this._error=null,this._validation=null,this._copyHint=null,this._snapping=!1,this._snapFlash=!1,this._debounce=null}get _isCommand(){return null!==this.commandId}get _isEdit(){return null!==this.signalId||null!==this.commandId}get _dirty(){return this._pronto!==this.initialPronto||this._alias!==this.initialAlias||this._sendCount!==this.initialSendCount||this._ditto!==this.initialDitto}get _canSave(){return!this._busy&&!0===this._validation?.valid&&(!this._isEdit||this._dirty)}get _dittoCountDisabled(){return this._isCommand?!this.initialDecodedProtocol||!!this.initialTxForceRaw:!this._pronto.trim()||null===this._validation||!this._validation.recognized_protocol}get _dittoDisabledTooltip(){return this._isCommand&&this.initialDecodedProtocol&&this.initialTxForceRaw?"Ditto count applies when the command transmits as NEC. Toggle the pill to NEC to enable.":"Ditto count applies to decoded signals (NEC today). Raw Pronto codes transmit as captured."}firstUpdated(){this._pronto=this.initialPronto,this._alias=this.initialAlias,this._sendCount=this.initialSendCount,this._ditto=this.initialDitto,this._pronto.trim()&&this._validate()}updated(){const e=this.shadowRoot?.querySelector("textarea");if(!e)return;const t=Math.round(.45*window.innerHeight);e.style.height="0px";const i=Math.min(Math.max(e.scrollHeight+2,64),t);e.style.height=`${i}px`}disconnectedCallback(){super.disconnectedCallback(),null!==this._debounce&&clearTimeout(this._debounce)}_close(){this.dispatchEvent(new CustomEvent("closed",{bubbles:!0,composed:!0}))}_onSendCountInput(e){const t=parseInt(e.target.value,10);this._sendCount=Number.isNaN(t)?1:Math.max(1,Math.min(t,10))}_onDittoInput(e){const t=parseInt(e.target.value,10);this._ditto=Number.isNaN(t)?0:Math.max(0,Math.min(t,20))}_onProntoInput(e){this._pronto=e.target.value,null!==this._debounce&&clearTimeout(this._debounce),this._pronto.trim()?this._debounce=setTimeout(()=>{this._validate()},250):this._validation=null}_onKeydown(e){"Enter"!==e.key||e.shiftKey||(e.preventDefault(),this._canSave&&this._save())}async _validate(){try{this._validation=await this.api.validatePronto(this._pronto)}catch{this._validation=null}}_slPreview(){const e=this._validation?.normalized;if(!e)return null;const t=e.split(" ").map(e=>parseInt(e,16));if(t.length<5||t.some(e=>Number.isNaN(e)))return null;const i=[];for(const e of t.slice(4)){if(e>=1024)break;i.push(e<48?"S":"L")}return i.length?i:null}async _save(){if(!this._canSave)return;this._busy=!0,this._error=null;const e=this._dittoCountDisabled?void 0:this._ditto;try{if(this._isCommand){const t=await this.api.updateCommand({device_id:this.deviceId,command_id:this.commandId,name:this._alias.trim(),pronto:this._pronto,send_count:this._sendCount,repeat_count:e});this.dispatchEvent(new CustomEvent("command-edited",{detail:t,bubbles:!0,composed:!0}))}else if(null!==this.signalId){const t=await this.api.editSignalPronto({device_id:this.deviceId,signal_id:this.signalId,pronto:this._pronto,alias:this._alias.trim(),send_count:this._sendCount,repeat_count:e});this.dispatchEvent(new CustomEvent("signal-edited",{detail:t,bubbles:!0,composed:!0}))}else{const t=await this.api.createSignal({device_id:this.deviceId,pronto:this._pronto,alias:this._alias.trim()||void 0,send_count:this._sendCount,repeat_count:e});this.dispatchEvent(new CustomEvent("signal-created",{detail:t.signal,bubbles:!0,composed:!0}))}}catch(e){this._error=e.message}finally{this._busy=!1}}async _selectCode(){const e=this.shadowRoot?.querySelector("textarea");e&&(e.focus(),e.select());let t=!1;try{window.isSecureContext&&navigator.clipboard&&(await navigator.clipboard.writeText(this._pronto),t=!0)}catch{t=!1}this._copyHint=t?"Copied":"Press Cmd/Ctrl+C",setTimeout(()=>{this._copyHint=null},2e3)}_renderFeedback(){const e=this._validation;if(!e)return"";const t=this._slPreview();return F`
+    `,e([he({attribute:!1})],Mi.prototype,"hass",void 0),e([he({attribute:!1})],Mi.prototype,"api",void 0),e([he({attribute:!1})],Mi.prototype,"value",void 0),e([he({type:Boolean})],Mi.prototype,"disabled",void 0),e([he({attribute:!1})],Mi.prototype,"excludeEntityIds",void 0),e([pe()],Mi.prototype,"_didAutoSelect",void 0),e([pe()],Mi.prototype,"_receiverIds",void 0),Mi=e([ue("ir-emitter-picker")],Mi);const Hi=[3e4,33e3,36e3,38e3,4e4,56e3],Ni=e=>Hi.reduce((t,i)=>Math.abs(i-e)<Math.abs(t-e)?i:t);let zi=class extends ne{constructor(){super(...arguments),this.signalId=null,this.commandId=null,this.initialPronto="",this.initialAlias="",this.initialSendCount=1,this.initialDitto=1,this.initialObservedRepeatCount=0,this.initialTxForceRaw=!1,this.initialDecodedProtocol=null,this.hasTrigger=!1,this.allowSnap=!1,this._pronto="",this._alias="",this._sendCount=1,this._ditto=1,this._busy=!1,this._error=null,this._validation=null,this._copyHint=null,this._snapping=!1,this._snapFlash=!1,this._debounce=null}get _isCommand(){return null!==this.commandId}get _isEdit(){return null!==this.signalId||null!==this.commandId}get _dirty(){return this._pronto!==this.initialPronto||this._alias!==this.initialAlias||this._sendCount!==this.initialSendCount||this._ditto!==this.initialDitto}get _canSave(){return!this._busy&&!0===this._validation?.valid&&(!this._isEdit||this._dirty)}get _dittoCountDisabled(){return this._isCommand?!this.initialDecodedProtocol||!!this.initialTxForceRaw:!this._pronto.trim()||null===this._validation||!this._validation.recognized_protocol}get _dittoDisabledTooltip(){return this._isCommand&&this.initialDecodedProtocol&&this.initialTxForceRaw?"Ditto count applies when the command transmits as NEC. Toggle the pill to NEC to enable.":"Ditto count applies to decoded signals (NEC today). Raw Pronto codes transmit as captured."}firstUpdated(){this._pronto=this.initialPronto,this._alias=this.initialAlias,this._sendCount=this.initialSendCount,this._ditto=this.initialDitto,this._pronto.trim()&&this._validate()}updated(){const e=this.shadowRoot?.querySelector("textarea");if(!e)return;const t=Math.round(.45*window.innerHeight);e.style.height="0px";const i=Math.min(Math.max(e.scrollHeight+2,64),t);e.style.height=`${i}px`}disconnectedCallback(){super.disconnectedCallback(),null!==this._debounce&&clearTimeout(this._debounce)}_close(){this.dispatchEvent(new CustomEvent("closed",{bubbles:!0,composed:!0}))}_onSendCountInput(e){const t=parseInt(e.target.value,10);this._sendCount=Number.isNaN(t)?1:Math.max(1,Math.min(t,10))}_onDittoInput(e){const t=parseInt(e.target.value,10);this._ditto=Number.isNaN(t)?0:Math.max(0,Math.min(t,20))}_onProntoInput(e){this._pronto=e.target.value,null!==this._debounce&&clearTimeout(this._debounce),this._pronto.trim()?this._debounce=setTimeout(()=>{this._validate()},250):this._validation=null}_onKeydown(e){"Enter"!==e.key||e.shiftKey||(e.preventDefault(),this._canSave&&this._save())}async _validate(){try{this._validation=await this.api.validatePronto(this._pronto)}catch{this._validation=null}}_slPreview(){const e=this._validation?.normalized;if(!e)return null;const t=e.split(" ").map(e=>parseInt(e,16));if(t.length<5||t.some(e=>Number.isNaN(e)))return null;const i=[];for(const e of t.slice(4)){if(e>=1024)break;i.push(e<48?"S":"L")}return i.length?i:null}async _save(){if(!this._canSave)return;this._busy=!0,this._error=null;const e=this._dittoCountDisabled?void 0:this._ditto;try{if(this._isCommand){const t=await this.api.updateCommand({device_id:this.deviceId,command_id:this.commandId,name:this._alias.trim(),pronto:this._pronto,send_count:this._sendCount,repeat_count:e});this.dispatchEvent(new CustomEvent("command-edited",{detail:t,bubbles:!0,composed:!0}))}else if(null!==this.signalId){const t=await this.api.editSignalPronto({device_id:this.deviceId,signal_id:this.signalId,pronto:this._pronto,alias:this._alias.trim(),send_count:this._sendCount,repeat_count:e});this.dispatchEvent(new CustomEvent("signal-edited",{detail:t,bubbles:!0,composed:!0}))}else{const t=await this.api.createSignal({device_id:this.deviceId,pronto:this._pronto,alias:this._alias.trim()||void 0,send_count:this._sendCount,repeat_count:e});this.dispatchEvent(new CustomEvent("signal-created",{detail:t.signal,bubbles:!0,composed:!0}))}}catch(e){this._error=e.message}finally{this._busy=!1}}async _selectCode(){const e=this.shadowRoot?.querySelector("textarea");e&&(e.focus(),e.select());let t=!1;try{window.isSecureContext&&navigator.clipboard&&(await navigator.clipboard.writeText(this._pronto),t=!0)}catch{t=!1}this._copyHint=t?"Copied":"Press Cmd/Ctrl+C",setTimeout(()=>{this._copyHint=null},2e3)}_renderFeedback(){const e=this._validation;if(!e)return"";const t=this._slPreview();return B`
             <div class="feedback">
                 <div class="status ${e.valid?"ok":"bad"}">
                     <span class="mark">${e.valid?"✓":"✗"}</span>
                     ${e.valid?"Valid Pronto code":"Not valid yet"}
                 </div>
-                ${e.valid?F`
+                ${e.valid?B`
                           <div class="metrics">
-                              ${null!==e.frequency_khz?F`<span>${e.frequency_khz} kHz</span>`:""}
-                              ${null!==e.burst_pair_count?F`<span
+                              ${null!==e.frequency_khz?B`<span>${e.frequency_khz} kHz</span>`:""}
+                              ${null!==e.burst_pair_count?B`<span
                                         >${e.burst_pair_count} burst
                                         ${1===e.burst_pair_count?"pair":"pairs"}</span
                                     >`:""}
-                              ${e.recognized_protocol?F`<span class="recognized"
+                              ${e.recognized_protocol?B`<span class="recognized"
                                         >Recognized as ${e.recognized_protocol}</span
                                     >`:""}
                           </div>
-                          ${t?F`<div class="diamonds">
-                                    ${t.map(e=>"L"===e?F`<span class="diamond long">◆</span>`:F`<span class="diamond short">◇</span>`)}
+                          ${t?B`<div class="diamonds">
+                                    ${t.map(e=>"L"===e?B`<span class="diamond long">◆</span>`:B`<span class="diamond short">◇</span>`)}
                                 </div>`:""}
                       `:""}
-                ${e.errors.map(e=>F`<div class="msg err">${e}</div>`)}
-                ${e.warnings.map(e=>F`<div class="msg warn">${e}</div>`)}
+                ${e.errors.map(e=>B`<div class="msg err">${e}</div>`)}
+                ${e.warnings.map(e=>B`<div class="msg warn">${e}</div>`)}
             </div>
-        `}get _carrierHz(){const e=this._validation?.valid?this._validation.frequency_khz:null;return null!=e?Math.round(1e3*e):null}get _showSnap(){if(!this.allowSnap)return!1;const e=this._carrierHz;return null!=e&&!(e=>Math.abs(e-Hi(e))<=500)(e)}async _snap(e){this._snapping=!0,this._error=null;try{const t=await this.api.snapPreview({pronto:this._pronto,target_frequency:e});this._pronto=t.pronto,await this._validate(),this._snapFlash=!0,setTimeout(()=>{this._snapFlash=!1},700)}catch(e){this._error=e.message}finally{this._snapping=!1}}_renderSnap(){if(!this._showSnap)return"";const e=this._carrierHz,t=Hi(e),i=(e/1e3).toFixed(1),s=(t/1e3).toFixed(0);return F`
+        `}get _carrierHz(){const e=this._validation?.valid?this._validation.frequency_khz:null;return null!=e?Math.round(1e3*e):null}get _showSnap(){if(!this.allowSnap)return!1;const e=this._carrierHz;return null!=e&&!(e=>Math.abs(e-Ni(e))<=500)(e)}async _snap(e){this._snapping=!0,this._error=null;try{const t=await this.api.snapPreview({pronto:this._pronto,target_frequency:e});this._pronto=t.pronto,await this._validate(),this._snapFlash=!0,setTimeout(()=>{this._snapFlash=!1},700)}catch(e){this._error=e.message}finally{this._snapping=!1}}_renderSnap(){if(!this._showSnap)return"";const e=this._carrierHz,t=Ni(e),i=(e/1e3).toFixed(1),s=(t/1e3).toFixed(0);return B`
             <div class="snap-notice">
                 <div class="snap-text">
                     Carrier is ${i} kHz, off the IR standards. Some
@@ -736,14 +803,14 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     ${this._snapping?"Snapping...":`Snap to ${s} kHz`}
                 </button>
             </div>
-        `}render(){const e=this._isCommand?"Edit command":this._isEdit?"Edit signal":"Create signal",t=this._isEdit?this._busy?"Saving...":"Save":this._busy?"Creating...":"Create",i=this._isEdit&&this.hasTrigger&&this._dirty,s=this._isCommand?"This command has a trigger that will automatically re-point.":"This signal has a trigger that will automatically re-point.",a=this._isCommand?"Command name":"Alias"+(this._isEdit?"":" (optional)");return F`
+        `}render(){const e=this._isCommand?"Edit command":this._isEdit?"Edit signal":"Create signal",t=this._isEdit?this._busy?"Saving...":"Save":this._busy?"Creating...":"Create",i=this._isEdit&&this.hasTrigger&&this._dirty,s=this._isCommand?"This command has a trigger that will automatically re-point.":"This signal has a trigger that will automatically re-point.",o=this._isCommand?"Command name":"Alias"+(this._isEdit?"":" (optional)");return B`
             <ha-dialog
                 open
                 heading=${e}
                 scrimClickAction=""
                 @closed=${this._close}
             >
-                ${this._error?F`<ha-alert alert-type="error">${this._error}</ha-alert>`:""}
+                ${this._error?B`<ha-alert alert-type="error">${this._error}</ha-alert>`:""}
 
                 <div class="field">
                     <label>Pronto code</label>
@@ -758,8 +825,8 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                             @input=${this._onProntoInput}
                             @keydown=${this._onKeydown}
                         ></textarea>
-                        ${this._pronto.trim()?F`
-                                  ${this._copyHint?F`<span class="copy-flash"
+                        ${this._pronto.trim()?B`
+                                  ${this._copyHint?B`<span class="copy-flash"
                                             >${this._copyHint}</span
                                         >`:""}
                                   <button
@@ -778,7 +845,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                 ${this._renderFeedback()} ${this._renderSnap()}
 
                 <div class="field">
-                    <label>${a}</label>
+                    <label>${o}</label>
                     <input
                         type="text"
                         .value=${this._alias}
@@ -802,7 +869,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                             @keydown=${this._onKeydown}
                         />
                     </div>
-                    ${this._dittoCountDisabled?"":F`<div class="knob">
+                    ${this._dittoCountDisabled?"":B`<div class="knob">
                               <label>Ditto count</label>
                               <input
                                   class="num-input"
@@ -816,13 +883,13 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                               />
                           </div>`}
                 </div>
-                ${this.initialObservedRepeatCount>0?F`<div class="observed-hint">
+                ${this.initialObservedRepeatCount>0?B`<div class="observed-hint">
                           Observed at capture:
                           ${this.initialObservedRepeatCount}
                           ${1===this.initialObservedRepeatCount?"ditto":"dittos"}
                       </div>`:""}
 
-                ${i?F`<div class="note">${s}</div>`:""}
+                ${i?B`<div class="note">${s}</div>`:""}
 
                 <div class="dialog-actions">
                     <span class="spacer"></span>
@@ -842,7 +909,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     </button>
                 </div>
             </ha-dialog>
-        `}};Ni.styles=n`
+        `}};zi.styles=r`
         .field {
             display: block;
             margin: 12px 0;
@@ -1118,10 +1185,107 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
         .create-btn:hover:not(:disabled) {
             opacity: 0.9;
         }
-    `,e([he({attribute:!1})],Ni.prototype,"api",void 0),e([he({attribute:!1})],Ni.prototype,"deviceId",void 0),e([he({attribute:!1})],Ni.prototype,"signalId",void 0),e([he({attribute:!1})],Ni.prototype,"commandId",void 0),e([he({attribute:!1})],Ni.prototype,"initialPronto",void 0),e([he({attribute:!1})],Ni.prototype,"initialAlias",void 0),e([he({attribute:!1})],Ni.prototype,"initialSendCount",void 0),e([he({attribute:!1})],Ni.prototype,"initialDitto",void 0),e([he({attribute:!1})],Ni.prototype,"initialObservedRepeatCount",void 0),e([he({attribute:!1})],Ni.prototype,"initialTxForceRaw",void 0),e([he({attribute:!1})],Ni.prototype,"initialDecodedProtocol",void 0),e([he({type:Boolean})],Ni.prototype,"hasTrigger",void 0),e([he({type:Boolean})],Ni.prototype,"allowSnap",void 0),e([pe()],Ni.prototype,"_pronto",void 0),e([pe()],Ni.prototype,"_alias",void 0),e([pe()],Ni.prototype,"_sendCount",void 0),e([pe()],Ni.prototype,"_ditto",void 0),e([pe()],Ni.prototype,"_busy",void 0),e([pe()],Ni.prototype,"_error",void 0),e([pe()],Ni.prototype,"_validation",void 0),e([pe()],Ni.prototype,"_copyHint",void 0),e([pe()],Ni.prototype,"_snapping",void 0),e([pe()],Ni.prototype,"_snapFlash",void 0),Ni=e([ue("ir-signal-editor")],Ni);let zi=class extends re{constructor(){super(...arguments),this.signalFingerprint="",this.protocol=null,this.code=null,this.slPattern=null,this.alias=null,this.sourceDeviceId=null,this.sourceCommandId=null,this.trigger=null,this._name="",this._minHits=1,this._busy=!1,this._error=null}connectedCallback(){super.connectedCallback(),this.trigger&&(this._name=this.trigger.name,this._minHits=this.trigger.min_hits)}_close(){this.dispatchEvent(new CustomEvent("closed",{bubbles:!0,composed:!0}))}async _save(){const e=this._name.trim();if(e){this._busy=!0,this._error=null;try{let t;if(this.trigger)t=await this.api.updateTrigger(this.trigger.id,{name:e,min_hits:this._minHits});else{const i={name:e,protocol:this.protocol,code:this.code,min_hits:this._minHits,source_device_id:this.sourceDeviceId,source_command_id:this.sourceCommandId};this.signalFingerprint&&(i.signal_fingerprint=this.signalFingerprint),t=await this.api.createTrigger(i)}this.dispatchEvent(new CustomEvent("trigger-saved",{detail:t,bubbles:!0,composed:!0}))}catch(e){this._error=e.message??"Save failed"}finally{this._busy=!1}}else this._error="Name is required."}_emitDelete(){this.trigger&&this.dispatchEvent(new CustomEvent("trigger-delete",{detail:{triggerId:this.trigger.id},bubbles:!0,composed:!0}))}_prontoSlArray(e){const t=e.trim().split(/\s+/);if(t.length<6)return null;const i=parseInt(t[2],16)+parseInt(t[3],16),s=t.slice(4);if(s.length<2*i)return null;const a=[];for(let e=0;e<2*i;e++){const t=parseInt(s[e],16);a.push(t>=48)}return a.length>0?a:null}_renderSignalInfo(){const e=!!this.trigger;if(!e&&this.alias)return F`<span class="alias-inline"
+    `,e([he({attribute:!1})],zi.prototype,"api",void 0),e([he({attribute:!1})],zi.prototype,"deviceId",void 0),e([he({attribute:!1})],zi.prototype,"signalId",void 0),e([he({attribute:!1})],zi.prototype,"commandId",void 0),e([he({attribute:!1})],zi.prototype,"initialPronto",void 0),e([he({attribute:!1})],zi.prototype,"initialAlias",void 0),e([he({attribute:!1})],zi.prototype,"initialSendCount",void 0),e([he({attribute:!1})],zi.prototype,"initialDitto",void 0),e([he({attribute:!1})],zi.prototype,"initialObservedRepeatCount",void 0),e([he({attribute:!1})],zi.prototype,"initialTxForceRaw",void 0),e([he({attribute:!1})],zi.prototype,"initialDecodedProtocol",void 0),e([he({type:Boolean})],zi.prototype,"hasTrigger",void 0),e([he({type:Boolean})],zi.prototype,"allowSnap",void 0),e([pe()],zi.prototype,"_pronto",void 0),e([pe()],zi.prototype,"_alias",void 0),e([pe()],zi.prototype,"_sendCount",void 0),e([pe()],zi.prototype,"_ditto",void 0),e([pe()],zi.prototype,"_busy",void 0),e([pe()],zi.prototype,"_error",void 0),e([pe()],zi.prototype,"_validation",void 0),e([pe()],zi.prototype,"_copyHint",void 0),e([pe()],zi.prototype,"_snapping",void 0),e([pe()],zi.prototype,"_snapFlash",void 0),zi=e([ue("ir-signal-editor")],zi);let Li=class extends ne{constructor(){super(...arguments),this.value=[],this.disabled=!1,this._receivers=[],this._receiversLoaded=!1}updated(e){super.updated(e),e.has("api")&&this.api&&!this._receiversLoaded&&(this._receiversLoaded=!0,this._loadReceivers())}async _loadReceivers(){if(this.api)try{this._receivers=await this.api.listReceivers()}catch{this._receivers=[]}}_receiverName(e){const t=this._receivers.find(t=>t.entity_id===e);return t?.name??e}_onAdd(e){const t=e.target,i=t.value;i&&(t.value="",this.value.includes(i)||this._fireChange([...this.value,i]))}_onRemove(e){this._fireChange(this.value.filter(t=>t!==e))}_fireChange(e){this.value=e,this.dispatchEvent(new CustomEvent("receivers-changed",{detail:{value:e},bubbles:!0,composed:!0}))}render(){const e=this._receivers.filter(e=>!this.value.includes(e.entity_id));return B`
+            <label>Via receiver(s):</label>
+
+            ${this.value.length>0?B`
+                      <div class="chips">
+                          ${this.value.map(e=>B`
+                                  <span class="chip">
+                                      <span class="chip-name"
+                                          >${this._receiverName(e)}</span
+                                      >
+                                      ${this.disabled?"":B`<button
+                                                class="chip-remove"
+                                                @click=${()=>this._onRemove(e)}
+                                                title="Remove"
+                                            >
+                                                &times;
+                                            </button>`}
+                                  </span>
+                              `)}
+                      </div>
+                  `:""}
+
+            ${0===this._receivers.length?B`<div class="no-receivers">No IR receivers found.</div>`:e.length>0?B`
+                        <select @change=${this._onAdd} ?disabled=${this.disabled}>
+                            <option value="">+ Add receiver...</option>
+                            ${e.map(e=>B`
+                                    <option value=${e.entity_id}>
+                                        ${e.name}
+                                    </option>
+                                `)}
+                        </select>
+                    `:B`<div class="all-selected">All receivers selected.</div>`}
+        `}};Li.styles=r`
+        :host {
+            display: block;
+        }
+        label {
+            display: var(--picker-label-display, block);
+            font-size: 0.82rem;
+            font-weight: 500;
+            color: var(--primary-text-color);
+            margin-bottom: 6px;
+        }
+        .chips {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin-bottom: 8px;
+        }
+        .chip {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            background: var(--secondary-background-color);
+            color: var(--primary-color);
+            font-size: 0.82rem;
+            font-weight: 500;
+            padding: 4px 8px;
+            border-radius: 4px;
+            line-height: 1;
+        }
+        .chip-name {
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            max-width: 200px;
+        }
+        .chip-remove {
+            background: none;
+            border: none;
+            color: inherit;
+            font-size: 1rem;
+            cursor: pointer;
+            padding: 0 2px;
+            line-height: 1;
+            opacity: 0.65;
+            transition: opacity 120ms ease;
+        }
+        .chip-remove:hover {
+            opacity: 1;
+        }
+        select {
+            width: 100%;
+            padding: 6px 8px;
+            border-radius: 4px;
+            border: 1px solid var(--divider-color);
+            background: var(--card-background-color);
+            color: var(--primary-text-color);
+            font-family: inherit;
+            font-size: 0.85rem;
+        }
+        .no-receivers,
+        .all-selected {
+            font-size: 0.8rem;
+            color: var(--secondary-text-color);
+            font-style: italic;
+        }
+    `,e([he({attribute:!1})],Li.prototype,"api",void 0),e([he({attribute:!1})],Li.prototype,"value",void 0),e([he({type:Boolean})],Li.prototype,"disabled",void 0),e([pe()],Li.prototype,"_receivers",void 0),Li=e([ue("ir-receiver-picker")],Li);let Vi=class extends ne{constructor(){super(...arguments),this.signalFingerprint="",this.protocol=null,this.code=null,this.slPattern=null,this.alias=null,this.sourceDeviceId=null,this.sourceCommandId=null,this.trigger=null,this._name="",this._minHits=1,this._receiverIds=[],this._busy=!1,this._error=null}connectedCallback(){super.connectedCallback(),this.trigger&&(this._name=this.trigger.name,this._minHits=this.trigger.min_hits,this._receiverIds=[...this.trigger.receiver_entity_ids??[]])}_close(){this.dispatchEvent(new CustomEvent("closed",{bubbles:!0,composed:!0}))}async _save(){const e=this._name.trim();if(e){this._busy=!0,this._error=null;try{let t;if(this.trigger)t=await this.api.updateTrigger(this.trigger.id,{name:e,min_hits:this._minHits,receiver_entity_ids:this._receiverIds});else{const i={name:e,protocol:this.protocol,code:this.code,min_hits:this._minHits,source_device_id:this.sourceDeviceId,source_command_id:this.sourceCommandId,receiver_entity_ids:this._receiverIds};this.signalFingerprint&&(i.signal_fingerprint=this.signalFingerprint),t=await this.api.createTrigger(i)}this.dispatchEvent(new CustomEvent("trigger-saved",{detail:t,bubbles:!0,composed:!0}))}catch(e){this._error=e.message??"Save failed"}finally{this._busy=!1}}else this._error="Name is required."}_emitDelete(){this.trigger&&this.dispatchEvent(new CustomEvent("trigger-delete",{detail:{triggerId:this.trigger.id},bubbles:!0,composed:!0}))}_prontoSlArray(e){const t=e.trim().split(/\s+/);if(t.length<6)return null;const i=parseInt(t[2],16)+parseInt(t[3],16),s=t.slice(4);if(s.length<2*i)return null;const o=[];for(let e=0;e<2*i;e++){const t=parseInt(s[e],16);o.push(t>=48)}return o.length>0?o:null}_renderSignalInfo(){const e=!!this.trigger;if(!e&&this.alias)return B`<span class="alias-inline"
                 ><span class="alias-tag">alias</span
                 ><span class="alias-name">${this.alias}</span></span
-            >`;const t=e?null:this.slPattern;if(t)return F`<span class="diamonds">${[...t].map(e=>"L"===e?F`<span class="diamond long">&#9670;</span>`:F`<span class="diamond short">&#9671;</span>`)}</span>`;const i=e?this.trigger.code:this.code,s=e?this.trigger.protocol:this.protocol;if("PRONTO"===s?.toUpperCase()&&i){const e=this._prontoSlArray(i);if(e)return F`<span class="diamonds">${e.map(e=>e?F`<span class="diamond long">&#9670;</span>`:F`<span class="diamond short">&#9671;</span>`)}</span>`}return F`<span class="proto">Trigger Event</span>`}render(){const e=!!this.trigger;return F`
+            >`;const t=e?null:this.slPattern;if(t)return B`<span class="diamonds">${[...t].map(e=>"L"===e?B`<span class="diamond long">&#9670;</span>`:B`<span class="diamond short">&#9671;</span>`)}</span>`;const i=e?this.trigger.code:this.code,s=e?this.trigger.protocol:this.protocol;if("PRONTO"===s?.toUpperCase()&&i){const e=this._prontoSlArray(i);if(e)return B`<span class="diamonds">${e.map(e=>e?B`<span class="diamond long">&#9670;</span>`:B`<span class="diamond short">&#9671;</span>`)}</span>`}return B`<span class="proto">Trigger Event</span>`}render(){const e=!!this.trigger;return B`
             <div class="overlay" @click=${this._close}>
                 <div class="dialog" @click=${e=>e.stopPropagation()}>
                     <h3 class="heading">
@@ -1161,10 +1325,24 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                         ?disabled=${this._busy}
                     />
 
-                    ${this._error?F`<p class="error">${this._error}</p>`:""}
+                    <!-- Receiver scope -->
+                    <div class="receiver-field">
+                        <ir-receiver-picker
+                            .api=${this.api}
+                            .value=${this._receiverIds}
+                            ?disabled=${this._busy}
+                            @receivers-changed=${e=>{this._receiverIds=e.detail.value}}
+                        ></ir-receiver-picker>
+                        <p class="field-hint scope-hint">
+                            Fires once per press, regardless of how many scoped
+                            receivers observe the signal.
+                        </p>
+                    </div>
+
+                    ${this._error?B`<p class="error">${this._error}</p>`:""}
 
                     <div class="actions">
-                        ${e?F`<button
+                        ${e?B`<button
                                   class="btn delete-btn"
                                   @click=${this._emitDelete}
                                   ?disabled=${this._busy}
@@ -1183,7 +1361,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     </div>
                 </div>
             </div>
-        `}};zi.styles=n`
+        `}};Vi.styles=r`
         .overlay {
             position: fixed;
             inset: 0;
@@ -1287,6 +1465,13 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
         .hits-input {
             width: 80px;
         }
+        .receiver-field {
+            margin-bottom: 14px;
+        }
+        .scope-hint {
+            margin: 6px 0 0;
+            margin-left: 0;
+        }
         .error {
             color: #e65100;
             font-size: 0.85rem;
@@ -1337,11 +1522,129 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
         .delete-btn:hover {
             background: rgba(230, 81, 0, 0.08);
         }
-    `,e([he({attribute:!1})],zi.prototype,"api",void 0),e([he()],zi.prototype,"signalFingerprint",void 0),e([he()],zi.prototype,"protocol",void 0),e([he()],zi.prototype,"code",void 0),e([he()],zi.prototype,"slPattern",void 0),e([he()],zi.prototype,"alias",void 0),e([he()],zi.prototype,"sourceDeviceId",void 0),e([he()],zi.prototype,"sourceCommandId",void 0),e([he({attribute:!1})],zi.prototype,"trigger",void 0),e([pe()],zi.prototype,"_name",void 0),e([pe()],zi.prototype,"_minHits",void 0),e([pe()],zi.prototype,"_busy",void 0),e([pe()],zi.prototype,"_error",void 0),zi=e([ue("ir-trigger-dialog")],zi);const Vi=[{value:"media_player",label:"Media Player"},{value:"ac",label:"Air Conditioner"},{value:"fan",label:"Fan"},{value:"light",label:"Light"},{value:"switch",label:"Switch"},{value:"screen",label:"Screen / Shade"},{value:"other",label:"Other"}];let Li=class extends re{constructor(){super(...arguments),this._busy=!1,this._captureName=null,this._toast=null,this._confirmDelete=!1,this._commandToDelete=null,this._editCommand=null,this._actionOptions=[],this._mappingCommandName=null,this._popoverTop=0,this._popoverLeft=0,this._dismissHandler=null,this._editingName=!1,this._draftName="",this._triggers=[],this._triggerCommand=null,this._triggerEdit=null,this._confirmDeleteTriggerId=null,this._sortable=null,this._pendingReorderTimeout=null,this._commandsListVersion=0}_emitterName(e){const t=this.hass?.states?.[e];return t?.attributes?.friendly_name??e}_deviceRegistryName(e){const t=this.hass?.devices?.[e];return t?.name_by_user??t?.name??e}_deviceConfigEntryId(e){const t=this.hass?.devices?.[e];return t?(t.config_entries??[])[0]??null:null}_configEntryDomain(e){const t=this.hass?.config_entries?.entries?.[e];return t?.domain??null}_integrationUrl(e){if(!e)return null;const t=this._configEntryDomain(e);return t?`/config/integrations/integration/${t}`:null}_entityIntegrationUrl(e){const t=e.split(".")[0],i=this.hass?.entities?.[e];return i?.config_entry_id?this._integrationUrl(i.config_entry_id):i?.platform?`/config/integrations/integration/${i.platform}`:`/config/integrations/integration/${t}`}async _refresh(){this.device=await this.api.getDevice(this.device.id),this.dispatchEvent(new CustomEvent("device-changed",{bubbles:!0,composed:!0}))}_flash(e){this._toast=e,setTimeout(()=>{this._toast=null},2400)}_startEditName(){this._draftName=this.device.name,this._editingName=!0,this.updateComplete.then(()=>{const e=this.shadowRoot?.querySelector(".name-input");e?.focus(),e?.select()})}async _saveName(){const e=this._draftName.trim();if(e&&e!==this.device.name){this._busy=!0;try{this.device=await this.api.updateDevice(this.device.id,{name:e}),this._flash("Name updated"),this.dispatchEvent(new CustomEvent("device-changed",{bubbles:!0,composed:!0}))}catch(e){this._flash(`Update failed: ${e.message}`)}finally{this._busy=!1,this._editingName=!1}}else this._editingName=!1}_onNameKeyDown(e){"Enter"===e.key?(e.preventDefault(),this._saveName()):"Escape"===e.key&&(this._editingName=!1)}async _onTypeChanged(e){const t=e.target.value;if(t!==this.device.device_type){this._busy=!0;try{this.device=await this.api.updateDevice(this.device.id,{device_type:t}),this._flash("Device type updated"),this.dispatchEvent(new CustomEvent("device-changed",{bubbles:!0,composed:!0}))}catch(e){this._flash(`Update failed: ${e.message}`)}finally{this._busy=!1}}}async _onEmittersChanged(e){const t=e.detail.value,i=[...this.device.emitter_entity_ids];this.device={...this.device,emitter_entity_ids:t},this._busy=!0;try{this.device=await this.api.updateDevice(this.device.id,{emitter_entity_ids:t}),this._flash("Emitters updated"),this.dispatchEvent(new CustomEvent("device-changed",{bubbles:!0,composed:!0}))}catch(e){this.device={...this.device,emitter_entity_ids:i},this._flash(`Update failed: ${e.message}`)}finally{this._busy=!1}}connectedCallback(){super.connectedCallback(),this._loadActionOptions(),this._loadTriggers()}updated(e){e.has("device")&&(this._loadActionOptions(),this._loadTriggers()),e.has("_commandsListVersion")&&!this._sortable&&this._attachSortable()}async _loadActionOptions(){try{this._actionOptions=await this.api.getActionOptions(this.device.device_type)}catch{this._actionOptions=[]}}async _loadTriggers(){try{this._triggers=await this.api.listTriggers()}catch{this._triggers=[]}}_commandHasTrigger(e){return this._triggers.some(t=>t.source_command_id===e.id)}_onToggleTrigger(e){const t=e.detail?.command;if(!t)return;const i=this._triggers.find(e=>e.source_command_id===t.id);i?this._triggerEdit=i:this._triggerCommand=t}_closeTriggerDialog(){this._triggerCommand=null,this._triggerEdit=null}async _onTriggerSaved(){this._triggerCommand=null,this._triggerEdit=null,await this._loadTriggers(),this.dispatchEvent(new CustomEvent("trigger-changed",{bubbles:!0,composed:!0}))}_requestDeleteTrigger(e){this._confirmDeleteTriggerId=e}async _doDeleteTrigger(){if(!this._confirmDeleteTriggerId)return;const e=this._confirmDeleteTriggerId;this._confirmDeleteTriggerId=null,this._triggerEdit=null;try{await this.api.deleteTrigger(e),await this._loadTriggers(),this.dispatchEvent(new CustomEvent("trigger-changed",{bubbles:!0,composed:!0}))}catch{}}_getActionLabel(e){const t=this.device.entity_config?.command_mapping??{};for(const[i,s]of Object.entries(t))if(s.toLowerCase()===e.toLowerCase()){const e=this._actionOptions.find(e=>e.key===i);return e?.label??i}return null}_onMapAction(e){const{command:t}=e.detail;if(!t)return;const i=e.target.shadowRoot?.querySelector(".badge-btn");if(i){const e=i.getBoundingClientRect();this._popoverTop=e.bottom+4,this._popoverLeft=Math.max(8,e.right-220)}this._mappingCommandName=t.name,requestAnimationFrame(()=>{this._dismissHandler=e=>{const t=e.composedPath(),i=this.shadowRoot?.querySelector(".action-popover");i&&!t.includes(i)&&this._closePopover()},document.addEventListener("click",this._dismissHandler,!0)})}_closePopover(){this._mappingCommandName=null,this._dismissHandler&&(document.removeEventListener("click",this._dismissHandler,!0),this._dismissHandler=null)}disconnectedCallback(){super.disconnectedCallback(),this._dismissHandler&&(document.removeEventListener("click",this._dismissHandler,!0),this._dismissHandler=null),this._sortable?.destroy(),this._sortable=null,this._cancelPendingReorderSave()}firstUpdated(){this._attachSortable()}_attachSortable(){if(this._sortable)return;const e=this.renderRoot.querySelector(".commands-list");e&&(this._sortable=di.create(e,{handle:".grip-handle",animation:150,ghostClass:"sortable-ghost",onEnd:e=>{const t=e.oldIndex,i=e.newIndex;if(void 0===t||void 0===i||t===i)return;const s=[...this.device.commands],[a]=s.splice(t,1);s.splice(i,0,a),this.device={...this.device,commands:s},this.dispatchEvent(new CustomEvent("commands-reordered",{detail:{commands:s},bubbles:!0,composed:!0})),this._sortable?.destroy(),this._sortable=null;const o=this.renderRoot.querySelector(".commands-list");if(o)for(const e of Array.from(o.querySelectorAll("ir-command-row")))e.remove();this._commandsListVersion++,this._scheduleReorderSave(s.map(e=>e.id))}}))}_scheduleReorderSave(e){this._cancelPendingReorderSave(),this._pendingReorderTimeout=window.setTimeout(async()=>{this._pendingReorderTimeout=null;try{await this.api.reorderCommands(this.device.id,e)}catch(e){this._flash(`Reorder failed: ${e.message}`),await this._refresh()}},500)}_cancelPendingReorderSave(){null!==this._pendingReorderTimeout&&(clearTimeout(this._pendingReorderTimeout),this._pendingReorderTimeout=null)}_getCommandForAction(e){return(this.device.entity_config?.command_mapping??{})[e]??null}async _selectAction(e,t){this._closePopover(),this._busy=!0;try{const i=await this.api.updateMapping(this.device.id,e,t);this.device={...this.device,entity_config:{...this.device.entity_config,command_mapping:i.mapping}},this._flash(t?`Mapped to ${t}`:"Mapping cleared"),this.dispatchEvent(new CustomEvent("device-changed",{bubbles:!0,composed:!0}))}catch(e){this._flash(`Mapping failed: ${e.message}`)}finally{this._busy=!1}}_getCurrentActionKey(e){const t=this.device.entity_config?.command_mapping??{};for(const[i,s]of Object.entries(t))if(s.toLowerCase()===e.toLowerCase())return i;return""}async _onTest(e){const{command:t}=e.detail;if(t){this._busy=!0;try{await this.api.sendCommand(this.device.id,t.id),this._flash(`Sent "${t.name}"`)}catch(e){this._flash(`Send failed: ${e.message}`)}finally{this._busy=!1}}}async _onToggleTxRaw(e){const{command:t}=e.detail;if(!t)return;const i=!t.tx_force_raw;this._busy=!0;try{await this.api.setCommandTxForceRaw(this.device.id,t.id,i),t.tx_force_raw=i,this.requestUpdate(),this._flash(i?`"${t.name}" will transmit the captured timings`:`"${t.name}" will transmit clean decoded timings`)}catch(e){this._flash(`Update failed: ${e.message}`)}finally{this._busy=!1}}_onDelete(e){const{command:t}=e.detail;t&&(this._commandToDelete=t)}_onEditCommand(e){const{command:t}=e.detail;t&&(this._editCommand=t)}async _onCommandEdited(e){const t=e.detail;this._editCommand=null,await this._refresh();const i=t.triggers?.rewired??[];if(i.length){const e=i.map(e=>`"${e}"`).join(", ");this._flash(`Command updated. Re-pointed trigger ${e}.`)}else this._flash("Command updated");this.dispatchEvent(new CustomEvent("trigger-changed",{bubbles:!0,composed:!0}))}async _onRenameCommand(e){const{command:t,name:i}=e.detail;this._busy=!0;try{const e=await this.api.updateCommand({device_id:this.device.id,command_id:t.id,name:i});await this._refresh();const s=e.mappings_updated;this._flash(s>0?`Renamed (updated ${s} action mapping${1===s?"":"s"})`:"Renamed"),this.dispatchEvent(new CustomEvent("device-changed",{bubbles:!0,composed:!0}))}catch(e){this._flash(`Rename failed: ${e.message}`)}finally{this._busy=!1}}async _confirmCommandDelete(){const e=this._commandToDelete;if(e){this._commandToDelete=null,this._cancelPendingReorderSave(),this._busy=!0;try{await this.api.deleteCommand(this.device.id,e.id),await this._refresh(),this._flash(`Removed "${e.name}"`)}catch(e){this._flash(`Delete failed: ${e.message}`)}finally{this._busy=!1}}}_onCaptureClosed(){this._captureName=null}async _onCommandSaved(e){const{commandName:t}=e.detail;this._cancelPendingReorderSave(),await this._refresh(),this._flash(`Saved "${t}"`),this._captureName=null}_goToSniffer(){this.dispatchEvent(new CustomEvent("navigate-sniffer",{bubbles:!0,composed:!0}))}_goToClips(){this.dispatchEvent(new CustomEvent("navigate-clips",{bubbles:!0,composed:!0}))}async _deleteDevice(){this._busy=!0;try{await this.api.deleteDevice(this.device.id),this.dispatchEvent(new CustomEvent("device-deleted",{bubbles:!0,composed:!0}))}catch(e){this._flash(`Delete failed: ${e.message}`)}finally{this._busy=!1,this._confirmDelete=!1}}_navigateIntegration(e){e&&(window.history.pushState(null,"",e),window.dispatchEvent(new PopStateEvent("popstate")))}render(){const e=this.device.commands,t=e.length;return F`
+    `,e([he({attribute:!1})],Vi.prototype,"api",void 0),e([he()],Vi.prototype,"signalFingerprint",void 0),e([he()],Vi.prototype,"protocol",void 0),e([he()],Vi.prototype,"code",void 0),e([he()],Vi.prototype,"slPattern",void 0),e([he()],Vi.prototype,"alias",void 0),e([he()],Vi.prototype,"sourceDeviceId",void 0),e([he()],Vi.prototype,"sourceCommandId",void 0),e([he({attribute:!1})],Vi.prototype,"trigger",void 0),e([pe()],Vi.prototype,"_name",void 0),e([pe()],Vi.prototype,"_minHits",void 0),e([pe()],Vi.prototype,"_receiverIds",void 0),e([pe()],Vi.prototype,"_busy",void 0),e([pe()],Vi.prototype,"_error",void 0),Vi=e([ue("ir-trigger-dialog")],Vi);const Oi=r`
+    .action-popover {
+        position: fixed;
+        z-index: 50;
+        min-width: 200px;
+        max-width: 280px;
+        background: var(--card-background-color, #1c1c1c);
+        border: 1px solid var(--divider-color);
+        border-radius: 6px;
+        box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+        padding: 4px 0;
+        overflow: auto;
+        max-height: 320px;
+    }
+    .popover-header {
+        font-size: 0.7rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--secondary-text-color);
+        padding: 6px 12px 4px;
+    }
+    .popover-item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        width: 100%;
+        padding: 7px 12px;
+        background: none;
+        border: none;
+        color: var(--primary-text-color);
+        font-size: 0.82rem;
+        font-family: inherit;
+        cursor: pointer;
+        text-align: left;
+        transition: background 100ms ease;
+    }
+    .popover-item:hover {
+        background: var(--secondary-background-color);
+    }
+    .popover-item.active {
+        color: var(--primary-color);
+        font-weight: 500;
+    }
+    .popover-item.clear {
+        color: var(--secondary-text-color);
+        font-style: italic;
+        border-bottom: 1px solid var(--divider-color);
+        margin-bottom: 2px;
+    }
+    .popover-check {
+        color: var(--primary-color);
+        font-size: 0.9rem;
+    }
+    .popover-existing {
+        font-size: 0.72rem;
+        color: var(--secondary-text-color);
+        font-style: italic;
+        margin-left: 8px;
+        flex-shrink: 0;
+    }
+    /* Trigger-popover extras (v0.5.7) */
+    .popover-item.accent {
+        color: var(--primary-color);
+        font-weight: 500;
+    }
+    .popover-divider {
+        height: 1px;
+        background: var(--divider-color);
+        margin: 2px 0;
+    }
+    .popover-row {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 2px;
+        min-width: 0;
+    }
+    .popover-name {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 240px;
+    }
+    .popover-scope {
+        font-size: 0.7rem;
+        color: var(--secondary-text-color);
+    }
+`;let Ui=class extends ne{constructor(){super(...arguments),this.triggers=[],this.receivers=[],this.top=0,this.left=0}render(){return B`
+            <div
+                class="action-popover"
+                style="top:${this.top}px; left:${this.left}px"
+            >
+                <div class="popover-header">Triggers</div>
+                <button
+                    class="popover-item accent"
+                    @click=${()=>this._emit("create-new")}
+                >
+                    <span>+ new trigger</span>
+                </button>
+                <div class="popover-divider"></div>
+                ${this.triggers.map(e=>B`
+                        <button
+                            class="popover-item"
+                            @click=${()=>this._emit("edit-trigger",e)}
+                        >
+                            <span class="popover-row">
+                                <span class="popover-name">${e.name}</span>
+                                <span class="popover-scope"
+                                    >${this._renderScope(e)}</span
+                                >
+                            </span>
+                        </button>
+                    `)}
+            </div>
+        `}_renderScope(e){const t=e.receiver_entity_ids??[];return 0===t.length?"Any receiver":1===t.length?this._friendly(t[0]):`${this._friendly(t[0])} + ${t.length-1} more`}_friendly(e){const t=this.receivers.find(t=>t.entity_id===e);return t?.name??e}_emit(e,t){this.dispatchEvent(new CustomEvent(e,{detail:t,bubbles:!0,composed:!0}))}};Ui.styles=[Oi,r`
+            :host {
+                display: contents;
+            }
+        `],e([he({attribute:!1})],Ui.prototype,"triggers",void 0),e([he({attribute:!1})],Ui.prototype,"receivers",void 0),e([he({type:Number})],Ui.prototype,"top",void 0),e([he({type:Number})],Ui.prototype,"left",void 0),Ui=e([ue("ir-trigger-popover")],Ui);const Fi=[{value:"media_player",label:"Media Player"},{value:"ac",label:"Air Conditioner"},{value:"fan",label:"Fan"},{value:"light",label:"Light"},{value:"switch",label:"Switch"},{value:"screen",label:"Screen / Shade"},{value:"other",label:"Other"}];let Bi=class extends ne{constructor(){super(...arguments),this._busy=!1,this._captureName=null,this._toast=null,this._confirmDelete=!1,this._commandToDelete=null,this._editCommand=null,this._actionOptions=[],this._mappingCommandName=null,this._popoverTop=0,this._popoverLeft=0,this._dismissHandler=null,this._editingName=!1,this._draftName="",this._triggers=[],this._triggerCommand=null,this._triggerEdit=null,this._confirmDeleteTriggerId=null,this._triggerPopover=null,this._receivers=[],this._sortable=null,this._pendingReorderTimeout=null,this._commandsListVersion=0,this._onDocClickForTriggerPopover=e=>{const t=this.shadowRoot?.querySelector("ir-trigger-popover");t&&e.composedPath().includes(t)||this._closeTriggerPopover()},this._onScrollForTriggerPopover=()=>{this._closeTriggerPopover()}}_emitterName(e){const t=this.hass?.states?.[e];return t?.attributes?.friendly_name??e}_deviceRegistryName(e){const t=this.hass?.devices?.[e];return t?.name_by_user??t?.name??e}_deviceConfigEntryId(e){const t=this.hass?.devices?.[e];return t?(t.config_entries??[])[0]??null:null}_configEntryDomain(e){const t=this.hass?.config_entries?.entries?.[e];return t?.domain??null}_integrationUrl(e){if(!e)return null;const t=this._configEntryDomain(e);return t?`/config/integrations/integration/${t}`:null}_entityIntegrationUrl(e){const t=e.split(".")[0],i=this.hass?.entities?.[e];return i?.config_entry_id?this._integrationUrl(i.config_entry_id):i?.platform?`/config/integrations/integration/${i.platform}`:`/config/integrations/integration/${t}`}async _refresh(){this.device=await this.api.getDevice(this.device.id),this.dispatchEvent(new CustomEvent("device-changed",{bubbles:!0,composed:!0}))}_flash(e){this._toast=e,setTimeout(()=>{this._toast=null},2400)}_startEditName(){this._draftName=this.device.name,this._editingName=!0,this.updateComplete.then(()=>{const e=this.shadowRoot?.querySelector(".name-input");e?.focus(),e?.select()})}async _saveName(){const e=this._draftName.trim();if(e&&e!==this.device.name){this._busy=!0;try{this.device=await this.api.updateDevice(this.device.id,{name:e}),this._flash("Name updated"),this.dispatchEvent(new CustomEvent("device-changed",{bubbles:!0,composed:!0}))}catch(e){this._flash(`Update failed: ${e.message}`)}finally{this._busy=!1,this._editingName=!1}}else this._editingName=!1}_onNameKeyDown(e){"Enter"===e.key?(e.preventDefault(),this._saveName()):"Escape"===e.key&&(this._editingName=!1)}async _onTypeChanged(e){const t=e.target.value;if(t!==this.device.device_type){this._busy=!0;try{this.device=await this.api.updateDevice(this.device.id,{device_type:t}),this._flash("Device type updated"),this.dispatchEvent(new CustomEvent("device-changed",{bubbles:!0,composed:!0}))}catch(e){this._flash(`Update failed: ${e.message}`)}finally{this._busy=!1}}}async _onEmittersChanged(e){const t=e.detail.value,i=[...this.device.emitter_entity_ids];this.device={...this.device,emitter_entity_ids:t},this._busy=!0;try{this.device=await this.api.updateDevice(this.device.id,{emitter_entity_ids:t}),this._flash("Emitters updated"),this.dispatchEvent(new CustomEvent("device-changed",{bubbles:!0,composed:!0}))}catch(e){this.device={...this.device,emitter_entity_ids:i},this._flash(`Update failed: ${e.message}`)}finally{this._busy=!1}}connectedCallback(){super.connectedCallback(),this._loadActionOptions(),this._loadTriggers(),this.api.listReceivers().then(e=>{this._receivers=e}).catch(()=>{this._receivers=[]})}updated(e){e.has("device")&&(this._loadActionOptions(),this._loadTriggers()),e.has("_commandsListVersion")&&!this._sortable&&this._attachSortable()}async _loadActionOptions(){try{this._actionOptions=await this.api.getActionOptions(this.device.device_type)}catch{this._actionOptions=[]}}async _loadTriggers(){try{this._triggers=await this.api.listTriggers()}catch{this._triggers=[]}}_commandHasTrigger(e){return this._triggers.some(t=>t.source_command_id===e.id)}_commandTriggerCount(e){return this._triggers.filter(t=>t.source_command_id===e.id).length}_onToggleTrigger(e){const t=e.detail?.command;if(!t)return;const i=this._triggers.filter(e=>e.source_command_id===t.id);if(0===i.length)return void(this._triggerCommand=t);const s=e.detail?.buttonRect;this._triggerPopover={command:t,top:s?s.bottom+4:120,left:s?Math.max(8,s.right-220):120},this._installTriggerPopoverDismiss()}_triggersForCommand(e){return this._triggers.filter(t=>t.source_command_id===e.id)}_closeTriggerPopover(){this._triggerPopover=null,this._removeTriggerPopoverDismiss()}_onTriggerPopoverCreateNew(){const e=this._triggerPopover;this._closeTriggerPopover(),e&&(this._triggerCommand=e.command)}_onTriggerPopoverEdit(e){const t=e.detail;this._closeTriggerPopover(),t&&(this._triggerEdit=t)}_installTriggerPopoverDismiss(){setTimeout(()=>{document.addEventListener("click",this._onDocClickForTriggerPopover,!0),window.addEventListener("scroll",this._onScrollForTriggerPopover,!0)},0)}_removeTriggerPopoverDismiss(){document.removeEventListener("click",this._onDocClickForTriggerPopover,!0),window.removeEventListener("scroll",this._onScrollForTriggerPopover,!0)}_closeTriggerDialog(){this._triggerCommand=null,this._triggerEdit=null}async _onTriggerSaved(){this._triggerCommand=null,this._triggerEdit=null,await this._loadTriggers(),this.dispatchEvent(new CustomEvent("trigger-changed",{bubbles:!0,composed:!0}))}_requestDeleteTrigger(e){this._confirmDeleteTriggerId=e}async _doDeleteTrigger(){if(!this._confirmDeleteTriggerId)return;const e=this._confirmDeleteTriggerId;this._confirmDeleteTriggerId=null,this._triggerEdit=null;try{await this.api.deleteTrigger(e),await this._loadTriggers(),this.dispatchEvent(new CustomEvent("trigger-changed",{bubbles:!0,composed:!0}))}catch{}}_getActionLabel(e){const t=this.device.entity_config?.command_mapping??{};for(const[i,s]of Object.entries(t))if(s.toLowerCase()===e.toLowerCase()){const e=this._actionOptions.find(e=>e.key===i);return e?.label??i}return null}_onMapAction(e){const{command:t}=e.detail;if(!t)return;const i=e.target.shadowRoot?.querySelector(".badge-btn");if(i){const e=i.getBoundingClientRect();this._popoverTop=e.bottom+4,this._popoverLeft=Math.max(8,e.right-220)}this._mappingCommandName=t.name,requestAnimationFrame(()=>{this._dismissHandler=e=>{const t=e.composedPath(),i=this.shadowRoot?.querySelector(".action-popover");i&&!t.includes(i)&&this._closePopover()},document.addEventListener("click",this._dismissHandler,!0)})}_closePopover(){this._mappingCommandName=null,this._dismissHandler&&(document.removeEventListener("click",this._dismissHandler,!0),this._dismissHandler=null)}disconnectedCallback(){super.disconnectedCallback(),this._dismissHandler&&(document.removeEventListener("click",this._dismissHandler,!0),this._dismissHandler=null),this._removeTriggerPopoverDismiss(),this._sortable?.destroy(),this._sortable=null,this._cancelPendingReorderSave()}firstUpdated(){this._attachSortable()}_attachSortable(){if(this._sortable)return;const e=this.renderRoot.querySelector(".commands-list");e&&(this._sortable=di.create(e,{handle:".grip-handle",animation:150,ghostClass:"sortable-ghost",onEnd:e=>{const t=e.oldIndex,i=e.newIndex;if(void 0===t||void 0===i||t===i)return;const s=[...this.device.commands],[o]=s.splice(t,1);s.splice(i,0,o),this.device={...this.device,commands:s},this.dispatchEvent(new CustomEvent("commands-reordered",{detail:{commands:s},bubbles:!0,composed:!0})),this._sortable?.destroy(),this._sortable=null;const a=this.renderRoot.querySelector(".commands-list");if(a)for(const e of Array.from(a.querySelectorAll("ir-command-row")))e.remove();this._commandsListVersion++,this._scheduleReorderSave(s.map(e=>e.id))}}))}_scheduleReorderSave(e){this._cancelPendingReorderSave(),this._pendingReorderTimeout=window.setTimeout(async()=>{this._pendingReorderTimeout=null;try{await this.api.reorderCommands(this.device.id,e)}catch(e){this._flash(`Reorder failed: ${e.message}`),await this._refresh()}},500)}_cancelPendingReorderSave(){null!==this._pendingReorderTimeout&&(clearTimeout(this._pendingReorderTimeout),this._pendingReorderTimeout=null)}_getCommandForAction(e){return(this.device.entity_config?.command_mapping??{})[e]??null}async _selectAction(e,t){this._closePopover(),this._busy=!0;try{const i=await this.api.updateMapping(this.device.id,e,t);this.device={...this.device,entity_config:{...this.device.entity_config,command_mapping:i.mapping}},this._flash(t?`Mapped to ${t}`:"Mapping cleared"),this.dispatchEvent(new CustomEvent("device-changed",{bubbles:!0,composed:!0}))}catch(e){this._flash(`Mapping failed: ${e.message}`)}finally{this._busy=!1}}_getCurrentActionKey(e){const t=this.device.entity_config?.command_mapping??{};for(const[i,s]of Object.entries(t))if(s.toLowerCase()===e.toLowerCase())return i;return""}async _onTest(e){const{command:t}=e.detail;if(t){this._busy=!0;try{await this.api.sendCommand(this.device.id,t.id),this._flash(`Sent "${t.name}"`)}catch(e){this._flash(`Send failed: ${e.message}`)}finally{this._busy=!1}}}async _onToggleTxRaw(e){const{command:t}=e.detail;if(!t)return;const i=!t.tx_force_raw;this._busy=!0;try{await this.api.setCommandTxForceRaw(this.device.id,t.id,i),t.tx_force_raw=i,this.requestUpdate(),this._flash(i?`"${t.name}" will transmit the captured timings`:`"${t.name}" will transmit clean decoded timings`)}catch(e){this._flash(`Update failed: ${e.message}`)}finally{this._busy=!1}}_onDelete(e){const{command:t}=e.detail;t&&(this._commandToDelete=t)}_onEditCommand(e){const{command:t}=e.detail;t&&(this._editCommand=t)}async _onCommandEdited(e){const t=e.detail;this._editCommand=null,await this._refresh();const i=t.triggers?.rewired??[];if(i.length){const e=i.map(e=>`"${e}"`).join(", ");this._flash(`Command updated. Re-pointed trigger ${e}.`)}else this._flash("Command updated");this.dispatchEvent(new CustomEvent("trigger-changed",{bubbles:!0,composed:!0}))}async _onRenameCommand(e){const{command:t,name:i}=e.detail;this._busy=!0;try{const e=await this.api.updateCommand({device_id:this.device.id,command_id:t.id,name:i});await this._refresh();const s=e.mappings_updated;this._flash(s>0?`Renamed (updated ${s} action mapping${1===s?"":"s"})`:"Renamed"),this.dispatchEvent(new CustomEvent("device-changed",{bubbles:!0,composed:!0}))}catch(e){this._flash(`Rename failed: ${e.message}`)}finally{this._busy=!1}}async _confirmCommandDelete(){const e=this._commandToDelete;if(e){this._commandToDelete=null,this._cancelPendingReorderSave(),this._busy=!0;try{await this.api.deleteCommand(this.device.id,e.id),await this._refresh(),this._flash(`Removed "${e.name}"`)}catch(e){this._flash(`Delete failed: ${e.message}`)}finally{this._busy=!1}}}_onCaptureClosed(){this._captureName=null}async _onCommandSaved(e){const{commandName:t}=e.detail;this._cancelPendingReorderSave(),await this._refresh(),this._flash(`Saved "${t}"`),this._captureName=null}_goToSniffer(){this.dispatchEvent(new CustomEvent("navigate-sniffer",{bubbles:!0,composed:!0}))}_goToClips(){this.dispatchEvent(new CustomEvent("navigate-clips",{bubbles:!0,composed:!0}))}async _deleteDevice(){this._busy=!0;try{await this.api.deleteDevice(this.device.id),this.dispatchEvent(new CustomEvent("device-deleted",{bubbles:!0,composed:!0}))}catch(e){this._flash(`Delete failed: ${e.message}`)}finally{this._busy=!1,this._confirmDelete=!1}}_navigateIntegration(e){e&&(window.history.pushState(null,"",e),window.dispatchEvent(new PopStateEvent("popstate")))}render(){const e=this.device.commands,t=e.length;return B`
             <!-- Header: editable name + delete -->
             <section class="header">
                 <div class="header-left">
-                    ${this._editingName?F`
+                    ${this._editingName?B`
                               <input
                                   class="name-input"
                                   type="text"
@@ -1351,7 +1654,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                   @keydown=${this._onNameKeyDown}
                                   ?disabled=${this._busy}
                               />
-                          `:F`
+                          `:B`
                               <h1
                                   class="editable-name"
                                   @click=${this._startEditName}
@@ -1378,7 +1681,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                         @change=${this._onTypeChanged}
                         ?disabled=${this._busy}
                     >
-                        ${Vi.map(e=>F`
+                        ${Fi.map(e=>B`
                                 <option
                                     value=${e.value}
                                     ?selected=${this.device.device_type===e.value}
@@ -1406,7 +1709,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     <span>Commands (${t})</span>
                 </div>
                 <div class="commands-list">
-                    ${Se(this._commandsListVersion,e.length>0?Te(e,e=>e.id,e=>F`
+                    ${Se(this._commandsListVersion,e.length>0?Te(e,e=>e.id,e=>B`
                                       <ir-command-row
                                           data-id=${e.id}
                                           .templateName=${e.name}
@@ -1414,6 +1717,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                           .busy=${this._busy}
                                           .actionLabel=${this._getActionLabel(e.name)}
                                           .hasTrigger=${this._commandHasTrigger(e)}
+                                          .triggerCount=${this._commandTriggerCount(e)}
                                           .showActionMapping=${"other"!==this.device.device_type}
                                           @map-action=${this._onMapAction}
                                           @test=${this._onTest}
@@ -1430,15 +1734,15 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                               title="Drag to reorder"
                                           ></ha-svg-icon>
                                       </ir-command-row>
-                                  `):F`<div class="empty">No commands yet. Add one below.</div>`)}
+                                  `):B`<div class="empty">No commands yet. Add one below.</div>`)}
 
-                    ${this._mappingCommandName?F`
+                    ${this._mappingCommandName?B`
                               <div
                                   class="action-popover"
                                   style="top:${this._popoverTop}px; left:${this._popoverLeft}px"
                               >
                                   <div class="popover-header">Map action</div>
-                                  ${this._getCurrentActionKey(this._mappingCommandName)?F`
+                                  ${this._getCurrentActionKey(this._mappingCommandName)?B`
                                             <button
                                                 class="popover-item clear"
                                                 @click=${()=>this._selectAction(this._mappingCommandName,null)}
@@ -1446,13 +1750,13 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                                 <span class="popover-label">None (clear)</span>
                                             </button>
                                         `:""}
-                                  ${this._actionOptions.map(e=>{const t=this._getCurrentActionKey(this._mappingCommandName)===e.key,i=this._getCommandForAction(e.key),s=i&&i.toLowerCase()!==this._mappingCommandName.toLowerCase();return F`
+                                  ${this._actionOptions.map(e=>{const t=this._getCurrentActionKey(this._mappingCommandName)===e.key,i=this._getCommandForAction(e.key),s=i&&i.toLowerCase()!==this._mappingCommandName.toLowerCase();return B`
                                           <button
                                               class="popover-item ${t?"active":""}"
                                               @click=${()=>this._selectAction(this._mappingCommandName,e.key)}
                                           >
                                               <span class="popover-label">${e.label}</span>
-                                              ${t?F`<span class="popover-check">&#10003;</span>`:s?F`<span class="popover-existing">${i}</span>`:""}
+                                              ${t?B`<span class="popover-check">&#10003;</span>`:s?B`<span class="popover-existing">${i}</span>`:""}
                                           </button>
                                       `})}
                               </div>
@@ -1483,7 +1787,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
             </div>
 
             <!-- Dialogs -->
-            ${this._captureName?F`
+            ${this._captureName?B`
                       <ir-capture-dialog
                           .api=${this.api}
                           .hass=${this.hass}
@@ -1493,7 +1797,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                           @command-saved=${this._onCommandSaved}
                       ></ir-capture-dialog>
                   `:""}
-            ${this._confirmDelete?F`
+            ${this._confirmDelete?B`
                       <ir-confirm-dialog
                           title="Delete ${this.device.name}?"
                           message="This removes all captured commands and the auto-created entity. The action cannot be undone."
@@ -1503,7 +1807,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                           @closed=${()=>this._confirmDelete=!1}
                       ></ir-confirm-dialog>
                   `:""}
-            ${this._commandToDelete?F`
+            ${this._commandToDelete?B`
                       <ir-confirm-dialog
                           title="Delete command?"
                           message="Remove &quot;${this._commandToDelete.name}&quot;? This cannot be undone."
@@ -1513,7 +1817,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                           @closed=${()=>this._commandToDelete=null}
                       ></ir-confirm-dialog>
                   `:""}
-            ${this._editCommand?F`
+            ${this._editCommand?B`
                       <ir-signal-editor
                           .api=${this.api}
                           .deviceId=${this.device.id}
@@ -1529,7 +1833,17 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                           @closed=${()=>this._editCommand=null}
                       ></ir-signal-editor>
                   `:""}
-            ${this._triggerCommand?F`
+            ${this._triggerPopover?B`
+                      <ir-trigger-popover
+                          .triggers=${this._triggersForCommand(this._triggerPopover.command)}
+                          .receivers=${this._receivers}
+                          .top=${this._triggerPopover.top}
+                          .left=${this._triggerPopover.left}
+                          @create-new=${this._onTriggerPopoverCreateNew}
+                          @edit-trigger=${this._onTriggerPopoverEdit}
+                      ></ir-trigger-popover>
+                  `:""}
+            ${this._triggerCommand?B`
                       <ir-trigger-dialog
                           .api=${this.api}
                           .protocol=${this._triggerCommand.protocol}
@@ -1540,7 +1854,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                           @closed=${this._closeTriggerDialog}
                       ></ir-trigger-dialog>
                   `:""}
-            ${this._triggerEdit?F`
+            ${this._triggerEdit?B`
                       <ir-trigger-dialog
                           .api=${this.api}
                           .trigger=${this._triggerEdit}
@@ -1549,7 +1863,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                           @trigger-delete=${e=>this._requestDeleteTrigger(e.detail.triggerId)}
                       ></ir-trigger-dialog>
                   `:""}
-            ${this._confirmDeleteTriggerId?F`
+            ${this._confirmDeleteTriggerId?B`
                       <ir-confirm-dialog
                           title="Delete Trigger"
                           message="Remove this trigger? The associated HA event entity will also be removed."
@@ -1559,8 +1873,8 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                           @closed=${()=>this._confirmDeleteTriggerId=null}
                       ></ir-confirm-dialog>
                   `:""}
-            ${this._toast?F`<div class="toast" role="status">${this._toast}</div>`:""}
-        `}};Li.styles=n`
+            ${this._toast?B`<div class="toast" role="status">${this._toast}</div>`:""}
+        `}};Bi.styles=[Oi,r`
         :host {
             display: block;
         }
@@ -1723,66 +2037,9 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
         ir-command-row.sortable-ghost {
             opacity: 0.4;
         }
-        /* --- Action popover --- */
-        .action-popover {
-            position: fixed;
-            z-index: 50;
-            min-width: 200px;
-            max-width: 280px;
-            background: var(--card-background-color, #1c1c1c);
-            border: 1px solid var(--divider-color);
-            border-radius: 6px;
-            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
-            padding: 4px 0;
-            overflow: auto;
-            max-height: 320px;
-        }
-        .popover-header {
-            font-size: 0.7rem;
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
-            color: var(--secondary-text-color);
-            padding: 6px 12px 4px;
-        }
-        .popover-item {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            width: 100%;
-            padding: 7px 12px;
-            background: none;
-            border: none;
-            color: var(--primary-text-color);
-            font-size: 0.82rem;
-            font-family: inherit;
-            cursor: pointer;
-            text-align: left;
-            transition: background 100ms ease;
-        }
-        .popover-item:hover {
-            background: var(--secondary-background-color);
-        }
-        .popover-item.active {
-            color: var(--primary-color);
-            font-weight: 500;
-        }
-        .popover-item.clear {
-            color: var(--secondary-text-color);
-            font-style: italic;
-            border-bottom: 1px solid var(--divider-color);
-            margin-bottom: 2px;
-        }
-        .popover-check {
-            color: var(--primary-color);
-            font-size: 0.9rem;
-        }
-        .popover-existing {
-            font-size: 0.72rem;
-            color: var(--secondary-text-color);
-            font-style: italic;
-            margin-left: 8px;
-            flex-shrink: 0;
-        }
+        /* Action-popover styles live in the shared ir-popover-styles module
+           (spread into static styles below) so ir-trigger-popover reuses the
+           exact same treatment. */
         .empty {
             color: var(--secondary-text-color);
             font-style: italic;
@@ -1820,14 +2077,14 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
             box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
             z-index: 100;
         }
-    `,e([he({attribute:!1})],Li.prototype,"api",void 0),e([he({attribute:!1})],Li.prototype,"hass",void 0),e([he({attribute:!1})],Li.prototype,"device",void 0),e([pe()],Li.prototype,"_busy",void 0),e([pe()],Li.prototype,"_captureName",void 0),e([pe()],Li.prototype,"_toast",void 0),e([pe()],Li.prototype,"_confirmDelete",void 0),e([pe()],Li.prototype,"_commandToDelete",void 0),e([pe()],Li.prototype,"_editCommand",void 0),e([pe()],Li.prototype,"_actionOptions",void 0),e([pe()],Li.prototype,"_mappingCommandName",void 0),e([pe()],Li.prototype,"_popoverTop",void 0),e([pe()],Li.prototype,"_popoverLeft",void 0),e([pe()],Li.prototype,"_editingName",void 0),e([pe()],Li.prototype,"_draftName",void 0),e([pe()],Li.prototype,"_triggers",void 0),e([pe()],Li.prototype,"_triggerCommand",void 0),e([pe()],Li.prototype,"_triggerEdit",void 0),e([pe()],Li.prototype,"_confirmDeleteTriggerId",void 0),e([pe()],Li.prototype,"_commandsListVersion",void 0),Li=e([ue("ir-device-detail")],Li);let Oi=class extends re{constructor(){super(...arguments),this.sourceId="",this.sourceName="",this._name="",this._busy=!1,this._error=null}connectedCallback(){super.connectedCallback(),this._name=`${this.sourceName} (Copy)`}_close(){this.dispatchEvent(new CustomEvent("closed",{bubbles:!0,composed:!0}))}async _duplicate(){const e=this._name.trim();if(e){this._busy=!0,this._error=null;try{const t=await this.api.duplicateDevice(this.sourceId,e);this.dispatchEvent(new CustomEvent("device-duplicated",{detail:t,bubbles:!0,composed:!0})),this._close()}catch(e){this._error=e.message}finally{this._busy=!1}}else this._error="Name is required."}_onKeyDown(e){"Enter"===e.key&&(e.preventDefault(),this._duplicate())}render(){return F`
+    `],e([he({attribute:!1})],Bi.prototype,"api",void 0),e([he({attribute:!1})],Bi.prototype,"hass",void 0),e([he({attribute:!1})],Bi.prototype,"device",void 0),e([pe()],Bi.prototype,"_busy",void 0),e([pe()],Bi.prototype,"_captureName",void 0),e([pe()],Bi.prototype,"_toast",void 0),e([pe()],Bi.prototype,"_confirmDelete",void 0),e([pe()],Bi.prototype,"_commandToDelete",void 0),e([pe()],Bi.prototype,"_editCommand",void 0),e([pe()],Bi.prototype,"_actionOptions",void 0),e([pe()],Bi.prototype,"_mappingCommandName",void 0),e([pe()],Bi.prototype,"_popoverTop",void 0),e([pe()],Bi.prototype,"_popoverLeft",void 0),e([pe()],Bi.prototype,"_editingName",void 0),e([pe()],Bi.prototype,"_draftName",void 0),e([pe()],Bi.prototype,"_triggers",void 0),e([pe()],Bi.prototype,"_triggerCommand",void 0),e([pe()],Bi.prototype,"_triggerEdit",void 0),e([pe()],Bi.prototype,"_confirmDeleteTriggerId",void 0),e([pe()],Bi.prototype,"_triggerPopover",void 0),e([pe()],Bi.prototype,"_receivers",void 0),e([pe()],Bi.prototype,"_commandsListVersion",void 0),Bi=e([ue("ir-device-detail")],Bi);let ji=class extends ne{constructor(){super(...arguments),this.sourceId="",this.sourceName="",this._name="",this._busy=!1,this._error=null}connectedCallback(){super.connectedCallback(),this._name=`${this.sourceName} (Copy)`}_close(){this.dispatchEvent(new CustomEvent("closed",{bubbles:!0,composed:!0}))}async _duplicate(){const e=this._name.trim();if(e){this._busy=!0,this._error=null;try{const t=await this.api.duplicateDevice(this.sourceId,e);this.dispatchEvent(new CustomEvent("device-duplicated",{detail:t,bubbles:!0,composed:!0})),this._close()}catch(e){this._error=e.message}finally{this._busy=!1}}else this._error="Name is required."}_onKeyDown(e){"Enter"===e.key&&(e.preventDefault(),this._duplicate())}render(){return B`
             <ha-dialog
                 open
                 heading="Duplicate device"
                 scrimClickAction=""
                 @closed=${this._close}
             >
-                ${this._error?F`<ha-alert alert-type="error">${this._error}</ha-alert>`:""}
+                ${this._error?B`<ha-alert alert-type="error">${this._error}</ha-alert>`:""}
 
                 <p class="hint">
                     Duplicating <strong>${this.sourceName}</strong>. The new
@@ -1865,7 +2122,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     </button>
                 </div>
             </ha-dialog>
-        `}};Oi.styles=n`
+        `}};ji.styles=r`
         .hint {
             font-size: 0.85rem;
             color: var(--secondary-text-color);
@@ -1932,20 +2189,20 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
         .create-btn:hover:not(:disabled) {
             opacity: 0.9;
         }
-    `,e([he({attribute:!1})],Oi.prototype,"api",void 0),e([he({attribute:!1})],Oi.prototype,"sourceId",void 0),e([he({attribute:!1})],Oi.prototype,"sourceName",void 0),e([pe()],Oi.prototype,"_name",void 0),e([pe()],Oi.prototype,"_busy",void 0),e([pe()],Oi.prototype,"_error",void 0),Oi=e([ue("ir-duplicate-device-dialog")],Oi);const Ui={media_player:"M21,17H3V5H21M21,3H3A2,2 0 0,0 1,5V17A2,2 0 0,0 3,19H8V21H16V19H21A2,2 0 0,0 23,17V5A2,2 0 0,0 21,3Z",ac:"M11,21H13V11.85L14.6,13.5L16,12.05L12,8L8,12.05L9.4,13.5L11,11.85V21M2,3V11C2,12.66 5.69,14 12,14C18.31,14 22,12.66 22,11V3H2M4,5H20V8.5C18.5,9.27 15.6,10 12,10C8.4,10 5.5,9.27 4,8.5V5Z",fan:"M12,11A1,1 0 0,0 11,12A1,1 0 0,0 12,13A1,1 0 0,0 13,12A1,1 0 0,0 12,11M12.5,2C17,2 17.11,5.57 14.75,6.75C13.76,7.24 13.32,8.29 13.13,9.22C13.61,9.42 14.03,9.73 14.35,10.13C18.05,8.13 22.03,8.92 22.03,12.5C22.03,17 18.46,17.1 17.28,14.73C16.78,13.74 15.72,13.3 14.79,13.11C14.59,13.59 14.28,14 13.88,14.34C15.87,18.03 15.08,22 11.5,22C7,22 6.91,18.42 9.27,17.24C10.25,16.75 10.69,15.71 10.89,14.79C10.4,14.59 9.97,14.27 9.65,13.87C5.96,15.85 2,15.07 2,11.5C2,7 5.56,6.89 6.74,9.26C7.24,10.25 8.29,10.68 9.22,10.87C9.41,10.39 9.73,9.97 10.14,9.65C8.15,5.95 8.94,2 12.5,2Z",light:"M12,2A7,7 0 0,0 5,9C5,11.38 6.19,13.47 8,14.74V17A1,1 0 0,0 9,18H15A1,1 0 0,0 16,17V14.74C17.81,13.47 19,11.38 19,9A7,7 0 0,0 12,2M9,21A1,1 0 0,0 10,22H14A1,1 0 0,0 15,21V20H9V21Z",switch:"M13,3H11V13H13V3M17.83,5.17L16.41,6.59C18,7.35 19,9.05 19,11A7,7 0 0,1 12,18A7,7 0 0,1 5,11C5,9.05 6,7.35 7.58,6.59L6.17,5.17C4.23,6.82 3,9.26 3,12A9,9 0 0,0 12,21A9,9 0 0,0 21,12C21,9.26 19.77,6.82 17.83,5.17Z",screen:"M20,19H4A2,2 0 0,1 2,17V7A2,2 0 0,1 4,5H20A2,2 0 0,1 22,7V17A2,2 0 0,1 20,19M4,7V17H20V7H4M12,10L16,14H13V17H11V14H8L12,10Z",other:"M11,2A2,2 0 0,0 9,4V8H4A2,2 0 0,0 2,10V13A2,2 0 0,0 4,15H5V21A2,2 0 0,0 7,23H17A2,2 0 0,0 19,21V15H20A2,2 0 0,0 22,13V10A2,2 0 0,0 20,8H15V4A2,2 0 0,0 13,2H11Z"},Bi={media_player:"Media Player",ac:"Air Conditioner",fan:"Fan",light:"Light",switch:"Switch",screen:"Screen / Shade",other:"IR Device"},Fi="M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19M8,9H16V19H8V9M15.5,4L14.5,3H9.5L8.5,4H5V6H19V4H15.5Z";let qi=class extends re{constructor(){super(...arguments),this.devices=[],this.loading=!1,this.expandedDeviceId=null,this._emitters=[],this._captureProviders=[],this._pluckBlasters=[],this._expandedDevice=null,this._triggers=[],this._glowTriggerIds=new Set,this._editTrigger=null,this._confirmDeleteTrigger=null,this._duplicateTarget=null,this._confirmDeleteDevice=null,this._devicesVersion=0,this._localDevices=null,this._devicesSortable=null,this._pendingDevicesSave=null,this._unsubTriggerFired=null}connectedCallback(){super.connectedCallback(),this._discoverHardware(),this._loadTriggers(),this._subscribeTriggerFired()}disconnectedCallback(){super.disconnectedCallback(),this._unsubscribeTriggerFired(),this._devicesSortable?.destroy(),this._devicesSortable=null,null!==this._pendingDevicesSave&&clearTimeout(this._pendingDevicesSave)}willUpdate(e){e.has("devices")&&(this._localDevices=null)}updated(e){(e.has("hass")||e.has("api"))&&this._discoverHardware(),e.has("api")&&this.api&&!this._unsubTriggerFired&&(this._loadTriggers(),this._subscribeTriggerFired()),e.has("expandedDeviceId")&&this._loadExpandedDevice(),this._syncDevicesSortable()}_syncDevicesSortable(){const e=this.renderRoot.querySelector(".device-grid");e&&!this._devicesSortable?this._attachDevicesSortable(e):!e&&this._devicesSortable&&(this._devicesSortable.destroy(),this._devicesSortable=null)}_attachDevicesSortable(e){this._devicesSortable=di.create(e,{draggable:".device-card",filter:".card-action",preventOnFilter:!1,delay:150,delayOnTouchOnly:!0,animation:150,ghostClass:"sortable-ghost",onEnd:()=>{const t=Array.from(e.querySelectorAll(".device-card")).map(e=>e.dataset.id).filter(e=>!!e),i=this._localDevices??this.devices,s=new Map(i.map(e=>[e.id,e])),a=t.map(e=>s.get(e)).filter(e=>!!e);if(a.length===i.length){this._localDevices=a,this._devicesSortable?.destroy(),this._devicesSortable=null;for(const t of Array.from(e.querySelectorAll(".device-card, .expanded-detail")))t.remove();this._devicesVersion++,this._scheduleDevicesSave(a.map(e=>e.id))}}})}_scheduleDevicesSave(e){null!==this._pendingDevicesSave&&clearTimeout(this._pendingDevicesSave),this._pendingDevicesSave=window.setTimeout(async()=>{if(this._pendingDevicesSave=null,this.api)try{await this.api.reorderDevices(e)}catch{this.dispatchEvent(new CustomEvent("device-changed",{bubbles:!0,composed:!0}))}},500)}async _loadExpandedDevice(){if(this.expandedDeviceId&&this.api)try{this._expandedDevice=await this.api.getDevice(this.expandedDeviceId)}catch{this._expandedDevice=null}else this._expandedDevice=null}async _onExpandedDeviceChanged(){await this._loadExpandedDevice(),this.dispatchEvent(new CustomEvent("device-changed",{bubbles:!0,composed:!0}))}_onExpandedDeviceDeleted(){this.dispatchEvent(new CustomEvent("device-deleted",{bubbles:!0,composed:!0}))}_onCommandsReordered(e){if(!this._expandedDevice)return;const t=e.detail?.commands;Array.isArray(t)&&(this._expandedDevice={...this._expandedDevice,commands:t})}_onCollapse(){this.dispatchEvent(new CustomEvent("device-selected",{detail:this.expandedDeviceId,bubbles:!0,composed:!0}))}async _discoverHardware(){const e=new Set;if(this.api)try{const t=await this.api.listReceivers();for(const i of t)e.add(i.entity_id)}catch{}const t=this.hass?.states??{},i=[];for(const[s,a]of Object.entries(t))!s.startsWith("infrared.")||e.has(s)||a.attributes.hair_observer||i.push({entity_id:s,name:a.attributes.friendly_name??s});if(this._emitters=i,this.api)try{this._captureProviders=await this.api.listCaptureProviders()}catch{}if(this.api)try{const{vendors:e}=await this.api.listPluckVendors(),t=[];for(const i of e)for(const e of i.blasters)t.push({integration:i.integration,entity_id:e.entity_id,name:e.name,vendorName:i.name});this._pluckBlasters=t}catch{this._pluckBlasters=[]}}_select(e){this.dispatchEvent(new CustomEvent("device-selected",{detail:e,bubbles:!0,composed:!0}))}_add(){this.dispatchEvent(new CustomEvent("add-device",{bubbles:!0,composed:!0}))}_openInPlucker(e){this.dispatchEvent(new CustomEvent("navigate-plucker",{detail:{vendor_entity_id:e},bubbles:!0,composed:!0}))}_openDuplicateDialog(e,t){t.stopPropagation(),this._duplicateTarget=e}_closeDuplicateDialog(){this._duplicateTarget=null}_onDeviceDuplicated(){this._duplicateTarget=null,this.dispatchEvent(new CustomEvent("device-changed",{bubbles:!0,composed:!0}))}_requestDeleteDevice(e,t){t.stopPropagation(),this._confirmDeleteDevice=e}async _doDeleteDevice(){if(!this._confirmDeleteDevice||!this.api)return;const e=this._confirmDeleteDevice;this._confirmDeleteDevice=null;try{await this.api.deleteDevice(e.id),this.dispatchEvent(new CustomEvent("device-deleted",{bubbles:!0,composed:!0}))}catch{}}_navigateIntegration(e){const t=`/config/integrations/integration/${e}`;window.history.pushState(null,"",t),window.dispatchEvent(new PopStateEvent("popstate"))}async _loadTriggers(){if(this.api)try{this._triggers=await this.api.listTriggers()}catch{}}async _subscribeTriggerFired(){if(this.api)try{this._unsubTriggerFired=await this.api.subscribeTriggerFired(e=>{this._glowTriggerIds=new Set([...this._glowTriggerIds,e.trigger_id]),setTimeout(()=>{const t=new Set(this._glowTriggerIds);t.delete(e.trigger_id),this._glowTriggerIds=t},2500)})}catch{}}async _unsubscribeTriggerFired(){this._unsubTriggerFired&&(await this._unsubTriggerFired(),this._unsubTriggerFired=null)}_openEditTrigger(e,t){t.stopPropagation(),this._editTrigger=e}_closeEditTrigger(){this._editTrigger=null}async _onTriggerUpdated(){this._editTrigger=null,await this._loadTriggers()}async _toggleTriggerEnabled(e,t){t.stopPropagation();try{await this.api.updateTrigger(e.id,{enabled:!e.enabled}),await this._loadTriggers()}catch{}}_requestDeleteTrigger(e,t){t.stopPropagation(),this._confirmDeleteTrigger=e}async _doDeleteTrigger(){if(!this._confirmDeleteTrigger)return;const e=this._confirmDeleteTrigger;this._confirmDeleteTrigger=null;try{await this.api.deleteTrigger(e.id),await this._loadTriggers()}catch{}}_emitterIntegrationDomain(e){const t=this.hass?.entities?.[e];return t?.platform?t.platform:e.split(".")[0]}_getEmitterDeviceIds(){const e=new Set;for(const t of this._emitters){const i=this.hass?.entities?.[t.entity_id];i?.device_id&&e.add(i.device_id)}return e}_getEmitterEntityIdsByDevice(){const e=new Map;for(const t of this._emitters){const i=this.hass?.entities?.[t.entity_id],s=i?.device_id;if(!s)continue;const a=e.get(s)??[];a.push(t.entity_id),e.set(s,a)}return e}_isPre2026_6(){const e=this.hass?.config?.version;if(!e)return!1;const t=e.match(/^(\d+)\.(\d+)/);if(!t)return!1;const i=parseInt(t[1],10),s=parseInt(t[2],10);return i<2026||2026===i&&s<6}_resolveNavType(e,t){if("native"===e.type&&t){const e=this.hass?.entities?.[t]?.platform;return e||"esphome"}return e.type}_classifyHardware(){const e=this._getEmitterEntityIdsByDevice(),t=new Set(e.keys()),i=new Map;for(const s of this._captureProviders){let a,o;if("native"===s.type?(o=s.receiver_entity_id??s.device_id,a=this.hass?.entities?.[o]?.device_id,a||(a=o)):a=s.device_id,!a)continue;const n=i.get(a)??{device_id:a,name:s.name,nav_type:this._resolveNavType(s,o),has_native:!1,has_bridge:!1,has_tx:t.has(a),tx_entity_ids:e.get(a)??[]};"native"===s.type?(n.has_native=!0,n.native_entity_id=o):(n.has_bridge=!0,n.name=s.name,n.nav_type=s.type),i.set(a,n)}const s=Array.from(i.values()),a=s.filter(e=>e.has_tx);return{receivers:s,proxies:a}}_renderRxBadges(e){const t=!e.has_native&&e.has_bridge&&this._isPre2026_6();return F`
-            ${e.has_native?F`<span
+    `,e([he({attribute:!1})],ji.prototype,"api",void 0),e([he({attribute:!1})],ji.prototype,"sourceId",void 0),e([he({attribute:!1})],ji.prototype,"sourceName",void 0),e([pe()],ji.prototype,"_name",void 0),e([pe()],ji.prototype,"_busy",void 0),e([pe()],ji.prototype,"_error",void 0),ji=e([ue("ir-duplicate-device-dialog")],ji);const qi={media_player:"M21,17H3V5H21M21,3H3A2,2 0 0,0 1,5V17A2,2 0 0,0 3,19H8V21H16V19H21A2,2 0 0,0 23,17V5A2,2 0 0,0 21,3Z",ac:"M11,21H13V11.85L14.6,13.5L16,12.05L12,8L8,12.05L9.4,13.5L11,11.85V21M2,3V11C2,12.66 5.69,14 12,14C18.31,14 22,12.66 22,11V3H2M4,5H20V8.5C18.5,9.27 15.6,10 12,10C8.4,10 5.5,9.27 4,8.5V5Z",fan:"M12,11A1,1 0 0,0 11,12A1,1 0 0,0 12,13A1,1 0 0,0 13,12A1,1 0 0,0 12,11M12.5,2C17,2 17.11,5.57 14.75,6.75C13.76,7.24 13.32,8.29 13.13,9.22C13.61,9.42 14.03,9.73 14.35,10.13C18.05,8.13 22.03,8.92 22.03,12.5C22.03,17 18.46,17.1 17.28,14.73C16.78,13.74 15.72,13.3 14.79,13.11C14.59,13.59 14.28,14 13.88,14.34C15.87,18.03 15.08,22 11.5,22C7,22 6.91,18.42 9.27,17.24C10.25,16.75 10.69,15.71 10.89,14.79C10.4,14.59 9.97,14.27 9.65,13.87C5.96,15.85 2,15.07 2,11.5C2,7 5.56,6.89 6.74,9.26C7.24,10.25 8.29,10.68 9.22,10.87C9.41,10.39 9.73,9.97 10.14,9.65C8.15,5.95 8.94,2 12.5,2Z",light:"M12,2A7,7 0 0,0 5,9C5,11.38 6.19,13.47 8,14.74V17A1,1 0 0,0 9,18H15A1,1 0 0,0 16,17V14.74C17.81,13.47 19,11.38 19,9A7,7 0 0,0 12,2M9,21A1,1 0 0,0 10,22H14A1,1 0 0,0 15,21V20H9V21Z",switch:"M13,3H11V13H13V3M17.83,5.17L16.41,6.59C18,7.35 19,9.05 19,11A7,7 0 0,1 12,18A7,7 0 0,1 5,11C5,9.05 6,7.35 7.58,6.59L6.17,5.17C4.23,6.82 3,9.26 3,12A9,9 0 0,0 12,21A9,9 0 0,0 21,12C21,9.26 19.77,6.82 17.83,5.17Z",screen:"M20,19H4A2,2 0 0,1 2,17V7A2,2 0 0,1 4,5H20A2,2 0 0,1 22,7V17A2,2 0 0,1 20,19M4,7V17H20V7H4M12,10L16,14H13V17H11V14H8L12,10Z",other:"M11,2A2,2 0 0,0 9,4V8H4A2,2 0 0,0 2,10V13A2,2 0 0,0 4,15H5V21A2,2 0 0,0 7,23H17A2,2 0 0,0 19,21V15H20A2,2 0 0,0 22,13V10A2,2 0 0,0 20,8H15V4A2,2 0 0,0 13,2H11Z"},Xi={media_player:"Media Player",ac:"Air Conditioner",fan:"Fan",light:"Light",switch:"Switch",screen:"Screen / Shade",other:"IR Device"},Zi="M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19M8,9H16V19H8V9M15.5,4L14.5,3H9.5L8.5,4H5V6H19V4H15.5Z";let Yi=class extends ne{constructor(){super(...arguments),this.devices=[],this.loading=!1,this.expandedDeviceId=null,this._emitters=[],this._captureProviders=[],this._pluckBlasters=[],this._expandedDevice=null,this._triggers=[],this._glowTriggerIds=new Set,this._editTrigger=null,this._confirmDeleteTrigger=null,this._duplicateTarget=null,this._confirmDeleteDevice=null,this._devicesVersion=0,this._localDevices=null,this._devicesSortable=null,this._pendingDevicesSave=null,this._unsubTriggerFired=null}connectedCallback(){super.connectedCallback(),this._discoverHardware(),this._loadTriggers(),this._subscribeTriggerFired()}disconnectedCallback(){super.disconnectedCallback(),this._unsubscribeTriggerFired(),this._devicesSortable?.destroy(),this._devicesSortable=null,null!==this._pendingDevicesSave&&clearTimeout(this._pendingDevicesSave)}willUpdate(e){e.has("devices")&&(this._localDevices=null)}updated(e){(e.has("hass")||e.has("api"))&&this._discoverHardware(),e.has("api")&&this.api&&!this._unsubTriggerFired&&(this._loadTriggers(),this._subscribeTriggerFired()),e.has("expandedDeviceId")&&this._loadExpandedDevice(),this._syncDevicesSortable()}_syncDevicesSortable(){const e=this.renderRoot.querySelector(".device-grid");e&&!this._devicesSortable?this._attachDevicesSortable(e):!e&&this._devicesSortable&&(this._devicesSortable.destroy(),this._devicesSortable=null)}_attachDevicesSortable(e){this._devicesSortable=di.create(e,{draggable:".device-card",filter:".card-action",preventOnFilter:!1,delay:150,delayOnTouchOnly:!0,animation:150,ghostClass:"sortable-ghost",onEnd:()=>{const t=Array.from(e.querySelectorAll(".device-card")).map(e=>e.dataset.id).filter(e=>!!e),i=this._localDevices??this.devices,s=new Map(i.map(e=>[e.id,e])),o=t.map(e=>s.get(e)).filter(e=>!!e);if(o.length===i.length){this._localDevices=o,this._devicesSortable?.destroy(),this._devicesSortable=null;for(const t of Array.from(e.querySelectorAll(".device-card, .expanded-detail")))t.remove();this._devicesVersion++,this._scheduleDevicesSave(o.map(e=>e.id))}}})}_scheduleDevicesSave(e){null!==this._pendingDevicesSave&&clearTimeout(this._pendingDevicesSave),this._pendingDevicesSave=window.setTimeout(async()=>{if(this._pendingDevicesSave=null,this.api)try{await this.api.reorderDevices(e)}catch{this.dispatchEvent(new CustomEvent("device-changed",{bubbles:!0,composed:!0}))}},500)}async _loadExpandedDevice(){if(this.expandedDeviceId&&this.api)try{this._expandedDevice=await this.api.getDevice(this.expandedDeviceId)}catch{this._expandedDevice=null}else this._expandedDevice=null}async _onExpandedDeviceChanged(){await this._loadExpandedDevice(),this.dispatchEvent(new CustomEvent("device-changed",{bubbles:!0,composed:!0}))}_onExpandedDeviceDeleted(){this.dispatchEvent(new CustomEvent("device-deleted",{bubbles:!0,composed:!0}))}_onCommandsReordered(e){if(!this._expandedDevice)return;const t=e.detail?.commands;Array.isArray(t)&&(this._expandedDevice={...this._expandedDevice,commands:t})}_onCollapse(){this.dispatchEvent(new CustomEvent("device-selected",{detail:this.expandedDeviceId,bubbles:!0,composed:!0}))}async _discoverHardware(){const e=new Set;if(this.api)try{const t=await this.api.listReceivers();for(const i of t)e.add(i.entity_id)}catch{}const t=this.hass?.states??{},i=[];for(const[s,o]of Object.entries(t))!s.startsWith("infrared.")||e.has(s)||o.attributes.hair_observer||i.push({entity_id:s,name:o.attributes.friendly_name??s});if(this._emitters=i,this.api)try{this._captureProviders=await this.api.listCaptureProviders()}catch{}if(this.api)try{const{vendors:e}=await this.api.listPluckVendors(),t=[];for(const i of e)for(const e of i.blasters)t.push({integration:i.integration,entity_id:e.entity_id,name:e.name,vendorName:i.name});this._pluckBlasters=t}catch{this._pluckBlasters=[]}}_select(e){this.dispatchEvent(new CustomEvent("device-selected",{detail:e,bubbles:!0,composed:!0}))}_add(){this.dispatchEvent(new CustomEvent("add-device",{bubbles:!0,composed:!0}))}_openInPlucker(e){this.dispatchEvent(new CustomEvent("navigate-plucker",{detail:{vendor_entity_id:e},bubbles:!0,composed:!0}))}_openDuplicateDialog(e,t){t.stopPropagation(),this._duplicateTarget=e}_closeDuplicateDialog(){this._duplicateTarget=null}_onDeviceDuplicated(){this._duplicateTarget=null,this.dispatchEvent(new CustomEvent("device-changed",{bubbles:!0,composed:!0}))}_requestDeleteDevice(e,t){t.stopPropagation(),this._confirmDeleteDevice=e}async _doDeleteDevice(){if(!this._confirmDeleteDevice||!this.api)return;const e=this._confirmDeleteDevice;this._confirmDeleteDevice=null;try{await this.api.deleteDevice(e.id),this.dispatchEvent(new CustomEvent("device-deleted",{bubbles:!0,composed:!0}))}catch{}}_navigateIntegration(e){const t=`/config/integrations/integration/${e}`;window.history.pushState(null,"",t),window.dispatchEvent(new PopStateEvent("popstate"))}async _loadTriggers(){if(this.api)try{this._triggers=await this.api.listTriggers()}catch{}}async _subscribeTriggerFired(){if(this.api)try{this._unsubTriggerFired=await this.api.subscribeTriggerFired(e=>{this._glowTriggerIds=new Set([...this._glowTriggerIds,e.trigger_id]),setTimeout(()=>{const t=new Set(this._glowTriggerIds);t.delete(e.trigger_id),this._glowTriggerIds=t},2500)})}catch{}}async _unsubscribeTriggerFired(){this._unsubTriggerFired&&(await this._unsubTriggerFired(),this._unsubTriggerFired=null)}_openEditTrigger(e,t){t.stopPropagation(),this._editTrigger=e}_closeEditTrigger(){this._editTrigger=null}async _onTriggerUpdated(){this._editTrigger=null,await this._loadTriggers()}async _toggleTriggerEnabled(e,t){t.stopPropagation();try{await this.api.updateTrigger(e.id,{enabled:!e.enabled}),await this._loadTriggers()}catch{}}_requestDeleteTrigger(e,t){t.stopPropagation(),this._confirmDeleteTrigger=e}async _doDeleteTrigger(){if(!this._confirmDeleteTrigger)return;const e=this._confirmDeleteTrigger;this._confirmDeleteTrigger=null;try{await this.api.deleteTrigger(e.id),await this._loadTriggers()}catch{}}_emitterIntegrationDomain(e){const t=this.hass?.entities?.[e];return t?.platform?t.platform:e.split(".")[0]}_getEmitterDeviceIds(){const e=new Set;for(const t of this._emitters){const i=this.hass?.entities?.[t.entity_id];i?.device_id&&e.add(i.device_id)}return e}_getEmitterEntityIdsByDevice(){const e=new Map;for(const t of this._emitters){const i=this.hass?.entities?.[t.entity_id],s=i?.device_id;if(!s)continue;const o=e.get(s)??[];o.push(t.entity_id),e.set(s,o)}return e}_isPre2026_6(){const e=this.hass?.config?.version;if(!e)return!1;const t=e.match(/^(\d+)\.(\d+)/);if(!t)return!1;const i=parseInt(t[1],10),s=parseInt(t[2],10);return i<2026||2026===i&&s<6}_resolveNavType(e,t){if("native"===e.type&&t){const e=this.hass?.entities?.[t]?.platform;return e||"esphome"}return e.type}_classifyHardware(){const e=this._getEmitterEntityIdsByDevice(),t=new Set(e.keys()),i=new Map;for(const s of this._captureProviders){let o,a;if("native"===s.type?(a=s.receiver_entity_id??s.device_id,o=this.hass?.entities?.[a]?.device_id,o||(o=a)):o=s.device_id,!o)continue;const r=i.get(o)??{device_id:o,name:s.name,nav_type:this._resolveNavType(s,a),has_native:!1,has_bridge:!1,has_tx:t.has(o),tx_entity_ids:e.get(o)??[]};"native"===s.type?(r.has_native=!0,r.native_entity_id=a):(r.has_bridge=!0,r.name=s.name,r.nav_type=s.type),i.set(o,r)}const s=Array.from(i.values()),o=s.filter(e=>e.has_tx);return{receivers:s,proxies:o}}_renderRxBadges(e){const t=!e.has_native&&e.has_bridge&&this._isPre2026_6();return B`
+            ${e.has_native?B`<span
                       class="badge rx-native"
                       title="Receives via HA's native infrared platform"
-                  >RX-NATIVE</span>`:j}
-            ${e.has_bridge?F`<span
+                  >RX-NATIVE</span>`:q}
+            ${e.has_bridge?B`<span
                       class="badge rx-bridge"
                       title=${e.has_native?"Legacy bridge still active. Native receiver supersedes it -- you can remove the on_pronto: block from your ESPHome config.":"Receives via legacy ESPHome event-bus bridge"}
-                  >RX-BRIDGE</span>`:j}
-            ${t?F`<span
+                  >RX-BRIDGE</span>`:q}
+            ${t?B`<span
                       class="badge rx-native-disabled"
                       title="Upgrade to HA 2026.6+ for native receiver support"
-                  >RX-NATIVE</span>`:j}
-        `}render(){if(this.loading)return F`<div class="loading">Loading IR devices...</div>`;const e=this._localDevices??this.devices,t=e.length>0,i=this._emitters.length>0,{receivers:s,proxies:a}=this._classifyHardware(),o=s.length>0,n=a.length>0,r=this._triggers.length>0;return t||i||o||n?F`
+                  >RX-NATIVE</span>`:q}
+        `}render(){if(this.loading)return B`<div class="loading">Loading IR devices...</div>`;const e=this._localDevices??this.devices,t=e.length>0,i=this._emitters.length>0,{receivers:s,proxies:o}=this._classifyHardware(),a=s.length>0,r=o.length>0,n=this._triggers.length>0;return t||i||a||r?B`
             <!-- Devices -->
             <div class="toolbar">
                 <span class="toolbar-title">
@@ -1960,9 +2217,9 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     Add Device
                 </button>
             </div>
-            ${t?F`
+            ${t?B`
                       <div class="grid device-grid">
-                          ${Se(this._devicesVersion,Te(e,e=>e.id,e=>F`
+                          ${Se(this._devicesVersion,Te(e,e=>e.id,e=>B`
                                   <div
                                       class="card device-card ${e.id===this.expandedDeviceId?"expanded":""}"
                                       data-id=${e.id}
@@ -1982,27 +2239,27 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                           title="Delete device"
                                           @click=${t=>this._requestDeleteDevice(e,t)}
                                       >
-                                          <ha-svg-icon .path=${Fi}></ha-svg-icon>
+                                          <ha-svg-icon .path=${Zi}></ha-svg-icon>
                                       </button>
                                       <div class="card-header">
                                           <ha-svg-icon
-                                              .path=${Ui[e.device_type]??Ui.other}
+                                              .path=${qi[e.device_type]??qi.other}
                                           ></ha-svg-icon>
                                           <div class="card-name">
                                               ${e.name}
                                           </div>
                                       </div>
                                       <div class="card-meta">
-                                          ${[e.manufacturer,Bi[e.device_type]].filter(Boolean).join(" • ")}
+                                          ${[e.manufacturer,Xi[e.device_type]].filter(Boolean).join(" • ")}
                                       </div>
                                       <div class="card-footer">
                                           <span class="badge cmd-badge">
                                               CMD: ${e.command_count}
                                           </span>
-                                          ${e.emitter_entity_ids.length>0?F`<span class="badge tx-badge">TX: ${e.emitter_entity_ids.length}</span>`:F`<span class="badge no-tx-badge">No TX</span>`}
+                                          ${e.emitter_entity_ids.length>0?B`<span class="badge tx-badge">TX: ${e.emitter_entity_ids.length}</span>`:B`<span class="badge no-tx-badge">No TX</span>`}
                                       </div>
                                   </div>
-                                  ${e.id===this.expandedDeviceId&&this._expandedDevice?F`
+                                  ${e.id===this.expandedDeviceId&&this._expandedDevice?B`
                                             <div class="expanded-detail">
                                                 <ir-device-detail
                                                     .api=${this.api}
@@ -2015,23 +2272,23 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                                     @collapse=${this._onCollapse}
                                                 ></ir-device-detail>
                                             </div>
-                                        `:j}
+                                        `:q}
                               `))}
                       </div>
-                  `:F`
+                  `:B`
                       <div class="empty-devices">
                           No devices yet. Sniff some signals, then add your first device.
                       </div>
                   `}
 
             <!-- Triggers -->
-            ${r?F`
+            ${n?B`
                       <div class="section-header">
                           <h2>Triggers</h2>
                           <span class="section-count">${this._triggers.length}</span>
                       </div>
                       <div class="grid">
-                          ${this._triggers.map(e=>F`
+                          ${this._triggers.map(e=>B`
                                   <div
                                       class="card trigger-card ${this._glowTriggerIds.has(e.id)?"trigger-glow":""} ${e.enabled?"":"trigger-disabled"}"
                                       tabindex="0"
@@ -2044,16 +2301,16 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                       </div>
                                       <div class="card-meta">Trigger Event</div>
                                       <div class="card-footer">
-                                          ${e.min_hits>1?F`<span class="badge trigger-hits-badge">
+                                          ${e.min_hits>1?B`<span class="badge trigger-hits-badge">
                                                     ${e.min_hits}x hits
-                                                </span>`:j}
+                                                </span>`:q}
                                           <span
                                               class="badge trigger-toggle ${e.enabled?"trigger-enabled":"trigger-off"}"
                                               @click=${t=>this._toggleTriggerEnabled(e,t)}
                                           >${e.enabled?"ON":"OFF"}</span>
                                           <ha-svg-icon
                                               class="trigger-trash"
-                                              .path=${Fi}
+                                              .path=${Zi}
                                               title="Delete trigger"
                                               @click=${t=>this._requestDeleteTrigger(e,t)}
                                           ></ha-svg-icon>
@@ -2061,10 +2318,10 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                   </div>
                               `)}
                       </div>
-                  `:j}
+                  `:q}
 
             <!-- Blasters (Pluckable) -- vendor IR blasters HAIR can pull from -->
-            ${this._pluckBlasters.length>0?F`
+            ${this._pluckBlasters.length>0?B`
                       <div class="section-header">
                           <h2>Blasters (Pluckable)</h2>
                           <span class="section-count"
@@ -2072,7 +2329,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                           >
                       </div>
                       <div class="grid">
-                          ${this._pluckBlasters.map(e=>F`
+                          ${this._pluckBlasters.map(e=>B`
                                   <div
                                       class="card hw-card"
                                       tabindex="0"
@@ -2095,16 +2352,16 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                   </div>
                               `)}
                       </div>
-                  `:j}
+                  `:q}
 
             <!-- Emitters -->
-            ${i?F`
+            ${i?B`
                       <div class="section-header">
                           <h2>Emitters</h2>
                           <span class="section-count">${this._emitters.length}</span>
                       </div>
                       <div class="grid">
-                          ${this._emitters.map(e=>F`
+                          ${this._emitters.map(e=>B`
                                   <div
                                       class="card hw-card"
                                       tabindex="0"
@@ -2125,16 +2382,16 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                   </div>
                               `)}
                       </div>
-                  `:j}
+                  `:q}
 
             <!-- Receivers (capture-capable hardware; proxies appear here too by design) -->
-            ${o?F`
+            ${a?B`
                       <div class="section-header">
                           <h2>Receivers</h2>
                           <span class="section-count">${s.length}</span>
                       </div>
                       <div class="grid">
-                          ${s.map(e=>F`
+                          ${s.map(e=>B`
                                   <div
                                       class="card hw-card"
                                       tabindex="0"
@@ -2152,16 +2409,16 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                   </div>
                               `)}
                       </div>
-                  `:j}
+                  `:q}
 
             <!-- Proxies (TX + RX hardware) -->
-            ${n?F`
+            ${r?B`
                       <div class="section-header">
                           <h2>Proxies</h2>
-                          <span class="section-count">${a.length}</span>
+                          <span class="section-count">${o.length}</span>
                       </div>
                       <div class="grid">
-                          ${a.map(e=>F`
+                          ${o.map(e=>B`
                                   <div
                                       class="card hw-card"
                                       tabindex="0"
@@ -2172,7 +2429,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                           <ha-svg-icon .path=${"M12,10A2,2 0 0,1 14,12C14,12.5 13.82,12.94 13.53,13.29L16.7,22H14.57L12,14.93L9.43,22H7.3L10.47,13.29C10.18,12.94 10,12.5 10,12A2,2 0 0,1 12,10M12,8A4,4 0 0,0 8,12C8,12.5 8.1,13 8.28,13.46L7.4,15.86C6.53,14.81 6,13.47 6,12A6,6 0 0,1 12,6A6,6 0 0,1 18,12C18,13.47 17.47,14.81 16.6,15.86L15.72,13.46C15.9,13 16,12.5 16,12A4,4 0 0,0 12,8M12,4A8,8 0 0,0 4,12C4,14.36 5,16.5 6.64,17.94L5.92,19.94C3.54,18.11 2,15.23 2,12A10,10 0 0,1 12,2A10,10 0 0,1 22,12C22,15.23 20.46,18.11 18.08,19.94L17.36,17.94C19,16.5 20,14.36 20,12A8,8 0 0,0 12,4Z"}></ha-svg-icon>
                                           <div class="card-name">${e.name}</div>
                                       </div>
-                                      ${e.tx_entity_ids[0]?F`<div class="card-meta">${e.tx_entity_ids[0]}</div>`:j}
+                                      ${e.tx_entity_ids[0]?B`<div class="card-meta">${e.tx_entity_ids[0]}</div>`:q}
                                       <div class="card-meta">${e.native_entity_id??e.nav_type}</div>
                                       <div class="card-footer">
                                           <span
@@ -2184,18 +2441,18 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                   </div>
                               `)}
                       </div>
-                  `:j}
+                  `:q}
 
-            ${this._editTrigger?F`
+            ${this._editTrigger?B`
                       <ir-trigger-dialog
                           .api=${this.api}
                           .trigger=${this._editTrigger}
                           @trigger-saved=${this._onTriggerUpdated}
                           @closed=${this._closeEditTrigger}
                       ></ir-trigger-dialog>
-                  `:j}
+                  `:q}
 
-            ${this._confirmDeleteTrigger?F`
+            ${this._confirmDeleteTrigger?B`
                       <ir-confirm-dialog
                           title="Delete Trigger"
                           message="Remove &quot;${this._confirmDeleteTrigger.name}&quot;? The associated HA event entity will also be removed."
@@ -2204,9 +2461,9 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                           @confirmed=${this._doDeleteTrigger}
                           @closed=${()=>this._confirmDeleteTrigger=null}
                       ></ir-confirm-dialog>
-                  `:j}
+                  `:q}
 
-            ${this._duplicateTarget&&this.api?F`
+            ${this._duplicateTarget&&this.api?B`
                       <ir-duplicate-device-dialog
                           .api=${this.api}
                           .sourceId=${this._duplicateTarget.id}
@@ -2214,9 +2471,9 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                           @device-duplicated=${this._onDeviceDuplicated}
                           @closed=${this._closeDuplicateDialog}
                       ></ir-duplicate-device-dialog>
-                  `:j}
+                  `:q}
 
-            ${this._confirmDeleteDevice?F`
+            ${this._confirmDeleteDevice?B`
                       <ir-confirm-dialog
                           title="Delete Device"
                           message="Remove &quot;${this._confirmDeleteDevice.name}&quot;? Commands, action mappings, and emitter assignments will be deleted. Triggers are unaffected."
@@ -2225,14 +2482,14 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                           @confirmed=${this._doDeleteDevice}
                           @closed=${()=>this._confirmDeleteDevice=null}
                       ></ir-confirm-dialog>
-                  `:j}
-        `:F`
+                  `:q}
+        `:B`
                 <ha-card class="empty">
                     <h2>No IR devices yet</h2>
                     <p>Add your first device to get started.</p>
                     <mwc-button raised @click=${this._add}>+ Add Device</mwc-button>
                 </ha-card>
-            `}};qi.styles=n`
+            `}};Yi.styles=r`
         :host {
             display: block;
         }
@@ -2616,14 +2873,14 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
             color: #f44336;
             opacity: 1;
         }
-    `,e([he({attribute:!1})],qi.prototype,"devices",void 0),e([he({attribute:!1})],qi.prototype,"hass",void 0),e([he({attribute:!1})],qi.prototype,"api",void 0),e([he({type:Boolean})],qi.prototype,"loading",void 0),e([he({attribute:!1})],qi.prototype,"expandedDeviceId",void 0),e([pe()],qi.prototype,"_emitters",void 0),e([pe()],qi.prototype,"_captureProviders",void 0),e([pe()],qi.prototype,"_pluckBlasters",void 0),e([pe()],qi.prototype,"_expandedDevice",void 0),e([pe()],qi.prototype,"_triggers",void 0),e([pe()],qi.prototype,"_glowTriggerIds",void 0),e([pe()],qi.prototype,"_editTrigger",void 0),e([pe()],qi.prototype,"_confirmDeleteTrigger",void 0),e([pe()],qi.prototype,"_duplicateTarget",void 0),e([pe()],qi.prototype,"_confirmDeleteDevice",void 0),e([pe()],qi.prototype,"_devicesVersion",void 0),e([pe()],qi.prototype,"_localDevices",void 0),qi=e([ue("ir-device-list")],qi);const ji=[{value:"media_player",label:"Media Player"},{value:"ac",label:"Air Conditioner"},{value:"fan",label:"Fan"},{value:"light",label:"Light"},{value:"switch",label:"Switch"},{value:"screen",label:"Screen / Shade"},{value:"other",label:"Other"}];let Xi=class extends re{constructor(){super(...arguments),this._name="",this._deviceType="media_player",this._emitterIds=[],this._captureProviders=[],this._busy=!1,this._error=null}connectedCallback(){super.connectedCallback(),this._loadCaptureProviders()}async _loadCaptureProviders(){try{this._captureProviders=await this.api.listCaptureProviders()}catch{}}_close(){this.dispatchEvent(new CustomEvent("closed",{bubbles:!0,composed:!0}))}async _create(){if(this._name.trim())if(0!==this._emitterIds.length){this._busy=!0,this._error=null;try{const e=this._captureProviders[0]??null,t=await this.api.createDevice({name:this._name.trim(),device_type:this._deviceType,emitter_entity_ids:this._emitterIds,capture_device_id:e?.device_id??null,capture_provider_type:e?.type??"esphome"});this.dispatchEvent(new CustomEvent("device-created",{detail:t,bubbles:!0,composed:!0}))}catch(e){this._error=e.message}finally{this._busy=!1}}else this._error="Pick at least one IR emitter.";else this._error="Name is required."}render(){return F`
+    `,e([he({attribute:!1})],Yi.prototype,"devices",void 0),e([he({attribute:!1})],Yi.prototype,"hass",void 0),e([he({attribute:!1})],Yi.prototype,"api",void 0),e([he({type:Boolean})],Yi.prototype,"loading",void 0),e([he({attribute:!1})],Yi.prototype,"expandedDeviceId",void 0),e([pe()],Yi.prototype,"_emitters",void 0),e([pe()],Yi.prototype,"_captureProviders",void 0),e([pe()],Yi.prototype,"_pluckBlasters",void 0),e([pe()],Yi.prototype,"_expandedDevice",void 0),e([pe()],Yi.prototype,"_triggers",void 0),e([pe()],Yi.prototype,"_glowTriggerIds",void 0),e([pe()],Yi.prototype,"_editTrigger",void 0),e([pe()],Yi.prototype,"_confirmDeleteTrigger",void 0),e([pe()],Yi.prototype,"_duplicateTarget",void 0),e([pe()],Yi.prototype,"_confirmDeleteDevice",void 0),e([pe()],Yi.prototype,"_devicesVersion",void 0),e([pe()],Yi.prototype,"_localDevices",void 0),Yi=e([ue("ir-device-list")],Yi);const Wi=[{value:"media_player",label:"Media Player"},{value:"ac",label:"Air Conditioner"},{value:"fan",label:"Fan"},{value:"light",label:"Light"},{value:"switch",label:"Switch"},{value:"screen",label:"Screen / Shade"},{value:"other",label:"Other"}];let Ki=class extends ne{constructor(){super(...arguments),this._name="",this._deviceType="media_player",this._emitterIds=[],this._captureProviders=[],this._busy=!1,this._error=null}connectedCallback(){super.connectedCallback(),this._loadCaptureProviders()}async _loadCaptureProviders(){try{this._captureProviders=await this.api.listCaptureProviders()}catch{}}_close(){this.dispatchEvent(new CustomEvent("closed",{bubbles:!0,composed:!0}))}async _create(){if(this._name.trim())if(0!==this._emitterIds.length){this._busy=!0,this._error=null;try{const e=this._captureProviders[0]??null,t=await this.api.createDevice({name:this._name.trim(),device_type:this._deviceType,emitter_entity_ids:this._emitterIds,capture_device_id:e?.device_id??null,capture_provider_type:e?.type??"esphome"});this.dispatchEvent(new CustomEvent("device-created",{detail:t,bubbles:!0,composed:!0}))}catch(e){this._error=e.message}finally{this._busy=!1}}else this._error="Pick at least one IR emitter.";else this._error="Name is required."}render(){return B`
             <ha-dialog
                 open
                 heading="Add Device"
                 scrimClickAction=""
                 @closed=${this._close}
             >
-                ${this._error?F`<ha-alert alert-type="error">${this._error}</ha-alert>`:""}
+                ${this._error?B`<ha-alert alert-type="error">${this._error}</ha-alert>`:""}
 
                 <div class="field">
                     <label>Name</label>
@@ -2643,7 +2900,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                         .value=${this._deviceType}
                         @change=${e=>this._deviceType=e.target.value}
                     >
-                        ${ji.map(e=>F`
+                        ${Wi.map(e=>B`
                                 <option
                                     value=${e.value}
                                     ?selected=${this._deviceType===e.value}
@@ -2679,7 +2936,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     </button>
                 </div>
             </ha-dialog>
-        `}};Xi.styles=n`
+        `}};Ki.styles=r`
         .field {
             display: block;
             margin: 12px 0;
@@ -2750,7 +3007,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
         .create-btn:hover:not(:disabled) {
             opacity: 0.9;
         }
-    `,e([he({attribute:!1})],Xi.prototype,"api",void 0),e([he({attribute:!1})],Xi.prototype,"hass",void 0),e([pe()],Xi.prototype,"_name",void 0),e([pe()],Xi.prototype,"_deviceType",void 0),e([pe()],Xi.prototype,"_emitterIds",void 0),e([pe()],Xi.prototype,"_captureProviders",void 0),e([pe()],Xi.prototype,"_busy",void 0),e([pe()],Xi.prototype,"_error",void 0),Xi=e([ue("ir-add-device-dialog")],Xi);let Zi=class extends re{constructor(){super(...arguments),this.deviceId="",this.disabled=!1,this._editing=!1,this._draft=""}updated(e){if(e.has("_editing")&&this._editing){const e=this.shadowRoot?.querySelector(".alias-input");e?.focus(),e?.select()}}_startEdit(e){this.disabled||(e?.stopPropagation(),this._draft=this.signal.alias??"",this._editing=!0)}_onKeydown(e){"Enter"===e.key?this._commit():"Escape"===e.key&&(this._editing=!1)}async _commit(){if(!this._editing)return;const e=this._draft.trim();this._editing=!1,await this._save(e)}async _clear(){this._editing=!1,await this._save("")}async _save(e){try{await this.api.setSignalAlias(this.deviceId,this.signal.id,e),this.dispatchEvent(new CustomEvent("alias-changed",{detail:{id:this.signal.id,alias:e},bubbles:!0,composed:!0}))}catch(e){this.dispatchEvent(new CustomEvent("alias-error",{detail:e.message,bubbles:!0,composed:!0}))}}render(){const e=this.signal;return this._editing?F`
+    `,e([he({attribute:!1})],Ki.prototype,"api",void 0),e([he({attribute:!1})],Ki.prototype,"hass",void 0),e([pe()],Ki.prototype,"_name",void 0),e([pe()],Ki.prototype,"_deviceType",void 0),e([pe()],Ki.prototype,"_emitterIds",void 0),e([pe()],Ki.prototype,"_captureProviders",void 0),e([pe()],Ki.prototype,"_busy",void 0),e([pe()],Ki.prototype,"_error",void 0),Ki=e([ue("ir-add-device-dialog")],Ki);let Gi=class extends ne{constructor(){super(...arguments),this.deviceId="",this.disabled=!1,this._editing=!1,this._draft=""}updated(e){if(e.has("_editing")&&this._editing){const e=this.shadowRoot?.querySelector(".alias-input");e?.focus(),e?.select()}}_startEdit(e){this.disabled||(e?.stopPropagation(),this._draft=this.signal.alias??"",this._editing=!0)}_onKeydown(e){"Enter"===e.key?this._commit():"Escape"===e.key&&(this._editing=!1)}async _commit(){if(!this._editing)return;const e=this._draft.trim();this._editing=!1,await this._save(e)}async _clear(){this._editing=!1,await this._save("")}async _save(e){try{await this.api.setSignalAlias(this.deviceId,this.signal.id,e),this.dispatchEvent(new CustomEvent("alias-changed",{detail:{id:this.signal.id,alias:e},bubbles:!0,composed:!0}))}catch(e){this.dispatchEvent(new CustomEvent("alias-error",{detail:e.message,bubbles:!0,composed:!0}))}}render(){const e=this.signal;return this._editing?B`
                 <span class="alias-edit" @click=${e=>e.stopPropagation()}>
                     <input
                         class="alias-input"
@@ -2768,7 +3025,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                         @click=${()=>{this._clear()}}
                     >✕</button>
                 </span>
-            `:e.alias?F`
+            `:e.alias?B`
                 <span
                     class="alias-display ${this.disabled?"locked":""}"
                     title=${this.disabled?"":"Click to edit alias"}
@@ -2777,18 +3034,18 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     <span class="alias-label">alias</span>
                     <span class="alias-name">${e.alias}</span>
                 </span>
-            `:F`
+            `:B`
             <span
                 class="diamonds-wrap ${this.disabled?"locked":""}"
                 title=${this.disabled?"":"Click to name this signal"}
                 @click=${e=>this._startEdit(e)}
             >
-                ${e.sl_pattern?F`<span class="diamonds"
-                          >${[...e.sl_pattern].map(e=>"L"===e?F`<span class="diamond long">◆</span>`:F`<span class="diamond short">◇</span>`)}</span
-                      >`:F`<span class="signal-short-label">IR Signal</span>`}
+                ${e.sl_pattern?B`<span class="diamonds"
+                          >${[...e.sl_pattern].map(e=>"L"===e?B`<span class="diamond long">◆</span>`:B`<span class="diamond short">◇</span>`)}</span
+                      >`:B`<span class="signal-short-label">IR Signal</span>`}
                 <ha-svg-icon class="alias-pencil" .path=${"M14.06,9L15,9.94L5.92,19H5V18.08L14.06,9M17.66,3C17.41,3 17.15,3.1 16.96,3.29L15.13,5.12L18.88,8.87L20.71,7.04C21.1,6.65 21.1,6.02 20.71,5.63L18.37,3.29C18.17,3.09 17.92,3 17.66,3M14.06,6.19L3,17.25V21H6.75L17.81,9.94L14.06,6.19Z"}></ha-svg-icon>
             </span>
-        `}};Zi.styles=n`
+        `}};Gi.styles=r`
         :host {
             display: inline-flex;
             align-items: center;
@@ -2883,17 +3140,17 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
             color: #e65100;
             border-color: rgba(230, 81, 0, 0.4);
         }
-    `,e([he({attribute:!1})],Zi.prototype,"api",void 0),e([he()],Zi.prototype,"deviceId",void 0),e([he({attribute:!1})],Zi.prototype,"signal",void 0),e([he({type:Boolean})],Zi.prototype,"disabled",void 0),e([pe()],Zi.prototype,"_editing",void 0),e([pe()],Zi.prototype,"_draft",void 0),Zi=e([ue("ir-signal-alias")],Zi);const Yi=[{value:"media_player",label:"Media Player"},{value:"ac",label:"Air Conditioner"},{value:"fan",label:"Fan"},{value:"light",label:"Light"},{value:"switch",label:"Switch"},{value:"screen",label:"Screen / Shade"},{value:"other",label:"Other"}];let Wi=class extends re{constructor(){super(...arguments),this.suggestedDeviceName="",this.initialMode="existing",this._mode="existing",this._devices=[],this._selectedDeviceId="",this._commandName="",this._newName="",this._newType="media_player",this._newEmitterIds=[],this._templates=[],this._customCommand=!1,this._sendCount=1,this._dittoCount=1,this._busy=!1,this._error=null}connectedCallback(){super.connectedCallback(),this._mode=this.initialMode,this.suggestedDeviceName&&!this._newName&&(this._newName=this.suggestedDeviceName),this._dittoCount=this.signal?.repeat_count??1,this._loadDevices(),"new"===this._mode&&this._loadTemplates(this._newType)}async _loadDevices(){try{if(this._devices=await this.api.listDevices(),this.suggestedDeviceName&&!this._selectedDeviceId){const e=this.suggestedDeviceName.toLowerCase(),t=this._devices.find(t=>t.name.toLowerCase()===e);if(t)return this._selectedDeviceId=t.id,void this._loadTemplates(t.device_type)}if("existing"===this._mode&&this._devices.length>0){const e=this._devices[0];this._loadTemplates(e.device_type)}else"existing"===this._mode&&this._loadTemplates("other")}catch{"existing"===this._mode&&this._loadTemplates("other")}}async _loadTemplates(e){try{this._templates=await this.api.listTemplates(e)}catch{this._templates=[]}this._customCommand||(this._commandName="")}_activeDeviceType(){if("new"===this._mode)return this._newType;const e=this._devices.find(e=>e.id===this._selectedDeviceId);return e?.device_type??"other"}_onDeviceSelected(e){this._selectedDeviceId=e.target.value;const t=this._devices.find(e=>e.id===this._selectedDeviceId);t&&this._loadTemplates(t.device_type)}_onNewTypeChanged(e){this._newType=e.target.value,this._loadTemplates(this._newType)}_switchMode(e){e!==this._mode&&(this._mode=e,this._customCommand=!1,this._commandName="",this._loadTemplates(this._activeDeviceType()))}_close(){this.dispatchEvent(new CustomEvent("closed",{bubbles:!0,composed:!0}))}_onSendCountInput(e){const t=parseInt(e.target.value,10);this._sendCount=Number.isNaN(t)?1:Math.max(1,Math.min(t,10))}_onDittoInput(e){const t=parseInt(e.target.value,10);this._dittoCount=Number.isNaN(t)?0:Math.max(0,Math.min(t,20))}async _assign(){const e=this._commandName.trim();if(e){this._busy=!0,this._error=null;try{let t;if("existing"===this._mode){if(!this._selectedDeviceId)return this._error="Select a target device.",void(this._busy=!1);t=await this.api.assignSignal({device_id:this.unknownDeviceId,signal_id:this.signal.id,hair_device_id:this._selectedDeviceId,command_name:e,send_count:this._sendCount,repeat_count:this.signal.decoded_fingerprint?this._dittoCount:void 0})}else{if(!this._newName.trim())return this._error="Device name is required.",void(this._busy=!1);if(0===this._newEmitterIds.length)return this._error="Select at least one IR emitter.",void(this._busy=!1);t=await this.api.assignToNewDevice({device_id:this.unknownDeviceId,signal_id:this.signal.id,device_name:this._newName.trim(),device_type:this._newType,emitter_entity_ids:this._newEmitterIds,command_name:e,send_count:this._sendCount,repeat_count:this.signal.decoded_fingerprint?this._dittoCount:void 0})}t.assigned?this.dispatchEvent(new CustomEvent("signal-assigned",{detail:t,bubbles:!0,composed:!0})):this._error="Assignment failed. The signal may have a duplicate code on the target device."}catch(e){this._error=e.message}finally{this._busy=!1}}else this._error="Command name is required."}_fmtTime(e){try{return new Date(e).toLocaleString(void 0,{month:"short",day:"numeric",hour:"2-digit",minute:"2-digit"})}catch{return e}}render(){const e=this.signal.frequency?`${Math.round(this.signal.frequency/1e3)}kHz`:"";return F`
+    `,e([he({attribute:!1})],Gi.prototype,"api",void 0),e([he()],Gi.prototype,"deviceId",void 0),e([he({attribute:!1})],Gi.prototype,"signal",void 0),e([he({type:Boolean})],Gi.prototype,"disabled",void 0),e([pe()],Gi.prototype,"_editing",void 0),e([pe()],Gi.prototype,"_draft",void 0),Gi=e([ue("ir-signal-alias")],Gi);const Ji=[{value:"media_player",label:"Media Player"},{value:"ac",label:"Air Conditioner"},{value:"fan",label:"Fan"},{value:"light",label:"Light"},{value:"switch",label:"Switch"},{value:"screen",label:"Screen / Shade"},{value:"other",label:"Other"}];let Qi=class extends ne{constructor(){super(...arguments),this.suggestedDeviceName="",this.initialMode="existing",this._mode="existing",this._devices=[],this._selectedDeviceId="",this._commandName="",this._newName="",this._newType="media_player",this._newEmitterIds=[],this._templates=[],this._customCommand=!1,this._sendCount=1,this._dittoCount=1,this._busy=!1,this._error=null}connectedCallback(){super.connectedCallback(),this._mode=this.initialMode,this.suggestedDeviceName&&!this._newName&&(this._newName=this.suggestedDeviceName),this._dittoCount=this.signal?.repeat_count??1,this._loadDevices(),"new"===this._mode&&this._loadTemplates(this._newType)}async _loadDevices(){try{if(this._devices=await this.api.listDevices(),this.suggestedDeviceName&&!this._selectedDeviceId){const e=this.suggestedDeviceName.toLowerCase(),t=this._devices.find(t=>t.name.toLowerCase()===e);if(t)return this._selectedDeviceId=t.id,void this._loadTemplates(t.device_type)}if("existing"===this._mode&&this._devices.length>0){const e=this._devices[0];this._loadTemplates(e.device_type)}else"existing"===this._mode&&this._loadTemplates("other")}catch{"existing"===this._mode&&this._loadTemplates("other")}}async _loadTemplates(e){try{this._templates=await this.api.listTemplates(e)}catch{this._templates=[]}this._customCommand||(this._commandName="")}_activeDeviceType(){if("new"===this._mode)return this._newType;const e=this._devices.find(e=>e.id===this._selectedDeviceId);return e?.device_type??"other"}_onDeviceSelected(e){this._selectedDeviceId=e.target.value;const t=this._devices.find(e=>e.id===this._selectedDeviceId);t&&this._loadTemplates(t.device_type)}_onNewTypeChanged(e){this._newType=e.target.value,this._loadTemplates(this._newType)}_switchMode(e){e!==this._mode&&(this._mode=e,this._customCommand=!1,this._commandName="",this._loadTemplates(this._activeDeviceType()))}_close(){this.dispatchEvent(new CustomEvent("closed",{bubbles:!0,composed:!0}))}_onSendCountInput(e){const t=parseInt(e.target.value,10);this._sendCount=Number.isNaN(t)?1:Math.max(1,Math.min(t,10))}_onDittoInput(e){const t=parseInt(e.target.value,10);this._dittoCount=Number.isNaN(t)?0:Math.max(0,Math.min(t,20))}async _assign(){const e=this._commandName.trim();if(e){this._busy=!0,this._error=null;try{let t;if("existing"===this._mode){if(!this._selectedDeviceId)return this._error="Select a target device.",void(this._busy=!1);t=await this.api.assignSignal({device_id:this.unknownDeviceId,signal_id:this.signal.id,hair_device_id:this._selectedDeviceId,command_name:e,send_count:this._sendCount,repeat_count:this.signal.decoded_fingerprint?this._dittoCount:void 0})}else{if(!this._newName.trim())return this._error="Device name is required.",void(this._busy=!1);if(0===this._newEmitterIds.length)return this._error="Select at least one IR emitter.",void(this._busy=!1);t=await this.api.assignToNewDevice({device_id:this.unknownDeviceId,signal_id:this.signal.id,device_name:this._newName.trim(),device_type:this._newType,emitter_entity_ids:this._newEmitterIds,command_name:e,send_count:this._sendCount,repeat_count:this.signal.decoded_fingerprint?this._dittoCount:void 0})}t.assigned?this.dispatchEvent(new CustomEvent("signal-assigned",{detail:t,bubbles:!0,composed:!0})):this._error="Assignment failed. The signal may have a duplicate code on the target device."}catch(e){this._error=e.message}finally{this._busy=!1}}else this._error="Command name is required."}_fmtTime(e){try{return new Date(e).toLocaleString(void 0,{month:"short",day:"numeric",hour:"2-digit",minute:"2-digit"})}catch{return e}}render(){const e=this.signal.frequency?`${Math.round(this.signal.frequency/1e3)}kHz`:"";return B`
             <ha-dialog
                 open
                 heading="Assign Signal"
                 scrimClickAction=""
                 @closed=${this._close}
             >
-                ${this._error?F`<ha-alert alert-type="error">${this._error}</ha-alert>`:""}
+                ${this._error?B`<ha-alert alert-type="error">${this._error}</ha-alert>`:""}
 
                 <div class="signal-header">
-                    ${this.suggestedDeviceName?F`<div class="device-name">${this.suggestedDeviceName}</div>`:""}
+                    ${this.suggestedDeviceName?B`<div class="device-name">${this.suggestedDeviceName}</div>`:""}
                     <div class="signal-detail">
                         <ir-signal-alias
                             .api=${this.api}
@@ -2904,7 +3161,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     </div>
                     <div class="signal-stats">
                         <span>${this.signal.hit_count} hits</span>
-                        ${e?F`<span>${e}</span>`:""}
+                        ${e?B`<span>${e}</span>`:""}
                         <span>${this._fmtTime(this.signal.last_seen)}</span>
                     </div>
                 </div>
@@ -2947,7 +3204,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     </div>
                 </div>
 
-                ${this.signal.decoded_fingerprint?F`<!-- NEC ditto count (decoded signals only) -->
+                ${this.signal.decoded_fingerprint?B`<!-- NEC ditto count (decoded signals only) -->
                           <div class="field">
                               <label>Ditto count</label>
                               <input
@@ -2983,18 +3240,18 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     </button>
                 </div>
             </ha-dialog>
-        `}_renderExistingMode(){return F`
+        `}_renderExistingMode(){return B`
             <div class="field">
                 <label>Target device</label>
-                ${0===this._devices.length?F`<ha-alert alert-type="info">
+                ${0===this._devices.length?B`<ha-alert alert-type="info">
                           No devices yet. Switch to "New Device" to create one.
-                      </ha-alert>`:F`
+                      </ha-alert>`:B`
                           <select
                               .value=${this._selectedDeviceId}
                               @change=${this._onDeviceSelected}
                           >
                               <option value="" disabled>Select device...</option>
-                              ${this._devices.map(e=>F`
+                              ${this._devices.map(e=>B`
                                       <option
                                           value=${e.id}
                                           ?selected=${this._selectedDeviceId===e.id}
@@ -3005,7 +3262,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                           </select>
                       `}
             </div>
-        `}_renderNewMode(){return F`
+        `}_renderNewMode(){return B`
             <div class="field">
                 <label>Device name</label>
                 <input
@@ -3024,7 +3281,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     .value=${this._newType}
                     @change=${this._onNewTypeChanged}
                 >
-                    ${Yi.map(e=>F`
+                    ${Ji.map(e=>B`
                             <option
                                 value=${e.value}
                                 ?selected=${this._newType===e.value}
@@ -3042,7 +3299,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                 ?disabled=${this._busy}
                 @emitters-changed=${e=>this._newEmitterIds=e.detail.value}
             ></ir-emitter-picker>
-        `}_onCommandSelect(e){const t=e.target.value;"__custom__"===t?(this._customCommand=!0,this._commandName="",this.updateComplete.then(()=>{const e=this.shadowRoot?.querySelector(".custom-cmd-input");e?.focus()})):(this._customCommand=!1,this._commandName=t)}_renderCommandPicker(){return this._customCommand?F`
+        `}_onCommandSelect(e){const t=e.target.value;"__custom__"===t?(this._customCommand=!0,this._commandName="",this.updateComplete.then(()=>{const e=this.shadowRoot?.querySelector(".custom-cmd-input");e?.focus()})):(this._customCommand=!1,this._commandName=t)}_renderCommandPicker(){return this._customCommand?B`
                 <div class="field">
                     <label>Command name</label>
                     <div class="custom-cmd-row">
@@ -3059,7 +3316,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                         >Templates</button>
                     </div>
                 </div>
-            `:F`
+            `:B`
             <div class="field">
                 <label>Command name</label>
                 <select
@@ -3069,7 +3326,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     <option value="" disabled ?selected=${!this._commandName}>
                         Select command...
                     </option>
-                    ${this._templates.map(e=>F`
+                    ${this._templates.map(e=>B`
                             <option
                                 value=${e.name}
                                 ?selected=${this._commandName===e.name}
@@ -3080,7 +3337,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     <option value="__custom__">Custom...</option>
                 </select>
             </div>
-        `}};Wi.styles=n`
+        `}};Qi.styles=r`
         .field {
             display: block;
             margin: 12px 0;
@@ -3272,14 +3529,14 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
         .back-link:hover {
             text-decoration: underline;
         }
-    `,e([he({attribute:!1})],Wi.prototype,"api",void 0),e([he({attribute:!1})],Wi.prototype,"hass",void 0),e([he()],Wi.prototype,"unknownDeviceId",void 0),e([he({attribute:!1})],Wi.prototype,"signal",void 0),e([he()],Wi.prototype,"suggestedDeviceName",void 0),e([he()],Wi.prototype,"initialMode",void 0),e([pe()],Wi.prototype,"_mode",void 0),e([pe()],Wi.prototype,"_devices",void 0),e([pe()],Wi.prototype,"_selectedDeviceId",void 0),e([pe()],Wi.prototype,"_commandName",void 0),e([pe()],Wi.prototype,"_newName",void 0),e([pe()],Wi.prototype,"_newType",void 0),e([pe()],Wi.prototype,"_newEmitterIds",void 0),e([pe()],Wi.prototype,"_templates",void 0),e([pe()],Wi.prototype,"_customCommand",void 0),e([pe()],Wi.prototype,"_sendCount",void 0),e([pe()],Wi.prototype,"_dittoCount",void 0),e([pe()],Wi.prototype,"_busy",void 0),e([pe()],Wi.prototype,"_error",void 0),Wi=e([ue("ir-assign-signal-dialog")],Wi);const Ki=[{value:"media_player",label:"Media Player"},{value:"ac",label:"Air Conditioner"},{value:"fan",label:"Fan"},{value:"light",label:"Light"},{value:"switch",label:"Switch"},{value:"screen",label:"Screen / Shade"},{value:"other",label:"Other"}];let Gi=class extends re{constructor(){super(...arguments),this.suggestedName="",this._name="",this._type="other",this._emitterIds=[],this._busy=!1,this._error=null}connectedCallback(){super.connectedCallback(),this.suggestedName&&!this._name&&(this._name=this.suggestedName)}_close(){this.dispatchEvent(new CustomEvent("closed",{bubbles:!0,composed:!0}))}async _create(){const e=this._name.trim();if(e)if(0!==this._emitterIds.length){this._busy=!0,this._error=null;try{await this.api.createDevice({name:e,device_type:this._type,emitter_entity_ids:this._emitterIds}),this.dispatchEvent(new CustomEvent("device-created",{bubbles:!0,composed:!0}))}catch(e){this._error=e.message}finally{this._busy=!1}}else this._error="Select at least one IR emitter.";else this._error="Device name is required."}render(){return F`
+    `,e([he({attribute:!1})],Qi.prototype,"api",void 0),e([he({attribute:!1})],Qi.prototype,"hass",void 0),e([he()],Qi.prototype,"unknownDeviceId",void 0),e([he({attribute:!1})],Qi.prototype,"signal",void 0),e([he()],Qi.prototype,"suggestedDeviceName",void 0),e([he()],Qi.prototype,"initialMode",void 0),e([pe()],Qi.prototype,"_mode",void 0),e([pe()],Qi.prototype,"_devices",void 0),e([pe()],Qi.prototype,"_selectedDeviceId",void 0),e([pe()],Qi.prototype,"_commandName",void 0),e([pe()],Qi.prototype,"_newName",void 0),e([pe()],Qi.prototype,"_newType",void 0),e([pe()],Qi.prototype,"_newEmitterIds",void 0),e([pe()],Qi.prototype,"_templates",void 0),e([pe()],Qi.prototype,"_customCommand",void 0),e([pe()],Qi.prototype,"_sendCount",void 0),e([pe()],Qi.prototype,"_dittoCount",void 0),e([pe()],Qi.prototype,"_busy",void 0),e([pe()],Qi.prototype,"_error",void 0),Qi=e([ue("ir-assign-signal-dialog")],Qi);const es=[{value:"media_player",label:"Media Player"},{value:"ac",label:"Air Conditioner"},{value:"fan",label:"Fan"},{value:"light",label:"Light"},{value:"switch",label:"Switch"},{value:"screen",label:"Screen / Shade"},{value:"other",label:"Other"}];let ts=class extends ne{constructor(){super(...arguments),this.suggestedName="",this._name="",this._type="other",this._emitterIds=[],this._busy=!1,this._error=null}connectedCallback(){super.connectedCallback(),this.suggestedName&&!this._name&&(this._name=this.suggestedName)}_close(){this.dispatchEvent(new CustomEvent("closed",{bubbles:!0,composed:!0}))}async _create(){const e=this._name.trim();if(e)if(0!==this._emitterIds.length){this._busy=!0,this._error=null;try{await this.api.createDevice({name:e,device_type:this._type,emitter_entity_ids:this._emitterIds}),this.dispatchEvent(new CustomEvent("device-created",{bubbles:!0,composed:!0}))}catch(e){this._error=e.message}finally{this._busy=!1}}else this._error="Select at least one IR emitter.";else this._error="Device name is required."}render(){return B`
             <ha-dialog
                 open
                 heading="Promote to Device"
                 scrimClickAction=""
                 @closed=${this._close}
             >
-                ${this._error?F`<ha-alert alert-type="error">${this._error}</ha-alert>`:""}
+                ${this._error?B`<ha-alert alert-type="error">${this._error}</ha-alert>`:""}
 
                 <p class="description">
                     Create a new HAIR device. You can then assign captured
@@ -3299,7 +3556,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                         .value=${this._type}
                         @change=${e=>this._type=e.target.value}
                     >
-                        ${Ki.map(e=>F`
+                        ${es.map(e=>B`
                                 <option
                                     value=${e.value}
                                     ?selected=${this._type===e.value}
@@ -3335,7 +3592,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     </button>
                 </div>
             </ha-dialog>
-        `}};Gi.styles=n`
+        `}};ts.styles=r`
         ha-textfield,
         .field {
             display: block;
@@ -3401,7 +3658,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
         .create-btn:hover:not(:disabled) {
             opacity: 0.9;
         }
-    `,e([he({attribute:!1})],Gi.prototype,"api",void 0),e([he({attribute:!1})],Gi.prototype,"hass",void 0),e([he()],Gi.prototype,"suggestedName",void 0),e([pe()],Gi.prototype,"_name",void 0),e([pe()],Gi.prototype,"_type",void 0),e([pe()],Gi.prototype,"_emitterIds",void 0),e([pe()],Gi.prototype,"_busy",void 0),e([pe()],Gi.prototype,"_error",void 0),Gi=e([ue("ir-promote-dialog")],Gi);let Ji=class extends re{constructor(){super(...arguments),this.value=[],this.busy=!1,this._local=[]}connectedCallback(){super.connectedCallback(),this._local=[...this.value]}_close(){this.dispatchEvent(new CustomEvent("closed",{bubbles:!0,composed:!0}))}_send(){0!==this._local.length&&this.dispatchEvent(new CustomEvent("send",{detail:{emitters:[...this._local]},bubbles:!0,composed:!0}))}_onEmittersChanged(e){this._local=e.detail.value,this.dispatchEvent(new CustomEvent("emitters-changed",{detail:{value:this._local},bubbles:!0,composed:!0}))}render(){const e=this._local.length>0&&!this.busy;return F`
+    `,e([he({attribute:!1})],ts.prototype,"api",void 0),e([he({attribute:!1})],ts.prototype,"hass",void 0),e([he()],ts.prototype,"suggestedName",void 0),e([pe()],ts.prototype,"_name",void 0),e([pe()],ts.prototype,"_type",void 0),e([pe()],ts.prototype,"_emitterIds",void 0),e([pe()],ts.prototype,"_busy",void 0),e([pe()],ts.prototype,"_error",void 0),ts=e([ue("ir-promote-dialog")],ts);let is=class extends ne{constructor(){super(...arguments),this.value=[],this.busy=!1,this._local=[]}connectedCallback(){super.connectedCallback(),this._local=[...this.value]}_close(){this.dispatchEvent(new CustomEvent("closed",{bubbles:!0,composed:!0}))}_send(){0!==this._local.length&&this.dispatchEvent(new CustomEvent("send",{detail:{emitters:[...this._local]},bubbles:!0,composed:!0}))}_onEmittersChanged(e){this._local=e.detail.value,this.dispatchEvent(new CustomEvent("emitters-changed",{detail:{value:this._local},bubbles:!0,composed:!0}))}render(){const e=this._local.length>0&&!this.busy;return B`
             <ha-dialog
                 open
                 heading="Send from"
@@ -3433,7 +3690,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     </button>
                 </div>
             </ha-dialog>
-        `}};var Qi;function es(e){try{return new Date(e).toLocaleString(void 0,{month:"short",day:"numeric",hour:"2-digit",minute:"2-digit"})}catch{return e}}function ts(e){try{const t=Date.now()-new Date(e).getTime();return t<6e4?"just now":t<36e5?`${Math.floor(t/6e4)} min ago`:t<864e5?`${Math.floor(t/36e5)}h ago`:`${Math.floor(t/864e5)}d ago`}catch{return""}}Ji.styles=n`
+        `}};var ss;function os(e){try{return new Date(e).toLocaleString(void 0,{month:"short",day:"numeric",hour:"2-digit",minute:"2-digit"})}catch{return e}}function as(e){try{const t=Date.now()-new Date(e).getTime();return t<6e4?"just now":t<36e5?`${Math.floor(t/6e4)} min ago`:t<864e5?`${Math.floor(t/36e5)}h ago`:`${Math.floor(t/864e5)}d ago`}catch{return""}}is.styles=r`
         .dialog-actions {
             display: flex;
             justify-content: flex-end;
@@ -3469,23 +3726,23 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
         .send-btn:hover:not(:disabled) {
             opacity: 0.9;
         }
-    `,e([he({attribute:!1})],Ji.prototype,"api",void 0),e([he({attribute:!1})],Ji.prototype,"hass",void 0),e([he({attribute:!1})],Ji.prototype,"value",void 0),e([he({type:Boolean})],Ji.prototype,"busy",void 0),e([pe()],Ji.prototype,"_local",void 0),Ji=e([ue("ir-test-emitter-dialog")],Ji);const is="M12 9.188c-1.553 0-2.812 1.259-2.812 2.812s1.259 2.812 2.812 2.812c1.553 0 2.812-1.259 2.812-2.812v0c-0.002-1.552-1.26-2.81-2.812-2.812h-0zM12 13.688c-0.932 0-1.688-0.755-1.688-1.688s0.755-1.688 1.688-1.688c0.932 0 1.688 0.755 1.688 1.688v0c-0.002 0.931-0.756 1.686-1.688 1.688h-0zM2.062 12c0.16-2.665 1.25-5.049 2.948-6.856l-0.005 0.006c0.098-0.101 0.159-0.239 0.159-0.392 0-0.31-0.252-0.562-0.562-0.562-0.153 0-0.291 0.061-0.393 0.16l0-0c-1.906 1.998-3.125 4.667-3.27 7.618l-0.001 0.028c0.146 2.979 1.365 5.647 3.275 7.652l-0.005-0.005c0.101 0.098 0.239 0.159 0.392 0.159 0.31 0 0.562-0.252 0.562-0.562 0-0.152-0.061-0.291-0.16-0.392l0 0c-1.694-1.8-2.785-4.185-2.94-6.821l-0.002-0.03zM6.647 12c0.113-1.859 0.874-3.523 2.058-4.784l-0.004 0.004c0.098-0.101 0.159-0.239 0.159-0.392 0-0.31-0.252-0.562-0.562-0.562-0.153 0-0.291 0.061-0.392 0.16l0-0c-1.39 1.457-2.278 3.403-2.383 5.554l-0.001 0.02c0.105 2.171 0.994 4.117 2.386 5.577l-0.003-0.004c0.102 0.104 0.244 0.167 0.4 0.167 0.31 0 0.562-0.251 0.562-0.562 0-0.156-0.064-0.297-0.167-0.399l-0-0c-1.183-1.256-1.944-2.92-2.053-4.759l-0.001-0.021zM19.793 4.355c-0.102-0.101-0.241-0.164-0.396-0.164-0.31 0-0.562 0.252-0.562 0.562 0 0.154 0.062 0.294 0.162 0.395l-0-0c1.691 1.802 2.782 4.185 2.94 6.82l0.002 0.03c-0.16 2.665-1.249 5.05-2.947 6.857l0.005-0.006c-0.105 0.102-0.17 0.244-0.17 0.403 0 0.31 0.252 0.562 0.562 0.562 0.158 0 0.301-0.065 0.404-0.171l0-0c1.906-1.999 3.125-4.667 3.268-7.618l0.001-0.028c-0.146-2.978-1.364-5.647-3.274-7.65l0.005 0.005zM15.299 6.425c-0.102 0.102-0.165 0.242-0.165 0.398 0 0.154 0.062 0.295 0.164 0.397l-0-0c1.181 1.257 1.942 2.92 2.054 4.758l0.001 0.022c-0.114 1.86-0.875 3.523-2.059 4.784l0.004-0.004c-0.101 0.102-0.164 0.241-0.164 0.396 0 0.311 0.252 0.563 0.563 0.563 0.155 0 0.295-0.062 0.397-0.164l-0 0c1.389-1.458 2.277-3.404 2.383-5.555l0.001-0.02c-0.105-2.172-0.994-4.118-2.388-5.578l0.003 0.003c-0.101-0.102-0.242-0.165-0.397-0.165s-0.295 0.063-0.397 0.165l-0 0z",ss="M7,19V17H9V19H7M11,19V17H13V19H11M15,19V17H17V19H15M7,15V13H9V15H7M11,15V13H13V15H11M15,15V13H17V15H15M7,11V9H9V11H7M11,11V9H13V11H11M15,11V9H17V11H15M7,7V5H9V7H7M11,7V5H13V7H11M15,7V5H17V7H15Z";let as=Qi=class extends re{constructor(){super(...arguments),this._devices=[],this._hairDevices=[],this._loading=!0,this._error=null,this._hasReceivers=!0,this._showDismissed=!1,this._expandedId=null,this._expandedDevice=null,this._flashIds=new Set,this._flashStats=new Set,this._recentSignalIds=[],this._glowSignalIds=new Set,this._hitFlashSignalIds=new Set,this._confirmClearAll=!1,this._triggers=[],this._triggerDialog=null,this._triggerEditDialog=null,this._confirmDeleteTriggerId=null,this._editingDeviceId=null,this._editLabel="",this._promoteTarget=null,this._assignSignal=null,this._deleteSignal=null,this._editSignal=null,this._testingSignalId=null,this._testResult=null,this._testDialog=null,this._testEmitters=[],this._dismissGlowActive=!1,this._dismissDotVisible=!1,this._unsubLive=null,this._unsubRemoved=null,this._unsubDismiss=null,this._dismissGlowTimer=null,this._remotesVersion=0,this._signalsVersion=0,this._remotesSortable=null,this._signalsSortable=null,this._signalsSortableContainer=null,this._pendingRemotesSave=null,this._pendingSignalsSave=null}connectedCallback(){super.connectedCallback(),this._load(),this._subscribeLive(),this._subscribeRemoved(),this._subscribeDismissActivity()}updated(e){if(super.updated(e),e.has("_editingDeviceId")&&this._editingDeviceId){const e=this.shadowRoot?.querySelector(".rename-input");e&&(e.focus(),e.select())}this._syncSortables()}disconnectedCallback(){super.disconnectedCallback(),this._unsubscribeLive(),this._unsubscribeRemoved(),this._unsubscribeDismissActivity(),null!==this._dismissGlowTimer&&(clearTimeout(this._dismissGlowTimer),this._dismissGlowTimer=null),this._remotesSortable?.destroy(),this._remotesSortable=null,this._signalsSortable?.destroy(),this._signalsSortable=null,this._signalsSortableContainer=null,null!==this._pendingRemotesSave&&clearTimeout(this._pendingRemotesSave),null!==this._pendingSignalsSave&&clearTimeout(this._pendingSignalsSave)}_syncSortables(){const e=this.renderRoot.querySelector(".device-list");e&&!this._remotesSortable?this._attachRemotesSortable(e):!e&&this._remotesSortable&&(this._remotesSortable.destroy(),this._remotesSortable=null);const t=this.renderRoot.querySelector(".signal-list"),i=!!this._expandedDevice&&!this._expandedDevice.dismissed;!t||!i||this._signalsSortable&&this._signalsSortableContainer===t?t&&i||!this._signalsSortable||(this._signalsSortable.destroy(),this._signalsSortable=null,this._signalsSortableContainer=null):(this._signalsSortable?.destroy(),this._attachSignalsSortable(t))}_attachRemotesSortable(e){this._remotesSortable=di.create(e,{handle:".remote-grip",animation:150,ghostClass:"sortable-ghost",onEnd:t=>{const{oldIndex:i,newIndex:s}=t;if(void 0===i||void 0===s||i===s)return;const a=[...this._devices],[o]=a.splice(i,1);a.splice(s,0,o),this._devices=a,this._remotesSortable?.destroy(),this._remotesSortable=null,this._purgeChildren(e,"ha-card"),this._remotesVersion++,this._scheduleRemotesSave(a.map(e=>e.id))}})}_attachSignalsSortable(e){this._expandedDevice&&(this._signalsSortableContainer=e,this._signalsSortable=di.create(e,{handle:".signal-grip",animation:150,ghostClass:"sortable-ghost",onEnd:t=>{const{oldIndex:i,newIndex:s}=t;if(void 0===i||void 0===s||i===s)return;const a=this._expandedDevice;if(!a)return;const o=[...a.signals],[n]=o.splice(i,1);o.splice(s,0,n),this._expandedDevice={...a,signals:o},this._signalsSortable?.destroy(),this._signalsSortable=null,this._signalsSortableContainer=null,this._purgeChildren(e,".signal-row"),this._signalsVersion++,this._scheduleSignalsSave(a.id,o.map(e=>e.id))}}))}_purgeChildren(e,t){for(const i of Array.from(e.querySelectorAll(t)))i.remove()}_scheduleRemotesSave(e){null!==this._pendingRemotesSave&&clearTimeout(this._pendingRemotesSave),this._pendingRemotesSave=window.setTimeout(async()=>{this._pendingRemotesSave=null;try{await this.api.reorderUnknownDevices("sniffed",e)}catch(e){this._error=`Reorder failed: ${e.message}`,await this._load()}},500)}_scheduleSignalsSave(e,t){null!==this._pendingSignalsSave&&clearTimeout(this._pendingSignalsSave),this._pendingSignalsSave=window.setTimeout(async()=>{this._pendingSignalsSave=null;try{await this.api.reorderUnknownSignals(e,t)}catch(e){this._error=`Reorder failed: ${e.message}`}},500)}async _load(){this._loading=!0;try{const[e,t,i,s]=await Promise.all([this.api.getUnknownDevices({include_dismissed:this._showDismissed,source:"sniffed"}),this.api.listDevices(),this.api.listTriggers(),this.api.getSnifferStatus()]);this._devices=e,this._hairDevices=t,this._triggers=i,this._hasReceivers=s.has_receivers,this._error=null}catch(e){this._error=`Failed to load: ${e.message}`}finally{this._loading=!1}}_matchesHairDevice(e){if(!e)return!1;const t=e.toLowerCase();return this._hairDevices.some(e=>e.name.toLowerCase()===t)}async _subscribeLive(){try{this._unsubLive=await this.api.subscribeUnknownSignals(e=>{this._onLiveSignal(e)})}catch{}}async _unsubscribeLive(){this._unsubLive&&(await this._unsubLive(),this._unsubLive=null)}async _subscribeRemoved(){try{this._unsubRemoved=await this.api.subscribeSignalRemoved(e=>{this._load(),this._expandedId===e.device_id&&(e.device_removed?(this._expandedId=null,this._expandedDevice=null):(this._toggleExpand(e.device_id),this._toggleExpand(e.device_id)))})}catch{}}async _unsubscribeRemoved(){this._unsubRemoved&&(await this._unsubRemoved(),this._unsubRemoved=null)}async _subscribeDismissActivity(){try{this._unsubDismiss=await this.api.subscribeDismissActivity(()=>this._onDismissActivity())}catch{}}async _unsubscribeDismissActivity(){this._unsubDismiss&&(await this._unsubDismiss(),this._unsubDismiss=null)}_onDismissActivity(){this._dismissDotVisible=!0,this._dismissGlowActive=!0,null!==this._dismissGlowTimer&&clearTimeout(this._dismissGlowTimer),this._dismissGlowTimer=setTimeout(()=>{this._dismissGlowActive=!1,this._dismissGlowTimer=null},Qi.DISMISS_GLOW_HOLD_MS)}_startRename(e,t){t.stopPropagation(),this._editingDeviceId=e.id,this._editLabel=e.label??e.protocol??""}async _commitRename(e){const t=this._editLabel.trim();this._editingDeviceId=null;try{const i=await this.api.renameUnknown(e,t),s=this._devices.findIndex(t=>t.id===e);if(s>=0){const e=[...this._devices];e[s]={...e[s],label:i.label},this._devices=e}}catch(e){this._error=`Rename failed: ${e.message}`}}_cancelRename(){this._editingDeviceId=null}_onRenameKeydown(e,t){"Enter"===t.key?this._commitRename(e):"Escape"===t.key&&this._cancelRename()}_promoteDevice(e,t){t.stopPropagation(),this._promoteTarget=e}_closePromote(){this._promoteTarget=null}async _onDevicePromoted(){this._promoteTarget=null,await this._load()}_openAssign(e,t,i,s){this._assignSignal={deviceId:e,signal:t,label:i??null,initialMode:s??"existing"}}_closeAssign(){this._assignSignal=null}async _onSignalAssigned(e){if(this._assignSignal=null,await this._load(),this._expandedId)try{this._expandedDevice=await this.api.getUnknownDevice(this._expandedId)}catch{this._expandedId=null,this._expandedDevice=null}}_openDelete(e,t){this._deleteSignal={deviceId:e,signal:t}}_closeDelete(){this._deleteSignal=null}_openEditSignal(e,t,i){i.stopPropagation(),this._editSignal={deviceId:e,signal:t}}async _onSignalEdited(){if(this._editSignal=null,await this._load(),this._expandedId)try{this._expandedDevice=await this.api.getUnknownDevice(this._expandedId)}catch{this._expandedId=null,this._expandedDevice=null}}async _confirmDelete(){if(!this._deleteSignal)return;const{deviceId:e,signal:t}=this._deleteSignal;this._deleteSignal=null;try{await this.api.deleteSignal(e,t.id),await this._load()}catch(e){this._error=`Delete failed: ${e.message}`}}_openTestDialog(e){this._testDialog={signal:e}}_closeTestDialog(){this._testDialog=null}async _sendTest(e){if(!this._testDialog)return;const{signal:t}=this._testDialog,i=e.detail.emitters;if(0!==i.length){this._testingSignalId=t.id,this._testResult=null,this._testDialog=null;try{const e=(await Promise.allSettled(i.map(e=>this.api.testSignal(t.id,e)))).filter(e=>"fulfilled"===e.status&&e.value.sent).length,s=i.length;this._testResult=e===s?1===s?"Sent!":`Sent! (${e}/${s})`:0===e?"Failed":`Sent (${e}/${s})`}catch{this._testResult="Error"}setTimeout(()=>{this._testResult=null,this._testingSignalId=null},3e3)}}_hasTrigger(e){return this._triggers.some(t=>t.signal_fingerprint===e)}_openTriggerDialog(e,t){const i=this._triggers.find(e=>e.signal_fingerprint===t.fingerprint);i?this._triggerEditDialog=i:this._triggerDialog={signal:t,deviceId:e}}_closeTriggerDialog(){this._triggerDialog=null,this._triggerEditDialog=null}_requestDeleteTrigger(e){this._confirmDeleteTriggerId=e}async _doDeleteTrigger(){if(!this._confirmDeleteTriggerId)return;const e=this._confirmDeleteTriggerId;this._confirmDeleteTriggerId=null,this._triggerEditDialog=null;try{await this.api.deleteTrigger(e),this._triggers=await this.api.listTriggers()}catch{}}async _onTriggerSaved(){this._triggerDialog=null,this._triggerEditDialog=null;try{this._triggers=await this.api.listTriggers()}catch{}}_onLiveSignal(e){const t=(new Date).toISOString(),i=this._devices.findIndex(t=>t.id===e.device_id);if(i>=0){{const s={...this._devices[i]};s.hit_count=e.device_hit_count??e.hit_count,s.last_seen=t,1===e.hit_count&&(s.signal_count=(s.signal_count??0)+1);const a=[...this._devices];a[i]=s,this._devices=a}if(this._expandedDevice&&this._expandedId===e.device_id){const i=this._expandedDevice.signals.findIndex(t=>t.id===e.signal_id);if(i>=0){const s={...this._expandedDevice.signals[i]};s.hit_count=e.hit_count,s.last_seen=t;const a=[...this._expandedDevice.signals];a[i]=s,this._expandedDevice={...this._expandedDevice,hit_count:e.device_hit_count??e.hit_count,last_seen:t,signals:a}}else this.api.getUnknownDevice(e.device_id).then(t=>{if(this._expandedId===e.device_id){this._expandedDevice=t;const i=this._devices.findIndex(t=>t.id===e.device_id);if(i>=0){const e={...this._devices[i],signal_count:t.signals.length},s=[...this._devices];s[i]=e,this._devices=s}}}).catch(()=>{})}if(this._flashIds=new Set([...this._flashIds,e.device_id]),setTimeout(()=>{const t=new Set(this._flashIds);t.delete(e.device_id),this._flashIds=t},800),this._flashStats=new Set([...this._flashStats,e.device_id]),setTimeout(()=>{const t=new Set(this._flashStats);t.delete(e.device_id),this._flashStats=t},1500),e.signal_id){const t=[e.signal_id,...this._recentSignalIds.filter(t=>t!==e.signal_id)].slice(0,2);this._recentSignalIds=t,this._glowSignalIds=new Set([...this._glowSignalIds,e.signal_id]),setTimeout(()=>{const t=new Set(this._glowSignalIds);t.delete(e.signal_id),this._glowSignalIds=t},1200),this._hitFlashSignalIds=new Set([...this._hitFlashSignalIds,e.signal_id]),setTimeout(()=>{const t=new Set(this._hitFlashSignalIds);t.delete(e.signal_id),this._hitFlashSignalIds=t},1200)}}else this._load()}_onAliasChanged(e){const{id:t,alias:i}=e.detail;this._expandedDevice&&(this._expandedDevice={...this._expandedDevice,signals:this._expandedDevice.signals.map(e=>e.id===t?{...e,alias:i}:e)})}async _toggleExpand(e){if(this._expandedId===e)return this._expandedId=null,void(this._expandedDevice=null);this._expandedId=e;try{this._expandedDevice=await this.api.getUnknownDevice(e)}catch{this._expandedDevice=null}}async _dismiss(e){try{await this.api.dismissUnknown(e),await this._load(),this._expandedId===e&&(this._expandedId=null,this._expandedDevice=null)}catch(e){this._error=`Dismiss failed: ${e.message}`}}async _undismiss(e){try{await this.api.undismissUnknown(e),await this._load()}catch(e){this._error=`Restore failed: ${e.message}`}}async _doClearAll(){this._confirmClearAll=!1;try{await this.api.clearUnknowns(),this._devices=[],this._expandedId=null,this._expandedDevice=null}catch(e){this._error=`Clear failed: ${e.message}`}}_toggleDismissed(){this._showDismissed=!this._showDismissed,this._dismissDotVisible=!1,this._load()}render(){return F`
+    `,e([he({attribute:!1})],is.prototype,"api",void 0),e([he({attribute:!1})],is.prototype,"hass",void 0),e([he({attribute:!1})],is.prototype,"value",void 0),e([he({type:Boolean})],is.prototype,"busy",void 0),e([pe()],is.prototype,"_local",void 0),is=e([ue("ir-test-emitter-dialog")],is);const rs="M12 9.188c-1.553 0-2.812 1.259-2.812 2.812s1.259 2.812 2.812 2.812c1.553 0 2.812-1.259 2.812-2.812v0c-0.002-1.552-1.26-2.81-2.812-2.812h-0zM12 13.688c-0.932 0-1.688-0.755-1.688-1.688s0.755-1.688 1.688-1.688c0.932 0 1.688 0.755 1.688 1.688v0c-0.002 0.931-0.756 1.686-1.688 1.688h-0zM2.062 12c0.16-2.665 1.25-5.049 2.948-6.856l-0.005 0.006c0.098-0.101 0.159-0.239 0.159-0.392 0-0.31-0.252-0.562-0.562-0.562-0.153 0-0.291 0.061-0.393 0.16l0-0c-1.906 1.998-3.125 4.667-3.27 7.618l-0.001 0.028c0.146 2.979 1.365 5.647 3.275 7.652l-0.005-0.005c0.101 0.098 0.239 0.159 0.392 0.159 0.31 0 0.562-0.252 0.562-0.562 0-0.152-0.061-0.291-0.16-0.392l0 0c-1.694-1.8-2.785-4.185-2.94-6.821l-0.002-0.03zM6.647 12c0.113-1.859 0.874-3.523 2.058-4.784l-0.004 0.004c0.098-0.101 0.159-0.239 0.159-0.392 0-0.31-0.252-0.562-0.562-0.562-0.153 0-0.291 0.061-0.392 0.16l0-0c-1.39 1.457-2.278 3.403-2.383 5.554l-0.001 0.02c0.105 2.171 0.994 4.117 2.386 5.577l-0.003-0.004c0.102 0.104 0.244 0.167 0.4 0.167 0.31 0 0.562-0.251 0.562-0.562 0-0.156-0.064-0.297-0.167-0.399l-0-0c-1.183-1.256-1.944-2.92-2.053-4.759l-0.001-0.021zM19.793 4.355c-0.102-0.101-0.241-0.164-0.396-0.164-0.31 0-0.562 0.252-0.562 0.562 0 0.154 0.062 0.294 0.162 0.395l-0-0c1.691 1.802 2.782 4.185 2.94 6.82l0.002 0.03c-0.16 2.665-1.249 5.05-2.947 6.857l0.005-0.006c-0.105 0.102-0.17 0.244-0.17 0.403 0 0.31 0.252 0.562 0.562 0.562 0.158 0 0.301-0.065 0.404-0.171l0-0c1.906-1.999 3.125-4.667 3.268-7.618l0.001-0.028c-0.146-2.978-1.364-5.647-3.274-7.65l0.005 0.005zM15.299 6.425c-0.102 0.102-0.165 0.242-0.165 0.398 0 0.154 0.062 0.295 0.164 0.397l-0-0c1.181 1.257 1.942 2.92 2.054 4.758l0.001 0.022c-0.114 1.86-0.875 3.523-2.059 4.784l0.004-0.004c-0.101 0.102-0.164 0.241-0.164 0.396 0 0.311 0.252 0.563 0.563 0.563 0.155 0 0.295-0.062 0.397-0.164l-0 0c1.389-1.458 2.277-3.404 2.383-5.555l0.001-0.02c-0.105-2.172-0.994-4.118-2.388-5.578l0.003 0.003c-0.101-0.102-0.242-0.165-0.397-0.165s-0.295 0.063-0.397 0.165l-0 0z",ns="M7,19V17H9V19H7M11,19V17H13V19H11M15,19V17H17V19H15M7,15V13H9V15H7M11,15V13H13V15H11M15,15V13H17V15H15M7,11V9H9V11H7M11,11V9H13V11H11M15,11V9H17V11H15M7,7V5H9V7H7M11,7V5H13V7H11M15,7V5H17V7H15Z";let ls=ss=class extends ne{constructor(){super(...arguments),this._devices=[],this._hairDevices=[],this._loading=!0,this._error=null,this._hasReceivers=!0,this._showDismissed=!1,this._expandedId=null,this._expandedDevice=null,this._flashIds=new Set,this._flashStats=new Set,this._recentSignalIds=[],this._glowSignalIds=new Set,this._hitFlashSignalIds=new Set,this._confirmClearAll=!1,this._triggers=[],this._triggerDialog=null,this._triggerEditDialog=null,this._confirmDeleteTriggerId=null,this._triggerPopover=null,this._receivers=[],this._unsubUpdated=null,this._editingDeviceId=null,this._editLabel="",this._promoteTarget=null,this._assignSignal=null,this._deleteSignal=null,this._editSignal=null,this._testingSignalId=null,this._testResult=null,this._testDialog=null,this._testEmitters=[],this._dismissGlowActive=!1,this._dismissDotVisible=!1,this._unsubLive=null,this._unsubRemoved=null,this._unsubDismiss=null,this._dismissGlowTimer=null,this._remotesVersion=0,this._signalsVersion=0,this._remotesSortable=null,this._signalsSortable=null,this._signalsSortableContainer=null,this._pendingRemotesSave=null,this._pendingSignalsSave=null,this._onDocClickForPopover=e=>{const t=this.shadowRoot?.querySelector("ir-trigger-popover");t&&e.composedPath().includes(t)||this._closeTriggerPopover()},this._onScrollForPopover=()=>{this._closeTriggerPopover()}}connectedCallback(){super.connectedCallback(),this._load(),this._subscribeLive(),this._subscribeRemoved(),this._subscribeDismissActivity(),this._subscribeUpdated()}updated(e){if(super.updated(e),e.has("_editingDeviceId")&&this._editingDeviceId){const e=this.shadowRoot?.querySelector(".rename-input");e&&(e.focus(),e.select())}this._syncSortables()}disconnectedCallback(){super.disconnectedCallback(),this._unsubscribeLive(),this._unsubscribeRemoved(),this._unsubscribeDismissActivity(),this._unsubscribeUpdated(),this._removePopoverDismiss(),null!==this._dismissGlowTimer&&(clearTimeout(this._dismissGlowTimer),this._dismissGlowTimer=null),this._remotesSortable?.destroy(),this._remotesSortable=null,this._signalsSortable?.destroy(),this._signalsSortable=null,this._signalsSortableContainer=null,null!==this._pendingRemotesSave&&clearTimeout(this._pendingRemotesSave),null!==this._pendingSignalsSave&&clearTimeout(this._pendingSignalsSave)}_syncSortables(){const e=this.renderRoot.querySelector(".device-list");e&&!this._remotesSortable?this._attachRemotesSortable(e):!e&&this._remotesSortable&&(this._remotesSortable.destroy(),this._remotesSortable=null);const t=this.renderRoot.querySelector(".signal-list"),i=!!this._expandedDevice&&!this._expandedDevice.dismissed;!t||!i||this._signalsSortable&&this._signalsSortableContainer===t?t&&i||!this._signalsSortable||(this._signalsSortable.destroy(),this._signalsSortable=null,this._signalsSortableContainer=null):(this._signalsSortable?.destroy(),this._attachSignalsSortable(t))}_attachRemotesSortable(e){this._remotesSortable=di.create(e,{handle:".remote-grip",animation:150,ghostClass:"sortable-ghost",onEnd:t=>{const{oldIndex:i,newIndex:s}=t;if(void 0===i||void 0===s||i===s)return;const o=[...this._devices],[a]=o.splice(i,1);o.splice(s,0,a),this._devices=o,this._remotesSortable?.destroy(),this._remotesSortable=null,this._purgeChildren(e,"ha-card"),this._remotesVersion++,this._scheduleRemotesSave(o.map(e=>e.id))}})}_attachSignalsSortable(e){this._expandedDevice&&(this._signalsSortableContainer=e,this._signalsSortable=di.create(e,{handle:".signal-grip",animation:150,ghostClass:"sortable-ghost",onEnd:t=>{const{oldIndex:i,newIndex:s}=t;if(void 0===i||void 0===s||i===s)return;const o=this._expandedDevice;if(!o)return;const a=[...o.signals],[r]=a.splice(i,1);a.splice(s,0,r),this._expandedDevice={...o,signals:a},this._signalsSortable?.destroy(),this._signalsSortable=null,this._signalsSortableContainer=null,this._purgeChildren(e,".signal-row"),this._signalsVersion++,this._scheduleSignalsSave(o.id,a.map(e=>e.id))}}))}_purgeChildren(e,t){for(const i of Array.from(e.querySelectorAll(t)))i.remove()}_scheduleRemotesSave(e){null!==this._pendingRemotesSave&&clearTimeout(this._pendingRemotesSave),this._pendingRemotesSave=window.setTimeout(async()=>{this._pendingRemotesSave=null;try{await this.api.reorderUnknownDevices("sniffed",e)}catch(e){this._error=`Reorder failed: ${e.message}`,await this._load()}},500)}_scheduleSignalsSave(e,t){null!==this._pendingSignalsSave&&clearTimeout(this._pendingSignalsSave),this._pendingSignalsSave=window.setTimeout(async()=>{this._pendingSignalsSave=null;try{await this.api.reorderUnknownSignals(e,t)}catch(e){this._error=`Reorder failed: ${e.message}`}},500)}async _load(){this._loading=!0;try{const[e,t,i,s]=await Promise.all([this.api.getUnknownDevices({include_dismissed:this._showDismissed,source:"sniffed"}),this.api.listDevices(),this.api.listTriggers(),this.api.getSnifferStatus()]);this._devices=e,this._hairDevices=t,this._triggers=i,this._hasReceivers=s.has_receivers,this._error=null,this.api.listReceivers().then(e=>{this._receivers=e}).catch(()=>{this._receivers=[]})}catch(e){this._error=`Failed to load: ${e.message}`}finally{this._loading=!1}}_matchesHairDevice(e){if(!e)return!1;const t=e.toLowerCase();return this._hairDevices.some(e=>e.name.toLowerCase()===t)}async _subscribeLive(){try{this._unsubLive=await this.api.subscribeUnknownSignals(e=>{this._onLiveSignal(e)})}catch{}}async _unsubscribeLive(){this._unsubLive&&(await this._unsubLive(),this._unsubLive=null)}async _subscribeRemoved(){try{this._unsubRemoved=await this.api.subscribeSignalRemoved(e=>{this._load(),this._expandedId===e.device_id&&(e.device_removed?(this._expandedId=null,this._expandedDevice=null):(this._toggleExpand(e.device_id),this._toggleExpand(e.device_id)))})}catch{}}async _unsubscribeRemoved(){this._unsubRemoved&&(await this._unsubRemoved(),this._unsubRemoved=null)}async _subscribeDismissActivity(){try{this._unsubDismiss=await this.api.subscribeDismissActivity(()=>this._onDismissActivity())}catch{}}async _unsubscribeDismissActivity(){this._unsubDismiss&&(await this._unsubDismiss(),this._unsubDismiss=null)}_onDismissActivity(){this._dismissDotVisible=!0,this._dismissGlowActive=!0,null!==this._dismissGlowTimer&&clearTimeout(this._dismissGlowTimer),this._dismissGlowTimer=setTimeout(()=>{this._dismissGlowActive=!1,this._dismissGlowTimer=null},ss.DISMISS_GLOW_HOLD_MS)}_startRename(e,t){t.stopPropagation(),this._editingDeviceId=e.id,this._editLabel=e.label??e.protocol??""}async _commitRename(e){const t=this._editLabel.trim();this._editingDeviceId=null;try{const i=await this.api.renameUnknown(e,t),s=this._devices.findIndex(t=>t.id===e);if(s>=0){const e=[...this._devices];e[s]={...e[s],label:i.label},this._devices=e}}catch(e){this._error=`Rename failed: ${e.message}`}}_cancelRename(){this._editingDeviceId=null}_onRenameKeydown(e,t){"Enter"===t.key?this._commitRename(e):"Escape"===t.key&&this._cancelRename()}_promoteDevice(e,t){t.stopPropagation(),this._promoteTarget=e}_closePromote(){this._promoteTarget=null}async _onDevicePromoted(){this._promoteTarget=null,await this._load()}_openAssign(e,t,i,s){this._assignSignal={deviceId:e,signal:t,label:i??null,initialMode:s??"existing"}}_closeAssign(){this._assignSignal=null}async _onSignalAssigned(e){if(this._assignSignal=null,await this._load(),this._expandedId)try{this._expandedDevice=await this.api.getUnknownDevice(this._expandedId)}catch{this._expandedId=null,this._expandedDevice=null}}_openDelete(e,t){this._deleteSignal={deviceId:e,signal:t}}_closeDelete(){this._deleteSignal=null}_openEditSignal(e,t,i){i.stopPropagation(),this._editSignal={deviceId:e,signal:t}}async _onSignalEdited(){if(this._editSignal=null,await this._load(),this._expandedId)try{this._expandedDevice=await this.api.getUnknownDevice(this._expandedId)}catch{this._expandedId=null,this._expandedDevice=null}}async _confirmDelete(){if(!this._deleteSignal)return;const{deviceId:e,signal:t}=this._deleteSignal;this._deleteSignal=null;try{await this.api.deleteSignal(e,t.id),await this._load()}catch(e){this._error=`Delete failed: ${e.message}`}}_openTestDialog(e){this._testDialog={signal:e}}_closeTestDialog(){this._testDialog=null}async _sendTest(e){if(!this._testDialog)return;const{signal:t}=this._testDialog,i=e.detail.emitters;if(0!==i.length){this._testingSignalId=t.id,this._testResult=null,this._testDialog=null;try{const e=(await Promise.allSettled(i.map(e=>this.api.testSignal(t.id,e)))).filter(e=>"fulfilled"===e.status&&e.value.sent).length,s=i.length;this._testResult=e===s?1===s?"Sent!":`Sent! (${e}/${s})`:0===e?"Failed":`Sent (${e}/${s})`}catch{this._testResult="Error"}setTimeout(()=>{this._testResult=null,this._testingSignalId=null},3e3)}}_hasTrigger(e){return this._triggers.some(t=>t.signal_fingerprint===e)}_triggerCountFor(e){return this._triggers.filter(t=>t.signal_fingerprint===e).length}_openTriggerDialog(e,t,i){const s=this._triggers.filter(e=>e.signal_fingerprint===t.fingerprint);if(0===s.length)return void(this._triggerDialog={signal:t,deviceId:e});const o=i?.currentTarget,a=o?.getBoundingClientRect();this._triggerPopover={deviceId:e,signal:t,top:a?a.bottom+4:120,left:a?Math.max(8,a.right-220):120},this._installPopoverDismiss()}_closeTriggerPopover(){this._triggerPopover=null,this._removePopoverDismiss()}_onPopoverCreateNew(){const e=this._triggerPopover;this._closeTriggerPopover(),e&&(this._triggerDialog={signal:e.signal,deviceId:e.deviceId})}_onPopoverEditTrigger(e){const t=e.detail;this._closeTriggerPopover(),t&&(this._triggerEditDialog=t)}_installPopoverDismiss(){setTimeout(()=>{document.addEventListener("click",this._onDocClickForPopover,!0),window.addEventListener("scroll",this._onScrollForPopover,!0)},0)}_removePopoverDismiss(){document.removeEventListener("click",this._onDocClickForPopover,!0),window.removeEventListener("scroll",this._onScrollForPopover,!0)}async _subscribeUpdated(){try{this._unsubUpdated=await this.api.subscribeSignalUpdated(()=>{this._refreshAfterSignalUpdate()})}catch{}}async _unsubscribeUpdated(){this._unsubUpdated&&(await this._unsubUpdated(),this._unsubUpdated=null)}async _refreshAfterSignalUpdate(){try{this._triggers=await this.api.listTriggers()}catch{}if(this._expandedId)try{this._expandedDevice=await this.api.getUnknownDevice(this._expandedId)}catch{}}_closeTriggerDialog(){this._triggerDialog=null,this._triggerEditDialog=null}_requestDeleteTrigger(e){this._confirmDeleteTriggerId=e}async _doDeleteTrigger(){if(!this._confirmDeleteTriggerId)return;const e=this._confirmDeleteTriggerId;this._confirmDeleteTriggerId=null,this._triggerEditDialog=null;try{await this.api.deleteTrigger(e),this._triggers=await this.api.listTriggers()}catch{}}async _onTriggerSaved(){this._triggerDialog=null,this._triggerEditDialog=null;try{this._triggers=await this.api.listTriggers()}catch{}}_onLiveSignal(e){const t=(new Date).toISOString(),i=this._devices.findIndex(t=>t.id===e.device_id);if(i>=0){{const s={...this._devices[i]};s.hit_count=e.device_hit_count??e.hit_count,s.last_seen=t,1===e.hit_count&&(s.signal_count=(s.signal_count??0)+1);const o=[...this._devices];o[i]=s,this._devices=o}if(this._expandedDevice&&this._expandedId===e.device_id){const i=this._expandedDevice.signals.findIndex(t=>t.id===e.signal_id);if(i>=0){const s={...this._expandedDevice.signals[i]};s.hit_count=e.hit_count,s.last_seen=t;const o=[...this._expandedDevice.signals];o[i]=s,this._expandedDevice={...this._expandedDevice,hit_count:e.device_hit_count??e.hit_count,last_seen:t,signals:o}}else this.api.getUnknownDevice(e.device_id).then(t=>{if(this._expandedId===e.device_id){this._expandedDevice=t;const i=this._devices.findIndex(t=>t.id===e.device_id);if(i>=0){const e={...this._devices[i],signal_count:t.signals.length},s=[...this._devices];s[i]=e,this._devices=s}}}).catch(()=>{})}if(this._flashIds=new Set([...this._flashIds,e.device_id]),setTimeout(()=>{const t=new Set(this._flashIds);t.delete(e.device_id),this._flashIds=t},800),this._flashStats=new Set([...this._flashStats,e.device_id]),setTimeout(()=>{const t=new Set(this._flashStats);t.delete(e.device_id),this._flashStats=t},1500),e.signal_id){const t=[e.signal_id,...this._recentSignalIds.filter(t=>t!==e.signal_id)].slice(0,2);this._recentSignalIds=t,this._glowSignalIds=new Set([...this._glowSignalIds,e.signal_id]),setTimeout(()=>{const t=new Set(this._glowSignalIds);t.delete(e.signal_id),this._glowSignalIds=t},1200),this._hitFlashSignalIds=new Set([...this._hitFlashSignalIds,e.signal_id]),setTimeout(()=>{const t=new Set(this._hitFlashSignalIds);t.delete(e.signal_id),this._hitFlashSignalIds=t},1200)}}else this._load()}_onAliasChanged(e){const{id:t,alias:i}=e.detail;this._expandedDevice&&(this._expandedDevice={...this._expandedDevice,signals:this._expandedDevice.signals.map(e=>e.id===t?{...e,alias:i}:e)})}async _toggleExpand(e){if(this._expandedId===e)return this._expandedId=null,void(this._expandedDevice=null);this._expandedId=e;try{this._expandedDevice=await this.api.getUnknownDevice(e)}catch{this._expandedDevice=null}}async _dismiss(e){try{await this.api.dismissUnknown(e),await this._load(),this._expandedId===e&&(this._expandedId=null,this._expandedDevice=null)}catch(e){this._error=`Dismiss failed: ${e.message}`}}async _undismiss(e){try{await this.api.undismissUnknown(e),await this._load()}catch(e){this._error=`Restore failed: ${e.message}`}}async _doClearAll(){this._confirmClearAll=!1;try{await this.api.clearUnknowns(),this._devices=[],this._expandedId=null,this._expandedDevice=null}catch(e){this._error=`Clear failed: ${e.message}`}}_toggleDismissed(){this._showDismissed=!this._showDismissed,this._dismissDotVisible=!1,this._load()}render(){return B`
             <div class="toolbar">
                 <span class="title">
-                    <ha-svg-icon .path=${is}></ha-svg-icon>
+                    <ha-svg-icon .path=${rs}></ha-svg-icon>
                     HAIR Sniffer
-                    ${this._loading?"":F`<span class="count"
+                    ${this._loading?"":B`<span class="count"
                               >(${this._devices.length}
                               ${1===this._devices.length?"remote":"remotes"})</span
                           >`}
                 </span>
             </div>
 
-            ${this._error?F`<ha-alert alert-type="error">${this._error}</ha-alert>`:""}
+            ${this._error?B`<ha-alert alert-type="error">${this._error}</ha-alert>`:""}
 
-            ${this._loading?F`<div class="loading">Scanning for signals...</div>`:0===this._devices.length?this._hasReceivers?F`
+            ${this._loading?B`<div class="loading">Scanning for signals...</div>`:0===this._devices.length?this._hasReceivers?B`
                         <ha-card class="empty">
-                            <ha-svg-icon class="empty-icon" .path=${is}></ha-svg-icon>
+                            <ha-svg-icon class="empty-icon" .path=${rs}></ha-svg-icon>
                             <h3>No unknown signals detected</h3>
                             <p>
                                 When unrecognized IR signals are received by your
@@ -3496,9 +3753,9 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                 configured yet.
                             </p>
                         </ha-card>
-                    `:F`
+                    `:B`
                         <ha-card class="empty">
-                            <ha-svg-icon class="empty-icon" .path=${is}></ha-svg-icon>
+                            <ha-svg-icon class="empty-icon" .path=${rs}></ha-svg-icon>
                             <h3>No IR receiver is set up</h3>
                             <p>
                                 HAIR has no way to receive IR signals yet, so the
@@ -3510,7 +3767,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                 Services, to confirm your IR device is adopted.
                             </p>
                         </ha-card>
-                    `:F`
+                    `:B`
                         <div class="device-list">
                             ${Se(this._remotesVersion,Te(this._devices,e=>e.id,e=>this._renderDevice(e)))}
                         </div>
@@ -3523,9 +3780,9 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     @click=${this._toggleDismissed}
                 >
                     ${this._showDismissed?"Hide Dismissed":"Show Dismissed"}
-                    ${this._dismissDotVisible?F`<span class="dismiss-dot" aria-hidden="true"></span>`:""}
+                    ${this._dismissDotVisible?B`<span class="dismiss-dot" aria-hidden="true"></span>`:""}
                 </button>
-                ${this._devices.length>0||this._showDismissed?F`<button
+                ${this._devices.length>0||this._showDismissed?B`<button
                           class="action-btn delete-btn"
                           title="Wipe the entire unknown catalog AND the dismiss list. Use Show Dismissed before Clear All if you want to retain individual dismissed entries."
                           @click=${()=>this._confirmClearAll=!0}
@@ -3534,7 +3791,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                       </button>`:""}
             </div>
 
-            ${this._assignSignal?F`
+            ${this._assignSignal?B`
                       <ir-assign-signal-dialog
                           .api=${this.api}
                           .hass=${this.hass}
@@ -3547,7 +3804,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                       ></ir-assign-signal-dialog>
                   `:""}
 
-            ${this._promoteTarget?F`
+            ${this._promoteTarget?B`
                       <ir-promote-dialog
                           .api=${this.api}
                           .hass=${this.hass}
@@ -3557,7 +3814,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                       ></ir-promote-dialog>
                   `:""}
 
-            ${this._deleteSignal?F`
+            ${this._deleteSignal?B`
                       <ir-confirm-dialog
                           title="Delete Signal"
                           message="Remove this signal permanently? This cannot be undone."
@@ -3568,7 +3825,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                       ></ir-confirm-dialog>
                   `:""}
 
-            ${this._editSignal?F`<ir-signal-editor
+            ${this._editSignal?B`<ir-signal-editor
                       .api=${this.api}
                       .deviceId=${this._editSignal.deviceId}
                       .signalId=${this._editSignal.signal.id}
@@ -3582,7 +3839,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                       @closed=${()=>this._editSignal=null}
                   ></ir-signal-editor>`:""}
 
-            ${this._confirmClearAll?F`
+            ${this._confirmClearAll?B`
                       <ir-confirm-dialog
                           title="Clear All Signals"
                           message="Remove all unknown signals and devices? This cannot be undone."
@@ -3593,7 +3850,17 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                       ></ir-confirm-dialog>
                   `:""}
 
-            ${this._triggerDialog?F`
+            ${this._triggerPopover?B`
+                      <ir-trigger-popover
+                          .triggers=${this._triggers.filter(e=>e.signal_fingerprint===this._triggerPopover.signal.fingerprint)}
+                          .receivers=${this._receivers}
+                          .top=${this._triggerPopover.top}
+                          .left=${this._triggerPopover.left}
+                          @create-new=${this._onPopoverCreateNew}
+                          @edit-trigger=${this._onPopoverEditTrigger}
+                      ></ir-trigger-popover>
+                  `:""}
+            ${this._triggerDialog?B`
                       <ir-trigger-dialog
                           .api=${this.api}
                           .signalFingerprint=${this._triggerDialog.signal.fingerprint}
@@ -3605,7 +3872,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                           @closed=${this._closeTriggerDialog}
                       ></ir-trigger-dialog>
                   `:""}
-            ${this._testDialog?F`
+            ${this._testDialog?B`
                       <ir-test-emitter-dialog
                           .api=${this.api}
                           .hass=${this.hass}
@@ -3615,7 +3882,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                           @closed=${this._closeTestDialog}
                       ></ir-test-emitter-dialog>
                   `:""}
-            ${this._triggerEditDialog?F`
+            ${this._triggerEditDialog?B`
                       <ir-trigger-dialog
                           .api=${this.api}
                           .trigger=${this._triggerEditDialog}
@@ -3624,7 +3891,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                           @trigger-delete=${e=>this._requestDeleteTrigger(e.detail.triggerId)}
                       ></ir-trigger-dialog>
                   `:""}
-            ${this._confirmDeleteTriggerId?F`
+            ${this._confirmDeleteTriggerId?B`
                       <ir-confirm-dialog
                           title="Delete Trigger"
                           message="Remove this trigger? The associated HA event entity will also be removed."
@@ -3634,7 +3901,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                           @closed=${()=>this._confirmDeleteTriggerId=null}
                       ></ir-confirm-dialog>
                   `:""}
-        `}_renderDevice(e){const t=this._expandedId===e.id,i=this._flashIds.has(e.id),s=this._flashStats.has(e.id);return F`
+        `}_renderDevice(e){const t=this._expandedId===e.id,i=this._flashIds.has(e.id),s=this._flashStats.has(e.id);return B`
             <ha-card class="device ${e.dismissed?"dismissed":""}">
                 <div
                     class="device-row ${i?"flash-row":""}"
@@ -3642,7 +3909,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                 >
                     <div class="device-info">
                         <div class="device-header">
-                            ${this._editingDeviceId===e.id?F`<input
+                            ${this._editingDeviceId===e.id?B`<input
                                       class="rename-input"
                                       type="text"
                                       .value=${this._editLabel}
@@ -3650,15 +3917,15 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                       @keydown=${t=>this._onRenameKeydown(e.id,t)}
                                       @blur=${()=>{this._commitRename(e.id)}}
                                       @click=${e=>e.stopPropagation()}
-                                  />`:F`<ha-svg-icon
+                                  />`:B`<ha-svg-icon
                                           class="remote-grip"
-                                          .path=${ss}
+                                          .path=${ns}
                                           title="Drag to reorder"
                                           @click=${e=>e.stopPropagation()}
                                       ></ha-svg-icon>
-                                      ${e.dismissed?F`<span class="protocol locked"
+                                      ${e.dismissed?B`<span class="protocol locked"
                                                 >${e.label??e.protocol??"RAW"}</span
-                                            >`:F`<span
+                                            >`:B`<span
                                                 class="protocol"
                                                 title="Click to rename"
                                                 @click=${t=>this._startRename(e,t)}
@@ -3672,23 +3939,23 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                     ><strong>${e.signal_count}</strong>
                                     ${1===e.signal_count?"signal":"signals"}</span
                                 >
-                                <span class="stat last-seen" title=${es(e.last_seen)}>${ts(e.last_seen)}</span>
+                                <span class="stat last-seen" title=${os(e.last_seen)}>${as(e.last_seen)}</span>
                             </span>
-                            ${e.label&&this._matchesHairDevice(e.label)?F`<span
+                            ${e.label&&this._matchesHairDevice(e.label)?B`<span
                                       class="status-badge hair-device"
                                       @click=${e=>e.stopPropagation()}
-                                  >HAIR Device</span>`:e.label&&!e.dismissed?F`<span
+                                  >HAIR Device</span>`:e.label&&!e.dismissed?B`<span
                                           class="status-badge promote-badge"
                                           @click=${t=>this._promoteDevice(e,t)}
                                       >Promote</span>`:""}
-                            ${e.device_address?F`<span class="address">addr: ${e.device_address}</span>`:""}
-                            ${e.dismissed?F`<span class="dismissed-badge">dismissed</span>`:""}
+                            ${e.device_address?B`<span class="address">addr: ${e.device_address}</span>`:""}
+                            ${e.dismissed?B`<span class="dismissed-badge">dismissed</span>`:""}
                         </div>
                     </div>
-                    ${e.dismissed?F`<button
+                    ${e.dismissed?B`<button
                               class="action-btn device-dismiss-btn"
                               @click=${t=>{t.stopPropagation(),this._undismiss(e.id)}}
-                          >Restore</button>`:F`<button
+                          >Restore</button>`:B`<button
                               class="action-btn device-dismiss-btn"
                               @click=${t=>{t.stopPropagation(),this._dismiss(e.id)}}
                           >Dismiss</button>`}
@@ -3700,18 +3967,18 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
 
                 ${t&&this._expandedDevice?this._renderExpanded(this._expandedDevice):""}
             </ha-card>
-        `}_renderExpanded(e){return F`
+        `}_renderExpanded(e){return B`
             <div class="expanded">
                 <div class="signal-header">
                     <span>Signals (${e.signals.length})</span>
-                    <span class="first-seen">First seen: ${es(e.first_seen)}</span>
+                    <span class="first-seen">First seen: ${os(e.first_seen)}</span>
                 </div>
                 <div class="signal-list">
-                    ${Se(this._signalsVersion,Te(e.signals,e=>e.id,t=>{const i=this._recentSignalIds.indexOf(t.id),s=0===i,a=1===i,o=this._glowSignalIds.has(t.id),n=this._hitFlashSignalIds.has(t.id);return F`
+                    ${Se(this._signalsVersion,Te(e.signals,e=>e.id,t=>{const i=this._recentSignalIds.indexOf(t.id),s=0===i,o=1===i,a=this._glowSignalIds.has(t.id),r=this._hitFlashSignalIds.has(t.id);return B`
                             <div class="signal-row">
-                                ${e.dismissed?"":F`<ha-svg-icon
+                                ${e.dismissed?"":B`<ha-svg-icon
                                           class="signal-grip"
-                                          .path=${ss}
+                                          .path=${ns}
                                           title="Drag to reorder"
                                       ></ha-svg-icon>`}
                                 <div class="signal-info">
@@ -3724,16 +3991,16 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                     ></ir-signal-alias>
                                 </div>
                                 <div class="signal-meta">
-                                    <span class="${n?"hit-flash":""}"
+                                    <span class="${r?"hit-flash":""}"
                                         >${t.hit_count}
                                         ${1===t.hit_count?"hit":"hits"}</span
                                     >
-                                    <span title=${es(t.last_seen)}
-                                        >${ts(t.last_seen)}</span
+                                    <span title=${os(t.last_seen)}
+                                        >${as(t.last_seen)}</span
                                     >
                                     <span>${Math.round(t.frequency/1e3)} kHz</span>
                                 </div>
-                                ${t.code?F`<button
+                                ${t.code?B`<button
                                           ?disabled=${e.dismissed}
                                           title="View or edit code"
                                           @click=${i=>this._openEditSignal(e.id,t,i)}
@@ -3746,11 +4013,14 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                       </button>`:""}
                                 <div class="signal-actions">
                                     <button
-                                        class="action-btn assign-btn ${s?"recent-latest":""} ${a?"recent-previous":""} ${o?"glow":""}"
+                                        class="action-btn assign-btn ${s?"recent-latest":""} ${o?"recent-previous":""} ${a?"glow":""}"
                                         @click=${i=>{i.stopPropagation(),this._openAssign(e.id,t,e.label)}}
                                         ?disabled=${e.dismissed}
-                                        title=${e.dismissed?"Restore this remote first":"Assign this signal to a HAIR device"}
-                                    >Assign</button>
+                                        title=${t.assignment_count&&t.assigned_to?.length?1===t.assignment_count?`Assigned to ${t.assigned_to[0]}`:`Assigned to ${t.assignment_count} commands:\n- ${t.assigned_to.join("\n- ")}`:e.dismissed?"Restore this remote first":"Assign this signal to a HAIR device"}
+                                    >Assign<ir-count-dot
+                                            color="green"
+                                            .count=${t.assignment_count??0}
+                                        ></ir-count-dot></button>
                                     <button
                                         class="action-btn test-btn"
                                         @click=${e=>{e.stopPropagation(),this._openTestDialog(t)}}
@@ -3758,11 +4028,14 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                         title=${e.dismissed?"Restore this remote first":"Send this signal through an emitter to test it"}
                                     >${this._testingSignalId===t.id?this._testResult??"Sending...":"Test"}</button>
                                     <button
-                                        class="action-btn trigger-btn ${this._hasTrigger(t.fingerprint)?"trigger-on":""}"
-                                        @click=${i=>{i.stopPropagation(),this._openTriggerDialog(e.id,t)}}
+                                        class="action-btn trigger-btn"
+                                        @click=${i=>{i.stopPropagation(),this._openTriggerDialog(e.id,t,i)}}
                                         ?disabled=${e.dismissed}
-                                        title=${e.dismissed?"Restore this remote first":"Create an HA event entity that fires on this signal"}
-                                    >Trigger</button>
+                                        title=${this._hasTrigger(t.fingerprint)?"Edit trigger(s) for this signal":e.dismissed?"Restore this remote first":"Create an HA event entity that fires on this signal"}
+                                    >Trigger<ir-count-dot
+                                            color="yellow"
+                                            .count=${this._triggerCountFor(t.fingerprint)}
+                                        ></ir-count-dot></button>
                                     <button
                                         class="action-btn delete-btn"
                                         @click=${i=>{i.stopPropagation(),this._openDelete(e.id,t)}}
@@ -3772,7 +4045,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                         `}))}
                 </div>
             </div>
-        `}};as.DISMISS_GLOW_HOLD_MS=3800,as.styles=n`
+        `}};ls.DISMISS_GLOW_HOLD_MS=3800,ls.styles=r`
         :host {
             display: block;
         }
@@ -4175,6 +4448,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
         .action-btn.assign-btn {
             color: #2e7d32;
             border-color: rgba(46, 125, 50, 0.3);
+            position: relative; /* anchor for the green assignment dot */
         }
         .action-btn.assign-btn:hover {
             background: rgba(46, 125, 50, 0.08);
@@ -4185,17 +4459,10 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
         .action-btn.trigger-btn {
             color: #b89930;
             border-color: rgba(184, 153, 48, 0.3);
+            position: relative; /* anchor for the yellow trigger dot */
         }
         .action-btn.trigger-btn:hover {
             background: rgba(184, 153, 48, 0.08);
-        }
-        .action-btn.trigger-btn.trigger-on {
-            color: #fff;
-            background: #b89930;
-            border-color: #b89930;
-        }
-        .action-btn.trigger-btn.trigger-on:hover {
-            background: #a08328;
         }
         .action-btn.delete-btn {
             color: #e65100;
@@ -4287,14 +4554,14 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
             color: var(--primary-color);
             transition: color 300ms ease;
         }
-    `,e([he({attribute:!1})],as.prototype,"api",void 0),e([he({attribute:!1})],as.prototype,"hass",void 0),e([pe()],as.prototype,"_devices",void 0),e([pe()],as.prototype,"_hairDevices",void 0),e([pe()],as.prototype,"_loading",void 0),e([pe()],as.prototype,"_error",void 0),e([pe()],as.prototype,"_hasReceivers",void 0),e([pe()],as.prototype,"_showDismissed",void 0),e([pe()],as.prototype,"_expandedId",void 0),e([pe()],as.prototype,"_expandedDevice",void 0),e([pe()],as.prototype,"_flashIds",void 0),e([pe()],as.prototype,"_flashStats",void 0),e([pe()],as.prototype,"_recentSignalIds",void 0),e([pe()],as.prototype,"_glowSignalIds",void 0),e([pe()],as.prototype,"_hitFlashSignalIds",void 0),e([pe()],as.prototype,"_confirmClearAll",void 0),e([pe()],as.prototype,"_triggers",void 0),e([pe()],as.prototype,"_triggerDialog",void 0),e([pe()],as.prototype,"_triggerEditDialog",void 0),e([pe()],as.prototype,"_confirmDeleteTriggerId",void 0),e([pe()],as.prototype,"_editingDeviceId",void 0),e([pe()],as.prototype,"_editLabel",void 0),e([pe()],as.prototype,"_promoteTarget",void 0),e([pe()],as.prototype,"_assignSignal",void 0),e([pe()],as.prototype,"_deleteSignal",void 0),e([pe()],as.prototype,"_editSignal",void 0),e([pe()],as.prototype,"_testingSignalId",void 0),e([pe()],as.prototype,"_testResult",void 0),e([pe()],as.prototype,"_testDialog",void 0),e([pe()],as.prototype,"_testEmitters",void 0),e([pe()],as.prototype,"_dismissGlowActive",void 0),e([pe()],as.prototype,"_dismissDotVisible",void 0),e([pe()],as.prototype,"_remotesVersion",void 0),e([pe()],as.prototype,"_signalsVersion",void 0),as=Qi=e([ue("ir-signal-monitor")],as);let os=class extends re{constructor(){super(...arguments),this._name="",this._busy=!1,this._error=null,this._brands=[],this._selectedBrand="",this._selectedCodebook="",this._nameEdited=!1}connectedCallback(){super.connectedCallback(),this._loadBrands()}async _loadBrands(){try{this._brands=await this.api.getCodeBrands()}catch{this._brands=[]}}_brand(e){return this._brands.find(t=>t.brand===e)}_codebookLabel(e,t){const i=this._brand(e)?.codebooks.find(e=>e.id===t);return i?.label??""}_maybeAutofillName(){if(this._nameEdited)return;const e=this._brand(this._selectedBrand);if(!e||!this._selectedCodebook)return;const t=this._codebookLabel(this._selectedBrand,this._selectedCodebook);this._name=`${e.label} ${t}`.trim()}_onBrandChange(e){this._selectedBrand=e.target.value;const t=this._brand(this._selectedBrand);t&&1===t.codebooks.length?this._selectedCodebook=t.codebooks[0].id:this._selectedCodebook="",this._maybeAutofillName()}_onCodebookChange(e){this._selectedCodebook=e.target.value,this._maybeAutofillName()}_close(){this.dispatchEvent(new CustomEvent("closed",{bubbles:!0,composed:!0}))}async _create(){if(this._name.trim()){this._busy=!0,this._error=null;try{let e;e=this._selectedCodebook?(await this.api.importCodeRemote(this._selectedCodebook,this._name.trim())).device:await this.api.createRemote(this._name.trim()),this.dispatchEvent(new CustomEvent("remote-created",{detail:e,bubbles:!0,composed:!0}))}catch(e){this._error=e.message}finally{this._busy=!1}}else this._error="Name is required."}_onKeydown(e){"Enter"===e.key&&this._create()}render(){const e=this._brand(this._selectedBrand);return F`
+    `,e([he({attribute:!1})],ls.prototype,"api",void 0),e([he({attribute:!1})],ls.prototype,"hass",void 0),e([pe()],ls.prototype,"_devices",void 0),e([pe()],ls.prototype,"_hairDevices",void 0),e([pe()],ls.prototype,"_loading",void 0),e([pe()],ls.prototype,"_error",void 0),e([pe()],ls.prototype,"_hasReceivers",void 0),e([pe()],ls.prototype,"_showDismissed",void 0),e([pe()],ls.prototype,"_expandedId",void 0),e([pe()],ls.prototype,"_expandedDevice",void 0),e([pe()],ls.prototype,"_flashIds",void 0),e([pe()],ls.prototype,"_flashStats",void 0),e([pe()],ls.prototype,"_recentSignalIds",void 0),e([pe()],ls.prototype,"_glowSignalIds",void 0),e([pe()],ls.prototype,"_hitFlashSignalIds",void 0),e([pe()],ls.prototype,"_confirmClearAll",void 0),e([pe()],ls.prototype,"_triggers",void 0),e([pe()],ls.prototype,"_triggerDialog",void 0),e([pe()],ls.prototype,"_triggerEditDialog",void 0),e([pe()],ls.prototype,"_confirmDeleteTriggerId",void 0),e([pe()],ls.prototype,"_triggerPopover",void 0),e([pe()],ls.prototype,"_receivers",void 0),e([pe()],ls.prototype,"_editingDeviceId",void 0),e([pe()],ls.prototype,"_editLabel",void 0),e([pe()],ls.prototype,"_promoteTarget",void 0),e([pe()],ls.prototype,"_assignSignal",void 0),e([pe()],ls.prototype,"_deleteSignal",void 0),e([pe()],ls.prototype,"_editSignal",void 0),e([pe()],ls.prototype,"_testingSignalId",void 0),e([pe()],ls.prototype,"_testResult",void 0),e([pe()],ls.prototype,"_testDialog",void 0),e([pe()],ls.prototype,"_testEmitters",void 0),e([pe()],ls.prototype,"_dismissGlowActive",void 0),e([pe()],ls.prototype,"_dismissDotVisible",void 0),e([pe()],ls.prototype,"_remotesVersion",void 0),e([pe()],ls.prototype,"_signalsVersion",void 0),ls=ss=e([ue("ir-signal-monitor")],ls);let ds=class extends ne{constructor(){super(...arguments),this._name="",this._busy=!1,this._error=null,this._brands=[],this._selectedBrand="",this._selectedCodebook="",this._nameEdited=!1}connectedCallback(){super.connectedCallback(),this._loadBrands()}async _loadBrands(){try{this._brands=await this.api.getCodeBrands()}catch{this._brands=[]}}_brand(e){return this._brands.find(t=>t.brand===e)}_codebookLabel(e,t){const i=this._brand(e)?.codebooks.find(e=>e.id===t);return i?.label??""}_maybeAutofillName(){if(this._nameEdited)return;const e=this._brand(this._selectedBrand);if(!e||!this._selectedCodebook)return;const t=this._codebookLabel(this._selectedBrand,this._selectedCodebook);this._name=`${e.label} ${t}`.trim()}_onBrandChange(e){this._selectedBrand=e.target.value;const t=this._brand(this._selectedBrand);t&&1===t.codebooks.length?this._selectedCodebook=t.codebooks[0].id:this._selectedCodebook="",this._maybeAutofillName()}_onCodebookChange(e){this._selectedCodebook=e.target.value,this._maybeAutofillName()}_close(){this.dispatchEvent(new CustomEvent("closed",{bubbles:!0,composed:!0}))}async _create(){if(this._name.trim()){this._busy=!0,this._error=null;try{let e;e=this._selectedCodebook?(await this.api.importCodeRemote(this._selectedCodebook,this._name.trim())).device:await this.api.createRemote(this._name.trim()),this.dispatchEvent(new CustomEvent("remote-created",{detail:e,bubbles:!0,composed:!0}))}catch(e){this._error=e.message}finally{this._busy=!1}}else this._error="Name is required."}_onKeydown(e){"Enter"===e.key&&this._create()}render(){const e=this._brand(this._selectedBrand);return B`
             <ha-dialog
                 open
                 heading="Create Remote"
                 scrimClickAction=""
                 @closed=${this._close}
             >
-                ${this._error?F`<ha-alert alert-type="error">${this._error}</ha-alert>`:""}
+                ${this._error?B`<ha-alert alert-type="error">${this._error}</ha-alert>`:""}
 
                 <div class="field">
                     <label>Name</label>
@@ -4309,7 +4576,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     />
                 </div>
 
-                ${this._brands.length>0?F`
+                ${this._brands.length>0?B`
                           <div class="field">
                               <label>Type</label>
                               <select
@@ -4318,14 +4585,14 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                               >
                                   <option value="">Blank remote</option>
                                   <optgroup label="From code library">
-                                      ${this._brands.map(e=>F`<option value=${e.brand}>
+                                      ${this._brands.map(e=>B`<option value=${e.brand}>
                                               ${e.label}
                                           </option>`)}
                                   </optgroup>
                               </select>
                           </div>
 
-                          ${e?F`<div class="field">
+                          ${e?B`<div class="field">
                                     <label>Model</label>
                                     <select
                                         .value=${this._selectedCodebook}
@@ -4334,7 +4601,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                         <option value="">
                                             Select a model
                                         </option>
-                                        ${e.codebooks.map(e=>F`<option value=${e.id}>
+                                        ${e.codebooks.map(e=>B`<option value=${e.id}>
                                                 ${e.label}
                                                 (${e.functions.length})
                                             </option>`)}
@@ -4359,7 +4626,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     </button>
                 </div>
             </ha-dialog>
-        `}};os.styles=n`
+        `}};ds.styles=r`
         .field {
             display: block;
             margin: 12px 0;
@@ -4430,12 +4697,12 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
         .create-btn:hover:not(:disabled) {
             opacity: 0.9;
         }
-    `,e([he({attribute:!1})],os.prototype,"api",void 0),e([pe()],os.prototype,"_name",void 0),e([pe()],os.prototype,"_busy",void 0),e([pe()],os.prototype,"_error",void 0),e([pe()],os.prototype,"_brands",void 0),e([pe()],os.prototype,"_selectedBrand",void 0),e([pe()],os.prototype,"_selectedCodebook",void 0),os=e([ue("ir-create-remote-dialog")],os);const ns="M12.462,10.448c-0.639-0.639-1.678-0.639-2.317,0c-0.639,0.639-0.639,1.678,0,2.317l1.09,1.09c0.319,0.319,0.739,0.479,1.159,0.479c0.42,0,0.839-0.16,1.159-0.479c0-0,0-0,0-0c0.639-0.639,0.639-1.678,0-2.317L12.462,10.448z M12.763,13.066c-0.204,0.204-0.535,0.204-0.739,0l-1.09-1.09c-0.204-0.204-0.204-0.535,0-0.739c0.102-0.102,0.236-0.153,0.369-0.153c0.134,0,0.267,0.051,0.369,0.153l1.09,1.09C12.966,12.531,12.966,12.863,12.763,13.066z M23.998,6.609l-0.104-1.419c-0.02-0.276-0.24-0.496-0.516-0.516l-0.938-0.068l-0.068-0.938c-0.02-0.276-0.24-0.496-0.516-0.516l-0.938-0.068l-0.069-0.938c-0.02-0.276-0.24-0.496-0.516-0.516l-0.938-0.068l-0.069-0.938c-0.02-0.276-0.24-0.496-0.516-0.516l-1.419-0.103c-0.162-0.012-0.321,0.047-0.435,0.162l-1.993,1.993c-0,0.001-0.001,0.001-0.001,0.001c-0.097,0.097-0.191,0.197-0.282,0.298c-1.933,2.042-12.871,13.598-13.716,14.551c-0.722,0.814-0.712,1.983,0.023,2.717l0.341,0.341L0.539,20.852c-0.719,0.719-0.719,1.889,0,2.609c0.36,0.36,0.832,0.539,1.304,0.539c0.472,0,0.945-0.18,1.304-0.539l0.787-0.787l0.341,0.341c0.735,0.735,1.903,0.745,2.717,0.023c0.953-0.845,12.509-11.783,14.551-13.716c0.102-0.091,0.201-0.186,0.299-0.283c0.001-0.001,0.001-0.001,0.001-0.002l1.992-1.992C23.951,6.93,24.01,6.771,23.998,6.609z M20.61,4.179l0.684,0.05l0.05,0.684l-1.418,1.418l-0.733-0.734L20.61,4.179z M19.087,2.656l0.684,0.05l0.05,0.684L18.403,4.807L17.67,4.074L19.087,2.656z M17.564,1.133l0.684,0.05l0.05,0.684l-1.418,1.418l-0.733-0.733L17.564,1.133z M2.359,22.671c-0.284,0.284-0.746,0.284-1.03,0c-0.284-0.284-0.284-0.746,0-1.03l0.787-0.787l1.03,1.03L2.359,22.671z M6.253,22.202c-0.366,0.324-0.877,0.334-1.188,0.023l-0.735-0.735l-2.555-2.555c-0.311-0.311-0.301-0.822,0.023-1.188c0.633-0.715,7.3-7.769,11.189-11.88c-0.014,0.084-0.026,0.169-0.036,0.253c-0.179,1.482,0.239,2.815,1.176,3.752c0.937,0.937,2.27,1.355,3.752,1.176c0.084-0.01,0.169-0.022,0.253-0.036C14.022,14.901,6.968,21.568,6.253,22.202z M14.917,9.083c-0.69-0.69-0.994-1.694-0.857-2.829c0.123-1.019,0.585-2.03,1.315-2.897l0.717,0.717l-0.879,0.879c-0.218,0.218-0.218,0.571,0,0.789c0.218,0.218,0.571,0.218,0.789,0l0.879-0.879l0.734,0.734l-0.879,0.879c-0.218,0.218-0.218,0.571,0,0.789c0.218,0.218,0.571,0.218,0.789,0l0.879-0.879l0.734,0.734l-0.879,0.879c-0.218,0.218-0.218,0.571,0,0.789c0.218,0.218,0.571,0.218,0.789,0l0.879-0.879l0.717,0.717C18.756,10.213,16.277,10.443,14.917,9.083z M21.449,7.853l-0.734-0.734l1.418-1.418l0.684,0.05l0.05,0.684L21.449,7.853z",rs="M7,19V17H9V19H7M11,19V17H13V19H11M15,19V17H17V19H15M7,15V13H9V15H7M11,15V13H13V15H11M15,15V13H17V15H15M7,11V9H9V11H7M11,11V9H13V11H11M15,11V9H17V11H15M7,7V5H9V7H7M11,7V5H13V7H11M15,7V5H17V7H15Z";let ls=class extends re{constructor(){super(...arguments),this._devices=[],this._hairDevices=[],this._triggers=[],this._loading=!0,this._error=null,this._expandedId=null,this._expandedDevice=null,this._confirmClearAll=!1,this._deleteRemoteId=null,this._deleteRemoteLabel="",this._deleteRemoteCount=0,this._editingDeviceId=null,this._editLabel="",this._createRemoteOpen=!1,this._createSignalDeviceId=null,this._editSignal=null,this._promoteTarget=null,this._assignSignal=null,this._deleteSignal=null,this._triggerDialog=null,this._triggerEditDialog=null,this._confirmDeleteTriggerId=null,this._testDialog=null,this._testEmitters=[],this._testingSignalId=null,this._testResult=null,this._remotesVersion=0,this._signalsVersion=0,this._remotesSortable=null,this._signalsSortable=null,this._signalsSortableContainer=null,this._pendingRemotesSave=null,this._pendingSignalsSave=null}connectedCallback(){super.connectedCallback(),this._load()}disconnectedCallback(){super.disconnectedCallback(),this._remotesSortable?.destroy(),this._remotesSortable=null,this._signalsSortable?.destroy(),this._signalsSortable=null,this._signalsSortableContainer=null,null!==this._pendingRemotesSave&&clearTimeout(this._pendingRemotesSave),null!==this._pendingSignalsSave&&clearTimeout(this._pendingSignalsSave)}updated(e){if(super.updated(e),e.has("_editingDeviceId")&&this._editingDeviceId){const e=this.shadowRoot?.querySelector(".rename-input");e?.focus(),e?.select()}this._syncSortables()}_syncSortables(){const e=this.renderRoot.querySelector(".device-list");e&&!this._remotesSortable?this._attachRemotesSortable(e):!e&&this._remotesSortable&&(this._remotesSortable.destroy(),this._remotesSortable=null);const t=this.renderRoot.querySelector(".signal-list"),i=!!this._expandedDevice&&!this._expandedDevice.dismissed;!t||!i||this._signalsSortable&&this._signalsSortableContainer===t?t&&i||!this._signalsSortable||(this._signalsSortable.destroy(),this._signalsSortable=null,this._signalsSortableContainer=null):(this._signalsSortable?.destroy(),this._attachSignalsSortable(t))}_attachRemotesSortable(e){this._remotesSortable=di.create(e,{handle:".remote-grip",animation:150,ghostClass:"sortable-ghost",onEnd:t=>{const{oldIndex:i,newIndex:s}=t;if(void 0===i||void 0===s||i===s)return;const a=[...this._devices],[o]=a.splice(i,1);a.splice(s,0,o),this._devices=a,this._remotesSortable?.destroy(),this._remotesSortable=null,this._purgeChildren(e,"ha-card"),this._remotesVersion++,this._scheduleRemotesSave(a.map(e=>e.id))}})}_attachSignalsSortable(e){this._expandedDevice&&(this._signalsSortableContainer=e,this._signalsSortable=di.create(e,{handle:".signal-grip",animation:150,ghostClass:"sortable-ghost",onEnd:t=>{const{oldIndex:i,newIndex:s}=t;if(void 0===i||void 0===s||i===s)return;const a=this._expandedDevice;if(!a)return;const o=[...a.signals],[n]=o.splice(i,1);o.splice(s,0,n),this._expandedDevice={...a,signals:o},this._signalsSortable?.destroy(),this._signalsSortable=null,this._signalsSortableContainer=null,this._purgeChildren(e,".signal-row"),this._signalsVersion++,this._scheduleSignalsSave(a.id,o.map(e=>e.id))}}))}_purgeChildren(e,t){for(const i of Array.from(e.querySelectorAll(t)))i.remove()}_scheduleRemotesSave(e){null!==this._pendingRemotesSave&&clearTimeout(this._pendingRemotesSave),this._pendingRemotesSave=window.setTimeout(async()=>{this._pendingRemotesSave=null;try{await this.api.reorderUnknownDevices("manual",e)}catch(e){this._error=`Reorder failed: ${e.message}`,await this._load()}},500)}_scheduleSignalsSave(e,t){null!==this._pendingSignalsSave&&clearTimeout(this._pendingSignalsSave),this._pendingSignalsSave=window.setTimeout(async()=>{this._pendingSignalsSave=null;try{await this.api.reorderUnknownSignals(e,t)}catch(e){this._error=`Reorder failed: ${e.message}`,await this._refreshExpanded()}},500)}async _load(){this._loading=!0;try{const[e,t,i]=await Promise.all([this.api.getUnknownDevices({include_dismissed:!0,min_hits:0,source:"manual"}),this.api.listDevices(),this.api.listTriggers()]);this._devices=e,this._hairDevices=t,this._triggers=i,this._error=null}catch(e){this._error=`Failed to load: ${e.message}`}finally{this._loading=!1}}_matchesHairDevice(e){if(!e)return!1;const t=e.toLowerCase();return this._hairDevices.some(e=>e.name.toLowerCase()===t)}async _refreshExpanded(){if(this._expandedId)try{this._expandedDevice=await this.api.getUnknownDevice(this._expandedId)}catch{this._expandedId=null,this._expandedDevice=null}}openCreateRemote(){this._createRemoteOpen=!0}async _onRemoteCreated(e){this._createRemoteOpen=!1,await this._load(),this._expandedId=e.detail.id,await this._refreshExpanded()}_openCreateSignal(e,t){t.stopPropagation(),this._createSignalDeviceId=e}async _onSignalCreated(){this._createSignalDeviceId=null,await this._refreshExpanded(),await this._load()}_openEditSignal(e,t,i){i.stopPropagation(),this._editSignal={deviceId:e,signal:t}}async _onSignalEdited(){this._editSignal=null,await this._refreshExpanded(),await this._load()}_openDeleteRemote(e){this._deleteRemoteId=e.id,this._deleteRemoteLabel=e.label||"this remote",this._deleteRemoteCount=e.signals.length}async _confirmDeleteRemote(){const e=this._deleteRemoteId;if(this._deleteRemoteId=null,e)try{await this.api.deleteRemote(e),this._expandedId===e&&(this._expandedId=null,this._expandedDevice=null),await this._load()}catch(e){this._error=`Delete failed: ${e.message}`}}_onAliasChanged(e){const{id:t,alias:i}=e.detail;this._expandedDevice&&(this._expandedDevice={...this._expandedDevice,signals:this._expandedDevice.signals.map(e=>e.id===t?{...e,alias:i}:e)})}_startRename(e,t){t.stopPropagation(),this._editingDeviceId=e.id,this._editLabel=e.label??""}async _commitRename(e){const t=this._editLabel.trim();this._editingDeviceId=null;try{const i=await this.api.renameUnknown(e,t),s=this._devices.findIndex(t=>t.id===e);if(s>=0){const e=[...this._devices];e[s]={...e[s],label:i.label},this._devices=e}}catch(e){this._error=`Rename failed: ${e.message}`}}_onRenameKeydown(e,t){"Enter"===t.key?this._commitRename(e):"Escape"===t.key&&(this._editingDeviceId=null)}_promoteDevice(e,t){t.stopPropagation(),this._promoteTarget=e}async _onDevicePromoted(){this._promoteTarget=null,await this._load()}_openAssign(e,t,i){this._assignSignal={deviceId:e,signal:t,label:i??null}}async _onSignalAssigned(e){this._assignSignal=null,await this._load(),await this._refreshExpanded()}_openDelete(e,t){this._deleteSignal={deviceId:e,signal:t}}async _confirmDelete(){if(!this._deleteSignal)return;const{deviceId:e,signal:t}=this._deleteSignal;this._deleteSignal=null;try{await this.api.deleteSignal(e,t.id),await this._load(),await this._refreshExpanded()}catch(e){this._error=`Delete failed: ${e.message}`}}_openTestDialog(e){this._testDialog={signal:e}}async _sendTest(e){if(!this._testDialog)return;const{signal:t}=this._testDialog,i=e.detail.emitters;if(0!==i.length){this._testingSignalId=t.id,this._testResult=null,this._testDialog=null;try{const e=(await Promise.allSettled(i.map(e=>this.api.testSignal(t.id,e)))).filter(e=>"fulfilled"===e.status&&e.value.sent).length,s=i.length;this._testResult=e===s?1===s?"Sent!":`Sent! (${e}/${s})`:0===e?"Failed":`Sent (${e}/${s})`}catch{this._testResult="Error"}setTimeout(()=>{this._testResult=null,this._testingSignalId=null},3e3)}}_hasTrigger(e){return this._triggers.some(t=>t.signal_fingerprint===e)}_openTriggerDialog(e,t){const i=this._triggers.find(e=>e.signal_fingerprint===t.fingerprint);i?this._triggerEditDialog=i:this._triggerDialog={signal:t,deviceId:e}}_closeTriggerDialog(){this._triggerDialog=null,this._triggerEditDialog=null}_requestDeleteTrigger(e){this._confirmDeleteTriggerId=e}async _doDeleteTrigger(){if(!this._confirmDeleteTriggerId)return;const e=this._confirmDeleteTriggerId;this._confirmDeleteTriggerId=null,this._triggerEditDialog=null;try{await this.api.deleteTrigger(e),this._triggers=await this.api.listTriggers()}catch{}}async _onTriggerSaved(){this._triggerDialog=null,this._triggerEditDialog=null;try{this._triggers=await this.api.listTriggers()}catch{}}async _toggleExpand(e){if(this._expandedId===e)return this._expandedId=null,void(this._expandedDevice=null);this._expandedId=e,await this._refreshExpanded()}async _doClearAll(){this._confirmClearAll=!1;try{await this.api.clearUnknowns("manual"),this._devices=[],this._expandedId=null,this._expandedDevice=null}catch(e){this._error=`Clear failed: ${e.message}`}}render(){const e=this._devices.length;return F`
+    `,e([he({attribute:!1})],ds.prototype,"api",void 0),e([pe()],ds.prototype,"_name",void 0),e([pe()],ds.prototype,"_busy",void 0),e([pe()],ds.prototype,"_error",void 0),e([pe()],ds.prototype,"_brands",void 0),e([pe()],ds.prototype,"_selectedBrand",void 0),e([pe()],ds.prototype,"_selectedCodebook",void 0),ds=e([ue("ir-create-remote-dialog")],ds);const cs="M12.462,10.448c-0.639-0.639-1.678-0.639-2.317,0c-0.639,0.639-0.639,1.678,0,2.317l1.09,1.09c0.319,0.319,0.739,0.479,1.159,0.479c0.42,0,0.839-0.16,1.159-0.479c0-0,0-0,0-0c0.639-0.639,0.639-1.678,0-2.317L12.462,10.448z M12.763,13.066c-0.204,0.204-0.535,0.204-0.739,0l-1.09-1.09c-0.204-0.204-0.204-0.535,0-0.739c0.102-0.102,0.236-0.153,0.369-0.153c0.134,0,0.267,0.051,0.369,0.153l1.09,1.09C12.966,12.531,12.966,12.863,12.763,13.066z M23.998,6.609l-0.104-1.419c-0.02-0.276-0.24-0.496-0.516-0.516l-0.938-0.068l-0.068-0.938c-0.02-0.276-0.24-0.496-0.516-0.516l-0.938-0.068l-0.069-0.938c-0.02-0.276-0.24-0.496-0.516-0.516l-0.938-0.068l-0.069-0.938c-0.02-0.276-0.24-0.496-0.516-0.516l-1.419-0.103c-0.162-0.012-0.321,0.047-0.435,0.162l-1.993,1.993c-0,0.001-0.001,0.001-0.001,0.001c-0.097,0.097-0.191,0.197-0.282,0.298c-1.933,2.042-12.871,13.598-13.716,14.551c-0.722,0.814-0.712,1.983,0.023,2.717l0.341,0.341L0.539,20.852c-0.719,0.719-0.719,1.889,0,2.609c0.36,0.36,0.832,0.539,1.304,0.539c0.472,0,0.945-0.18,1.304-0.539l0.787-0.787l0.341,0.341c0.735,0.735,1.903,0.745,2.717,0.023c0.953-0.845,12.509-11.783,14.551-13.716c0.102-0.091,0.201-0.186,0.299-0.283c0.001-0.001,0.001-0.001,0.001-0.002l1.992-1.992C23.951,6.93,24.01,6.771,23.998,6.609z M20.61,4.179l0.684,0.05l0.05,0.684l-1.418,1.418l-0.733-0.734L20.61,4.179z M19.087,2.656l0.684,0.05l0.05,0.684L18.403,4.807L17.67,4.074L19.087,2.656z M17.564,1.133l0.684,0.05l0.05,0.684l-1.418,1.418l-0.733-0.733L17.564,1.133z M2.359,22.671c-0.284,0.284-0.746,0.284-1.03,0c-0.284-0.284-0.284-0.746,0-1.03l0.787-0.787l1.03,1.03L2.359,22.671z M6.253,22.202c-0.366,0.324-0.877,0.334-1.188,0.023l-0.735-0.735l-2.555-2.555c-0.311-0.311-0.301-0.822,0.023-1.188c0.633-0.715,7.3-7.769,11.189-11.88c-0.014,0.084-0.026,0.169-0.036,0.253c-0.179,1.482,0.239,2.815,1.176,3.752c0.937,0.937,2.27,1.355,3.752,1.176c0.084-0.01,0.169-0.022,0.253-0.036C14.022,14.901,6.968,21.568,6.253,22.202z M14.917,9.083c-0.69-0.69-0.994-1.694-0.857-2.829c0.123-1.019,0.585-2.03,1.315-2.897l0.717,0.717l-0.879,0.879c-0.218,0.218-0.218,0.571,0,0.789c0.218,0.218,0.571,0.218,0.789,0l0.879-0.879l0.734,0.734l-0.879,0.879c-0.218,0.218-0.218,0.571,0,0.789c0.218,0.218,0.571,0.218,0.789,0l0.879-0.879l0.734,0.734l-0.879,0.879c-0.218,0.218-0.218,0.571,0,0.789c0.218,0.218,0.571,0.218,0.789,0l0.879-0.879l0.717,0.717C18.756,10.213,16.277,10.443,14.917,9.083z M21.449,7.853l-0.734-0.734l1.418-1.418l0.684,0.05l0.05,0.684L21.449,7.853z",hs="M7,19V17H9V19H7M11,19V17H13V19H11M15,19V17H17V19H15M7,15V13H9V15H7M11,15V13H13V15H11M15,15V13H17V15H15M7,11V9H9V11H7M11,11V9H13V11H11M15,11V9H17V11H15M7,7V5H9V7H7M11,7V5H13V7H11M15,7V5H17V7H15Z";let ps=class extends ne{constructor(){super(...arguments),this._devices=[],this._hairDevices=[],this._triggers=[],this._loading=!0,this._error=null,this._expandedId=null,this._expandedDevice=null,this._confirmClearAll=!1,this._deleteRemoteId=null,this._deleteRemoteLabel="",this._deleteRemoteCount=0,this._editingDeviceId=null,this._editLabel="",this._createRemoteOpen=!1,this._createSignalDeviceId=null,this._editSignal=null,this._promoteTarget=null,this._assignSignal=null,this._deleteSignal=null,this._triggerDialog=null,this._triggerEditDialog=null,this._triggerPopover=null,this._receivers=[],this._unsubUpdated=null,this._confirmDeleteTriggerId=null,this._testDialog=null,this._testEmitters=[],this._testingSignalId=null,this._testResult=null,this._remotesVersion=0,this._signalsVersion=0,this._remotesSortable=null,this._signalsSortable=null,this._signalsSortableContainer=null,this._pendingRemotesSave=null,this._pendingSignalsSave=null,this._onDocClickForPopover=e=>{const t=this.shadowRoot?.querySelector("ir-trigger-popover");t&&e.composedPath().includes(t)||this._closeTriggerPopover()},this._onScrollForPopover=()=>{this._closeTriggerPopover()}}connectedCallback(){super.connectedCallback(),this._load(),this._subscribeUpdated()}disconnectedCallback(){super.disconnectedCallback(),this._unsubscribeUpdated(),this._removePopoverDismiss(),this._remotesSortable?.destroy(),this._remotesSortable=null,this._signalsSortable?.destroy(),this._signalsSortable=null,this._signalsSortableContainer=null,null!==this._pendingRemotesSave&&clearTimeout(this._pendingRemotesSave),null!==this._pendingSignalsSave&&clearTimeout(this._pendingSignalsSave)}updated(e){if(super.updated(e),e.has("_editingDeviceId")&&this._editingDeviceId){const e=this.shadowRoot?.querySelector(".rename-input");e?.focus(),e?.select()}this._syncSortables()}_syncSortables(){const e=this.renderRoot.querySelector(".device-list");e&&!this._remotesSortable?this._attachRemotesSortable(e):!e&&this._remotesSortable&&(this._remotesSortable.destroy(),this._remotesSortable=null);const t=this.renderRoot.querySelector(".signal-list"),i=!!this._expandedDevice&&!this._expandedDevice.dismissed;!t||!i||this._signalsSortable&&this._signalsSortableContainer===t?t&&i||!this._signalsSortable||(this._signalsSortable.destroy(),this._signalsSortable=null,this._signalsSortableContainer=null):(this._signalsSortable?.destroy(),this._attachSignalsSortable(t))}_attachRemotesSortable(e){this._remotesSortable=di.create(e,{handle:".remote-grip",animation:150,ghostClass:"sortable-ghost",onEnd:t=>{const{oldIndex:i,newIndex:s}=t;if(void 0===i||void 0===s||i===s)return;const o=[...this._devices],[a]=o.splice(i,1);o.splice(s,0,a),this._devices=o,this._remotesSortable?.destroy(),this._remotesSortable=null,this._purgeChildren(e,"ha-card"),this._remotesVersion++,this._scheduleRemotesSave(o.map(e=>e.id))}})}_attachSignalsSortable(e){this._expandedDevice&&(this._signalsSortableContainer=e,this._signalsSortable=di.create(e,{handle:".signal-grip",animation:150,ghostClass:"sortable-ghost",onEnd:t=>{const{oldIndex:i,newIndex:s}=t;if(void 0===i||void 0===s||i===s)return;const o=this._expandedDevice;if(!o)return;const a=[...o.signals],[r]=a.splice(i,1);a.splice(s,0,r),this._expandedDevice={...o,signals:a},this._signalsSortable?.destroy(),this._signalsSortable=null,this._signalsSortableContainer=null,this._purgeChildren(e,".signal-row"),this._signalsVersion++,this._scheduleSignalsSave(o.id,a.map(e=>e.id))}}))}_purgeChildren(e,t){for(const i of Array.from(e.querySelectorAll(t)))i.remove()}_scheduleRemotesSave(e){null!==this._pendingRemotesSave&&clearTimeout(this._pendingRemotesSave),this._pendingRemotesSave=window.setTimeout(async()=>{this._pendingRemotesSave=null;try{await this.api.reorderUnknownDevices("manual",e)}catch(e){this._error=`Reorder failed: ${e.message}`,await this._load()}},500)}_scheduleSignalsSave(e,t){null!==this._pendingSignalsSave&&clearTimeout(this._pendingSignalsSave),this._pendingSignalsSave=window.setTimeout(async()=>{this._pendingSignalsSave=null;try{await this.api.reorderUnknownSignals(e,t)}catch(e){this._error=`Reorder failed: ${e.message}`,await this._refreshExpanded()}},500)}async _load(){this._loading=!0;try{const[e,t,i]=await Promise.all([this.api.getUnknownDevices({include_dismissed:!0,min_hits:0,source:"manual"}),this.api.listDevices(),this.api.listTriggers()]);this._devices=e,this._hairDevices=t,this._triggers=i,this._error=null,this.api.listReceivers().then(e=>{this._receivers=e}).catch(()=>{this._receivers=[]})}catch(e){this._error=`Failed to load: ${e.message}`}finally{this._loading=!1}}_matchesHairDevice(e){if(!e)return!1;const t=e.toLowerCase();return this._hairDevices.some(e=>e.name.toLowerCase()===t)}async _refreshExpanded(){if(this._expandedId)try{this._expandedDevice=await this.api.getUnknownDevice(this._expandedId)}catch{this._expandedId=null,this._expandedDevice=null}}openCreateRemote(){this._createRemoteOpen=!0}async _onRemoteCreated(e){this._createRemoteOpen=!1,await this._load(),this._expandedId=e.detail.id,await this._refreshExpanded()}_openCreateSignal(e,t){t.stopPropagation(),this._createSignalDeviceId=e}async _onSignalCreated(){this._createSignalDeviceId=null,await this._refreshExpanded(),await this._load()}_openEditSignal(e,t,i){i.stopPropagation(),this._editSignal={deviceId:e,signal:t}}async _onSignalEdited(){this._editSignal=null,await this._refreshExpanded(),await this._load()}_openDeleteRemote(e){this._deleteRemoteId=e.id,this._deleteRemoteLabel=e.label||"this remote",this._deleteRemoteCount=e.signals.length}async _confirmDeleteRemote(){const e=this._deleteRemoteId;if(this._deleteRemoteId=null,e)try{await this.api.deleteRemote(e),this._expandedId===e&&(this._expandedId=null,this._expandedDevice=null),await this._load()}catch(e){this._error=`Delete failed: ${e.message}`}}_onAliasChanged(e){const{id:t,alias:i}=e.detail;this._expandedDevice&&(this._expandedDevice={...this._expandedDevice,signals:this._expandedDevice.signals.map(e=>e.id===t?{...e,alias:i}:e)})}_startRename(e,t){t.stopPropagation(),this._editingDeviceId=e.id,this._editLabel=e.label??""}async _commitRename(e){const t=this._editLabel.trim();this._editingDeviceId=null;try{const i=await this.api.renameUnknown(e,t),s=this._devices.findIndex(t=>t.id===e);if(s>=0){const e=[...this._devices];e[s]={...e[s],label:i.label},this._devices=e}}catch(e){this._error=`Rename failed: ${e.message}`}}_onRenameKeydown(e,t){"Enter"===t.key?this._commitRename(e):"Escape"===t.key&&(this._editingDeviceId=null)}_promoteDevice(e,t){t.stopPropagation(),this._promoteTarget=e}async _onDevicePromoted(){this._promoteTarget=null,await this._load()}_openAssign(e,t,i){this._assignSignal={deviceId:e,signal:t,label:i??null}}async _onSignalAssigned(e){this._assignSignal=null,await this._load(),await this._refreshExpanded()}_openDelete(e,t){this._deleteSignal={deviceId:e,signal:t}}async _confirmDelete(){if(!this._deleteSignal)return;const{deviceId:e,signal:t}=this._deleteSignal;this._deleteSignal=null;try{await this.api.deleteSignal(e,t.id),await this._load(),await this._refreshExpanded()}catch(e){this._error=`Delete failed: ${e.message}`}}_openTestDialog(e){this._testDialog={signal:e}}async _sendTest(e){if(!this._testDialog)return;const{signal:t}=this._testDialog,i=e.detail.emitters;if(0!==i.length){this._testingSignalId=t.id,this._testResult=null,this._testDialog=null;try{const e=(await Promise.allSettled(i.map(e=>this.api.testSignal(t.id,e)))).filter(e=>"fulfilled"===e.status&&e.value.sent).length,s=i.length;this._testResult=e===s?1===s?"Sent!":`Sent! (${e}/${s})`:0===e?"Failed":`Sent (${e}/${s})`}catch{this._testResult="Error"}setTimeout(()=>{this._testResult=null,this._testingSignalId=null},3e3)}}_hasTrigger(e){return this._triggers.some(t=>t.signal_fingerprint===e)}_triggerCountFor(e){return this._triggers.filter(t=>t.signal_fingerprint===e).length}_openTriggerDialog(e,t,i){const s=this._triggers.filter(e=>e.signal_fingerprint===t.fingerprint);if(0===s.length)return void(this._triggerDialog={signal:t,deviceId:e});const o=i?.currentTarget,a=o?.getBoundingClientRect();this._triggerPopover={deviceId:e,signal:t,top:a?a.bottom+4:120,left:a?Math.max(8,a.right-220):120},this._installPopoverDismiss()}_closeTriggerPopover(){this._triggerPopover=null,this._removePopoverDismiss()}_onPopoverCreateNew(){const e=this._triggerPopover;this._closeTriggerPopover(),e&&(this._triggerDialog={signal:e.signal,deviceId:e.deviceId})}_onPopoverEditTrigger(e){const t=e.detail;this._closeTriggerPopover(),t&&(this._triggerEditDialog=t)}_installPopoverDismiss(){setTimeout(()=>{document.addEventListener("click",this._onDocClickForPopover,!0),window.addEventListener("scroll",this._onScrollForPopover,!0)},0)}_removePopoverDismiss(){document.removeEventListener("click",this._onDocClickForPopover,!0),window.removeEventListener("scroll",this._onScrollForPopover,!0)}async _subscribeUpdated(){try{this._unsubUpdated=await this.api.subscribeSignalUpdated(()=>{this._refreshAfterSignalUpdate()})}catch{}}async _unsubscribeUpdated(){this._unsubUpdated&&(await this._unsubUpdated(),this._unsubUpdated=null)}async _refreshAfterSignalUpdate(){try{this._triggers=await this.api.listTriggers()}catch{}if(this._expandedId)try{this._expandedDevice=await this.api.getUnknownDevice(this._expandedId)}catch{}}_closeTriggerDialog(){this._triggerDialog=null,this._triggerEditDialog=null}_requestDeleteTrigger(e){this._confirmDeleteTriggerId=e}async _doDeleteTrigger(){if(!this._confirmDeleteTriggerId)return;const e=this._confirmDeleteTriggerId;this._confirmDeleteTriggerId=null,this._triggerEditDialog=null;try{await this.api.deleteTrigger(e),this._triggers=await this.api.listTriggers()}catch{}}async _onTriggerSaved(){this._triggerDialog=null,this._triggerEditDialog=null;try{this._triggers=await this.api.listTriggers()}catch{}}async _toggleExpand(e){if(this._expandedId===e)return this._expandedId=null,void(this._expandedDevice=null);this._expandedId=e,await this._refreshExpanded()}async _doClearAll(){this._confirmClearAll=!1;try{await this.api.clearUnknowns("manual"),this._devices=[],this._expandedId=null,this._expandedDevice=null}catch(e){this._error=`Clear failed: ${e.message}`}}render(){const e=this._devices.length;return B`
             <div class="toolbar">
                 <span class="title">
-                    <ha-svg-icon .path=${ns}></ha-svg-icon>
+                    <ha-svg-icon .path=${cs}></ha-svg-icon>
                     HAIR Clipper
-                    ${this._loading?"":F`<span class="count"
+                    ${this._loading?"":B`<span class="count"
                               >(${e} ${1===e?"remote":"remotes"})</span
                           >`}
                 </span>
@@ -4449,11 +4716,11 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                 </div>
             </div>
 
-            ${this._error?F`<ha-alert alert-type="error">${this._error}</ha-alert>`:""}
+            ${this._error?B`<ha-alert alert-type="error">${this._error}</ha-alert>`:""}
 
-            ${this._loading?F`<div class="loading">Loading...</div>`:0===e?F`
+            ${this._loading?B`<div class="loading">Loading...</div>`:0===e?B`
                         <ha-card class="empty">
-                            <ha-svg-icon class="empty-icon" .path=${ns}></ha-svg-icon>
+                            <ha-svg-icon class="empty-icon" .path=${cs}></ha-svg-icon>
                             <h3>No virtual remotes yet</h3>
                             <p>
                                 Clipper lets you build remotes by pasting Pronto codes.
@@ -4463,13 +4730,13 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                 Click "+ Add Remote" above to start a clipped remote.
                             </p>
                         </ha-card>
-                    `:F`
+                    `:B`
                         <div class="device-list">
                             ${Se(this._remotesVersion,Te(this._devices,e=>e.id,e=>this._renderDevice(e)))}
                         </div>
                     `}
 
-            ${e>0?F`
+            ${e>0?B`
                       <div class="clear-all-row">
                           <button
                               class="action-btn delete-btn"
@@ -4482,12 +4749,12 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                   `:""}
 
             ${this._renderDialogs()}
-        `}_renderDevice(e){const t=this._expandedId===e.id;return F`
+        `}_renderDevice(e){const t=this._expandedId===e.id;return B`
             <ha-card class="device clip-device">
                 <div class="device-row" @click=${()=>this._toggleExpand(e.id)}>
                     <div class="device-info">
                         <div class="device-header">
-                            ${this._editingDeviceId===e.id?F`<input
+                            ${this._editingDeviceId===e.id?B`<input
                                       class="rename-input"
                                       type="text"
                                       .value=${this._editLabel}
@@ -4495,9 +4762,9 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                       @keydown=${t=>this._onRenameKeydown(e.id,t)}
                                       @blur=${()=>{this._commitRename(e.id)}}
                                       @click=${e=>e.stopPropagation()}
-                                  />`:F`<ha-svg-icon
+                                  />`:B`<ha-svg-icon
                                           class="remote-grip"
-                                          .path=${rs}
+                                          .path=${hs}
                                           title="Drag to reorder"
                                           @click=${e=>e.stopPropagation()}
                                       ></ha-svg-icon>
@@ -4511,10 +4778,10 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                 ><strong>${e.signal_count}</strong>
                                 ${1===e.signal_count?"signal":"signals"}</span
                             >
-                            ${e.label&&this._matchesHairDevice(e.label)?F`<span
+                            ${e.label&&this._matchesHairDevice(e.label)?B`<span
                                       class="status-badge hair-device"
                                       @click=${e=>e.stopPropagation()}
-                                  >HAIR Device</span>`:e.label?F`<span
+                                  >HAIR Device</span>`:e.label?B`<span
                                           class="status-badge promote-badge"
                                           @click=${t=>this._promoteDevice(e,t)}
                                       >Promote</span>`:""}
@@ -4528,7 +4795,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
 
                 ${t&&this._expandedDevice?this._renderExpanded(this._expandedDevice):""}
             </ha-card>
-        `}_renderExpanded(e){return F`
+        `}_renderExpanded(e){return B`
             <div class="expanded">
                 <div class="signal-header">
                     <span>Signals (${e.signals.length})</span>
@@ -4540,12 +4807,12 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                         + Add Signal
                     </button>
                 </div>
-                ${0===e.signals.length?F`<div class="no-signals-row">
+                ${0===e.signals.length?B`<div class="no-signals-row">
                           <span class="no-signals"
                               >No signals yet. Click "+ Add Signal" to paste a
                               Pronto code.</span
                           >
-                      </div>`:F`
+                      </div>`:B`
                           <div class="signal-list">
                               ${Se(this._signalsVersion,Te(e.signals,e=>e.id,t=>this._renderSignal(e.id,t,e.label)))}
                           </div>
@@ -4558,11 +4825,11 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     >Delete remote</button>
                 </div>
             </div>
-        `}_renderSignal(e,t,i){const s=this._testingSignalId===t.id;return F`
+        `}_renderSignal(e,t,i){const s=this._testingSignalId===t.id;return B`
             <div class="signal-row">
                 <ha-svg-icon
                     class="signal-grip"
-                    .path=${rs}
+                    .path=${hs}
                     title="Drag to reorder"
                 ></ha-svg-icon>
                 <div class="signal-info">
@@ -4575,9 +4842,9 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     ></ir-signal-alias>
                 </div>
                 <div class="signal-meta">
-                    ${s&&this._testResult?F`<span class="test-result">${this._testResult}</span>`:F`<span>${Math.round(t.frequency/1e3)} kHz</span>`}
+                    ${s&&this._testResult?B`<span class="test-result">${this._testResult}</span>`:B`<span>${Math.round(t.frequency/1e3)} kHz</span>`}
                 </div>
-                ${t.code?F`<button
+                ${t.code?B`<button
                           title="View or edit code"
                           @click=${i=>this._openEditSignal(e,t,i)}
                           style="background:none;border:none;cursor:pointer;color:var(--secondary-text-color);padding:2px;display:inline-flex;align-items:center"
@@ -4590,9 +4857,12 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                 <div class="signal-actions">
                     <button
                         class="action-btn assign-btn"
-                        title="Assign this signal to a HAIR device"
+                        title=${t.assignment_count&&t.assigned_to?.length?1===t.assignment_count?`Assigned to ${t.assigned_to[0]}`:`Assigned to ${t.assignment_count} commands:\n- ${t.assigned_to.join("\n- ")}`:"Assign this signal to a HAIR device"}
                         @click=${s=>{s.stopPropagation(),this._openAssign(e,t,i)}}
-                    >Assign</button>
+                    >Assign<ir-count-dot
+                            color="green"
+                            .count=${t.assignment_count??0}
+                        ></ir-count-dot></button>
                     <button
                         class="action-btn test-btn"
                         ?disabled=${s}
@@ -4600,31 +4870,34 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                         @click=${e=>{e.stopPropagation(),this._openTestDialog(t)}}
                     >${s?"Sending...":"Test"}</button>
                     <button
-                        class="action-btn trigger-btn ${this._hasTrigger(t.fingerprint)?"trigger-on":""}"
-                        title="Create an HA event entity that fires on this signal"
-                        @click=${i=>{i.stopPropagation(),this._openTriggerDialog(e,t)}}
-                    >Trigger</button>
+                        class="action-btn trigger-btn"
+                        title=${this._hasTrigger(t.fingerprint)?"Edit trigger(s) for this signal":"Create an HA event entity that fires on this signal"}
+                        @click=${i=>{i.stopPropagation(),this._openTriggerDialog(e,t,i)}}
+                    >Trigger<ir-count-dot
+                            color="yellow"
+                            .count=${this._triggerCountFor(t.fingerprint)}
+                        ></ir-count-dot></button>
                     <button
                         class="action-btn delete-btn"
                         @click=${i=>{i.stopPropagation(),this._openDelete(e,t)}}
                     >Delete</button>
                 </div>
             </div>
-        `}_renderDialogs(){return F`
-            ${this._createRemoteOpen?F`<ir-create-remote-dialog
+        `}_renderDialogs(){return B`
+            ${this._createRemoteOpen?B`<ir-create-remote-dialog
                       .api=${this.api}
                       @remote-created=${this._onRemoteCreated}
                       @closed=${()=>this._createRemoteOpen=!1}
                   ></ir-create-remote-dialog>`:""}
 
-            ${this._createSignalDeviceId?F`<ir-signal-editor
+            ${this._createSignalDeviceId?B`<ir-signal-editor
                       .api=${this.api}
                       .deviceId=${this._createSignalDeviceId}
                       @signal-created=${this._onSignalCreated}
                       @closed=${()=>this._createSignalDeviceId=null}
                   ></ir-signal-editor>`:""}
 
-            ${this._editSignal?F`<ir-signal-editor
+            ${this._editSignal?B`<ir-signal-editor
                       .api=${this.api}
                       .deviceId=${this._editSignal.deviceId}
                       .signalId=${this._editSignal.signal.id}
@@ -4638,7 +4911,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                       @closed=${()=>this._editSignal=null}
                   ></ir-signal-editor>`:""}
 
-            ${this._assignSignal?F`<ir-assign-signal-dialog
+            ${this._assignSignal?B`<ir-assign-signal-dialog
                       .api=${this.api}
                       .hass=${this.hass}
                       .unknownDeviceId=${this._assignSignal.deviceId}
@@ -4649,7 +4922,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                       @closed=${()=>this._assignSignal=null}
                   ></ir-assign-signal-dialog>`:""}
 
-            ${this._promoteTarget?F`<ir-promote-dialog
+            ${this._promoteTarget?B`<ir-promote-dialog
                       .api=${this.api}
                       .hass=${this.hass}
                       .suggestedName=${this._promoteTarget.label??""}
@@ -4657,7 +4930,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                       @closed=${()=>this._promoteTarget=null}
                   ></ir-promote-dialog>`:""}
 
-            ${this._deleteSignal?F`<ir-confirm-dialog
+            ${this._deleteSignal?B`<ir-confirm-dialog
                       title="Delete Signal"
                       message="Remove this signal permanently? This cannot be undone."
                       confirmLabel="Delete"
@@ -4666,7 +4939,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                       @closed=${()=>this._deleteSignal=null}
                   ></ir-confirm-dialog>`:""}
 
-            ${this._confirmClearAll?F`<ir-confirm-dialog
+            ${this._confirmClearAll?B`<ir-confirm-dialog
                       title="Clear All Clips"
                       message="Remove all clipped remotes and their signals? This cannot be undone. Sniffed signals are not affected."
                       confirmLabel="Clear All"
@@ -4675,7 +4948,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                       @closed=${()=>this._confirmClearAll=!1}
                   ></ir-confirm-dialog>`:""}
 
-            ${this._deleteRemoteId?F`<ir-confirm-dialog
+            ${this._deleteRemoteId?B`<ir-confirm-dialog
                       title="Delete Remote"
                       message=${this._deleteRemoteCount>0?`Remove "${this._deleteRemoteLabel}" and its ${this._deleteRemoteCount} ${1===this._deleteRemoteCount?"signal":"signals"}? This cannot be undone.`:`Remove "${this._deleteRemoteLabel}"? This cannot be undone.`}
                       confirmLabel="Delete"
@@ -4684,7 +4957,16 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                       @closed=${()=>this._deleteRemoteId=null}
                   ></ir-confirm-dialog>`:""}
 
-            ${this._triggerDialog?F`<ir-trigger-dialog
+            ${this._triggerPopover?B`<ir-trigger-popover
+                      .triggers=${this._triggers.filter(e=>e.signal_fingerprint===this._triggerPopover.signal.fingerprint)}
+                      .receivers=${this._receivers}
+                      .top=${this._triggerPopover.top}
+                      .left=${this._triggerPopover.left}
+                      @create-new=${this._onPopoverCreateNew}
+                      @edit-trigger=${this._onPopoverEditTrigger}
+                  ></ir-trigger-popover>`:""}
+
+            ${this._triggerDialog?B`<ir-trigger-dialog
                       .api=${this.api}
                       .signalFingerprint=${this._triggerDialog.signal.fingerprint}
                       .protocol=${this._triggerDialog.signal.protocol}
@@ -4695,7 +4977,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                       @closed=${this._closeTriggerDialog}
                   ></ir-trigger-dialog>`:""}
 
-            ${this._triggerEditDialog?F`<ir-trigger-dialog
+            ${this._triggerEditDialog?B`<ir-trigger-dialog
                       .api=${this.api}
                       .trigger=${this._triggerEditDialog}
                       @trigger-saved=${this._onTriggerSaved}
@@ -4703,7 +4985,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                       @trigger-delete=${e=>this._requestDeleteTrigger(e.detail.triggerId)}
                   ></ir-trigger-dialog>`:""}
 
-            ${this._confirmDeleteTriggerId?F`<ir-confirm-dialog
+            ${this._confirmDeleteTriggerId?B`<ir-confirm-dialog
                       title="Delete Trigger"
                       message="Remove this trigger? The associated HA event entity will also be removed."
                       confirmLabel="Delete"
@@ -4712,7 +4994,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                       @closed=${()=>this._confirmDeleteTriggerId=null}
                   ></ir-confirm-dialog>`:""}
 
-            ${this._testDialog?F`<ir-test-emitter-dialog
+            ${this._testDialog?B`<ir-test-emitter-dialog
                       .api=${this.api}
                       .hass=${this.hass}
                       .value=${this._testEmitters}
@@ -4720,7 +5002,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                       @send=${this._sendTest}
                       @closed=${()=>this._testDialog=null}
                   ></ir-test-emitter-dialog>`:""}
-        `}};ls.styles=n`
+        `}};ps.styles=r`
         :host {
             display: block;
         }
@@ -5090,6 +5372,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
         .action-btn.assign-btn {
             color: #2e7d32;
             border-color: rgba(46, 125, 50, 0.3);
+            position: relative;
         }
         .action-btn.assign-btn:hover {
             background: rgba(46, 125, 50, 0.08);
@@ -5100,14 +5383,10 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
         .action-btn.trigger-btn {
             color: #b89930;
             border-color: rgba(184, 153, 48, 0.3);
+            position: relative;
         }
         .action-btn.trigger-btn:hover {
             background: rgba(184, 153, 48, 0.08);
-        }
-        .action-btn.trigger-btn.trigger-on {
-            color: #fff;
-            background: #b89930;
-            border-color: #b89930;
         }
         .action-btn.delete-btn {
             color: #e65100;
@@ -5120,20 +5399,20 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
             color: var(--secondary-text-color);
             border-color: var(--divider-color);
         }
-    `,e([he({attribute:!1})],ls.prototype,"api",void 0),e([he({attribute:!1})],ls.prototype,"hass",void 0),e([pe()],ls.prototype,"_devices",void 0),e([pe()],ls.prototype,"_hairDevices",void 0),e([pe()],ls.prototype,"_triggers",void 0),e([pe()],ls.prototype,"_loading",void 0),e([pe()],ls.prototype,"_error",void 0),e([pe()],ls.prototype,"_expandedId",void 0),e([pe()],ls.prototype,"_expandedDevice",void 0),e([pe()],ls.prototype,"_confirmClearAll",void 0),e([pe()],ls.prototype,"_deleteRemoteId",void 0),e([pe()],ls.prototype,"_deleteRemoteLabel",void 0),e([pe()],ls.prototype,"_deleteRemoteCount",void 0),e([pe()],ls.prototype,"_editingDeviceId",void 0),e([pe()],ls.prototype,"_editLabel",void 0),e([pe()],ls.prototype,"_createRemoteOpen",void 0),e([pe()],ls.prototype,"_createSignalDeviceId",void 0),e([pe()],ls.prototype,"_editSignal",void 0),e([pe()],ls.prototype,"_promoteTarget",void 0),e([pe()],ls.prototype,"_assignSignal",void 0),e([pe()],ls.prototype,"_deleteSignal",void 0),e([pe()],ls.prototype,"_triggerDialog",void 0),e([pe()],ls.prototype,"_triggerEditDialog",void 0),e([pe()],ls.prototype,"_confirmDeleteTriggerId",void 0),e([pe()],ls.prototype,"_testDialog",void 0),e([pe()],ls.prototype,"_testEmitters",void 0),e([pe()],ls.prototype,"_testingSignalId",void 0),e([pe()],ls.prototype,"_testResult",void 0),e([pe()],ls.prototype,"_remotesVersion",void 0),e([pe()],ls.prototype,"_signalsVersion",void 0),ls=e([ue("ir-clips")],ls);let ds=class extends re{constructor(){super(...arguments),this.pendingEntity="",this._candidates=[],this._entityId="",this._appliance="",this._name="",this._busy=!1,this._loading=!0,this._error=null,this._nameEdited=!1}connectedCallback(){super.connectedCallback(),this._loadVendors()}async _loadVendors(){this._loading=!0;try{const{vendors:e}=await this.api.listPluckVendors();this._candidates=this._flatten(e);const t=this._candidates.find(e=>e.entityId===this.pendingEntity)??(1===this._candidates.length?this._candidates[0]:void 0);t&&(this._entityId=t.entityId,this._autofillName())}catch(e){this._error=e.message,this._candidates=[]}finally{this._loading=!1}}_flatten(e){const t=[];for(const i of e)for(const e of i.blasters)t.push({integration:i.integration,entityId:e.entity_id,vendorName:i.name,blasterName:e.name,applianceLabel:i.appliance_label||"Appliance",applianceHelp:i.appliance_help||""});return t}get _selected(){return this._candidates.find(e=>e.entityId===this._entityId)}_autofillName(){if(this._nameEdited)return;const e=this._selected;if(!e)return;const t=this._appliance.trim();this._name=(t?`${e.blasterName}: ${t}`:e.blasterName).trim()}_onVendorChange(e){this._entityId=e.target.value,this._autofillName()}_onApplianceInput(e){this._appliance=e.target.value,this._autofillName()}_close(){this.dispatchEvent(new CustomEvent("closed",{bubbles:!0,composed:!0}))}async _create(){const e=this._selected;if(e)if(this._appliance.trim())if(this._name.trim()){this._busy=!0,this._error=null;try{const t=await this.api.createPluckedBlaster({vendor_entity_id:e.entityId,appliance:this._appliance.trim(),name:this._name.trim()});this.dispatchEvent(new CustomEvent("blaster-created",{detail:t,bubbles:!0,composed:!0}))}catch(e){this._error=e.message}finally{this._busy=!1}}else this._error="Name is required.";else this._error="Appliance is required.";else this._error="Pick a blaster to pluck from."}render(){const e=this._selected;return F`
+    `,e([he({attribute:!1})],ps.prototype,"api",void 0),e([he({attribute:!1})],ps.prototype,"hass",void 0),e([pe()],ps.prototype,"_devices",void 0),e([pe()],ps.prototype,"_hairDevices",void 0),e([pe()],ps.prototype,"_triggers",void 0),e([pe()],ps.prototype,"_loading",void 0),e([pe()],ps.prototype,"_error",void 0),e([pe()],ps.prototype,"_expandedId",void 0),e([pe()],ps.prototype,"_expandedDevice",void 0),e([pe()],ps.prototype,"_confirmClearAll",void 0),e([pe()],ps.prototype,"_deleteRemoteId",void 0),e([pe()],ps.prototype,"_deleteRemoteLabel",void 0),e([pe()],ps.prototype,"_deleteRemoteCount",void 0),e([pe()],ps.prototype,"_editingDeviceId",void 0),e([pe()],ps.prototype,"_editLabel",void 0),e([pe()],ps.prototype,"_createRemoteOpen",void 0),e([pe()],ps.prototype,"_createSignalDeviceId",void 0),e([pe()],ps.prototype,"_editSignal",void 0),e([pe()],ps.prototype,"_promoteTarget",void 0),e([pe()],ps.prototype,"_assignSignal",void 0),e([pe()],ps.prototype,"_deleteSignal",void 0),e([pe()],ps.prototype,"_triggerDialog",void 0),e([pe()],ps.prototype,"_triggerEditDialog",void 0),e([pe()],ps.prototype,"_triggerPopover",void 0),e([pe()],ps.prototype,"_receivers",void 0),e([pe()],ps.prototype,"_confirmDeleteTriggerId",void 0),e([pe()],ps.prototype,"_testDialog",void 0),e([pe()],ps.prototype,"_testEmitters",void 0),e([pe()],ps.prototype,"_testingSignalId",void 0),e([pe()],ps.prototype,"_testResult",void 0),e([pe()],ps.prototype,"_remotesVersion",void 0),e([pe()],ps.prototype,"_signalsVersion",void 0),ps=e([ue("ir-clips")],ps);let gs=class extends ne{constructor(){super(...arguments),this.pendingEntity="",this._candidates=[],this._entityId="",this._appliance="",this._name="",this._busy=!1,this._loading=!0,this._error=null,this._nameEdited=!1}connectedCallback(){super.connectedCallback(),this._loadVendors()}async _loadVendors(){this._loading=!0;try{const{vendors:e}=await this.api.listPluckVendors();this._candidates=this._flatten(e);const t=this._candidates.find(e=>e.entityId===this.pendingEntity)??(1===this._candidates.length?this._candidates[0]:void 0);t&&(this._entityId=t.entityId,this._autofillName())}catch(e){this._error=e.message,this._candidates=[]}finally{this._loading=!1}}_flatten(e){const t=[];for(const i of e)for(const e of i.blasters)t.push({integration:i.integration,entityId:e.entity_id,vendorName:i.name,blasterName:e.name,applianceLabel:i.appliance_label||"Appliance",applianceHelp:i.appliance_help||""});return t}get _selected(){return this._candidates.find(e=>e.entityId===this._entityId)}_autofillName(){if(this._nameEdited)return;const e=this._selected;if(!e)return;const t=this._appliance.trim();this._name=(t?`${e.blasterName}: ${t}`:e.blasterName).trim()}_onVendorChange(e){this._entityId=e.target.value,this._autofillName()}_onApplianceInput(e){this._appliance=e.target.value,this._autofillName()}_close(){this.dispatchEvent(new CustomEvent("closed",{bubbles:!0,composed:!0}))}async _create(){const e=this._selected;if(e)if(this._appliance.trim())if(this._name.trim()){this._busy=!0,this._error=null;try{const t=await this.api.createPluckedBlaster({vendor_entity_id:e.entityId,appliance:this._appliance.trim(),name:this._name.trim()});this.dispatchEvent(new CustomEvent("blaster-created",{detail:t,bubbles:!0,composed:!0}))}catch(e){this._error=e.message}finally{this._busy=!1}}else this._error="Name is required.";else this._error="Appliance is required.";else this._error="Pick a blaster to pluck from."}render(){const e=this._selected;return B`
             <ha-dialog
                 open
                 heading="Add Blaster"
                 scrimClickAction=""
                 @closed=${this._close}
             >
-                ${this._error?F`<ha-alert alert-type="error">${this._error}</ha-alert>`:""}
+                ${this._error?B`<ha-alert alert-type="error">${this._error}</ha-alert>`:""}
 
-                ${this._loading?F`<div class="muted">Loading blasters...</div>`:0===this._candidates.length?F`<div class="muted">
+                ${this._loading?B`<div class="muted">Loading blasters...</div>`:0===this._candidates.length?B`<div class="muted">
                             No compatible blasters found. Install a supported IR
                             integration (such as Tuya Local) and learn a code
                             first.
-                        </div>`:F`
+                        </div>`:B`
                             <div class="field">
                                 <label>Pluck from</label>
                                 <select
@@ -5141,7 +5420,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                     @change=${this._onVendorChange}
                                 >
                                     <option value="">Select a blaster</option>
-                                    ${this._candidates.map(e=>F`<option
+                                    ${this._candidates.map(e=>B`<option
                                             value=${e.entityId}
                                         >
                                             ${e.vendorName}: ${e.blasterName}
@@ -5158,7 +5437,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                     required
                                     @input=${this._onApplianceInput}
                                 />
-                                ${e?.applianceHelp?F`<div class="help">
+                                ${e?.applianceHelp?B`<div class="help">
                                           ${e.applianceHelp}
                                       </div>`:""}
                             </div>
@@ -5191,7 +5470,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     </button>
                 </div>
             </ha-dialog>
-        `}};ds.styles=n`
+        `}};gs.styles=r`
         .field {
             display: block;
             margin: 12px 0;
@@ -5272,22 +5551,22 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
         .create-btn:hover:not(:disabled) {
             opacity: 0.9;
         }
-    `,e([he({attribute:!1})],ds.prototype,"api",void 0),e([he()],ds.prototype,"pendingEntity",void 0),e([pe()],ds.prototype,"_candidates",void 0),e([pe()],ds.prototype,"_entityId",void 0),e([pe()],ds.prototype,"_appliance",void 0),e([pe()],ds.prototype,"_name",void 0),e([pe()],ds.prototype,"_busy",void 0),e([pe()],ds.prototype,"_loading",void 0),e([pe()],ds.prototype,"_error",void 0),ds=e([ue("ir-pluck-add-remote-dialog")],ds);let cs=class extends re{constructor(){super(...arguments),this.integration="",this._commandName="",this._busy=!1,this._creating=!1,this._error=null,this._captures=null,this._aliases=[],this._validations=[]}_close(){this.dispatchEvent(new CustomEvent("closed",{bubbles:!0,composed:!0}))}async _pluck(){const e=this._commandName.trim();if(e){this._busy=!0,this._error=null;try{const t=await this.api.runPluck({integration:this.integration,vendor_entity_id:this.blaster.vendor_entity_id??"",appliance:this.blaster.appliance??"",command_name:e});t.error?this._error=t.message??"Pluck failed.":t.signals&&t.signals.length>0?(this._captures=t.signals,this._aliases=t.signals.map(e=>e.suggested_alias),this._validations=await Promise.all(t.signals.map(e=>this.api.validatePronto(e.code??"").catch(()=>null)))):this._error="No response from blaster. Try again."}catch(e){this._error=e.message}finally{this._busy=!1}}else this._error="Command name is required."}_removeCapture(e){this._captures&&(this._captures=this._captures.filter((t,i)=>i!==e),this._aliases=this._aliases.filter((t,i)=>i!==e),this._validations=this._validations.filter((t,i)=>i!==e),0===this._captures.length&&(this._captures=null))}async _create(){if(this._captures&&0!==this._captures.length){this._creating=!0,this._error=null;try{const e=[];for(let t=0;t<this._captures.length;t++){const i=this._captures[t],s=await this.api.createPluckedSignal({device_id:this.blaster.id,pronto:i.code??"",command_name:i.plucked_command_name,alias:this._aliases[t].trim()});e.push(s)}this.dispatchEvent(new CustomEvent("signals-created",{detail:e,bubbles:!0,composed:!0}))}catch(e){this._error=e.message}finally{this._creating=!1}}}_renderValid(e,t){const i=this._validations[t]??null,s=i?.recognized_protocol??e.decoded_protocol??null,a=null!=i?.frequency_khz?i.frequency_khz.toFixed(1):(e.frequency/1e3).toFixed(1),o=i?.burst_pair_count??null;return F`
+    `,e([he({attribute:!1})],gs.prototype,"api",void 0),e([he()],gs.prototype,"pendingEntity",void 0),e([pe()],gs.prototype,"_candidates",void 0),e([pe()],gs.prototype,"_entityId",void 0),e([pe()],gs.prototype,"_appliance",void 0),e([pe()],gs.prototype,"_name",void 0),e([pe()],gs.prototype,"_busy",void 0),e([pe()],gs.prototype,"_loading",void 0),e([pe()],gs.prototype,"_error",void 0),gs=e([ue("ir-pluck-add-remote-dialog")],gs);let us=class extends ne{constructor(){super(...arguments),this.integration="",this._commandName="",this._busy=!1,this._creating=!1,this._error=null,this._captures=null,this._aliases=[],this._validations=[]}_close(){this.dispatchEvent(new CustomEvent("closed",{bubbles:!0,composed:!0}))}async _pluck(){const e=this._commandName.trim();if(e){this._busy=!0,this._error=null;try{const t=await this.api.runPluck({integration:this.integration,vendor_entity_id:this.blaster.vendor_entity_id??"",appliance:this.blaster.appliance??"",command_name:e});t.error?this._error=t.message??"Pluck failed.":t.signals&&t.signals.length>0?(this._captures=t.signals,this._aliases=t.signals.map(e=>e.suggested_alias),this._validations=await Promise.all(t.signals.map(e=>this.api.validatePronto(e.code??"").catch(()=>null)))):this._error="No response from blaster. Try again."}catch(e){this._error=e.message}finally{this._busy=!1}}else this._error="Command name is required."}_removeCapture(e){this._captures&&(this._captures=this._captures.filter((t,i)=>i!==e),this._aliases=this._aliases.filter((t,i)=>i!==e),this._validations=this._validations.filter((t,i)=>i!==e),0===this._captures.length&&(this._captures=null))}async _create(){if(this._captures&&0!==this._captures.length){this._creating=!0,this._error=null;try{const e=[];for(let t=0;t<this._captures.length;t++){const i=this._captures[t],s=await this.api.createPluckedSignal({device_id:this.blaster.id,pronto:i.code??"",command_name:i.plucked_command_name,alias:this._aliases[t].trim()});e.push(s)}this.dispatchEvent(new CustomEvent("signals-created",{detail:e,bubbles:!0,composed:!0}))}catch(e){this._error=e.message}finally{this._creating=!1}}}_renderValid(e,t){const i=this._validations[t]??null,s=i?.recognized_protocol??e.decoded_protocol??null,o=null!=i?.frequency_khz?i.frequency_khz.toFixed(1):(e.frequency/1e3).toFixed(1),a=i?.burst_pair_count??null;return B`
             <div class="valid-box">
                 <div class="valid-head">
                     <ha-svg-icon .path=${"M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"}></ha-svg-icon>
                     ${s?`Recognized as ${s}`:"Valid Pronto code"}
                 </div>
                 <div class="valid-sub">
-                    ${a} kHz${null!=o?` · ${o} burst pairs`:""}
+                    ${o} kHz${null!=a?` · ${a} burst pairs`:""}
                 </div>
             </div>
-        `}_renderError(){return this._error?F`
+        `}_renderError(){return this._error?B`
             <div class="pluck-error">
                 <ha-svg-icon .path=${"M11,15H13V17H11V15M11,7H13V13H11V7M12,2C6.47,2 2,6.5 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20Z"}></ha-svg-icon>
                 <span>${this._error}</span>
             </div>
-        `:""}_renderCommandState(){return F`
+        `:""}_renderCommandState(){return B`
             <div class="field">
                 <label>Command name</label>
                 <input
@@ -5320,14 +5599,14 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     ${this._busy?"Plucking...":"Pluck"}
                 </button>
             </div>
-        `}_renderCaptures(e){const t=e.length>1;return F`
+        `}_renderCaptures(e){const t=e.length>1;return B`
             ${this._renderError()}
             <div class="captured-label">
                 Captured ${t?`(${e.length})`:""}
             </div>
-            ${e.map((e,i)=>F`
+            ${e.map((e,i)=>B`
                     <div class="capture">
-                        ${t?F`<button
+                        ${t?B`<button
                                   class="remove-btn"
                                   title="Remove this capture"
                                   @click=${()=>this._removeCapture(i)}
@@ -5362,7 +5641,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     ${this._creating?"Saving...":"Create"}
                 </button>
             </div>
-        `}render(){return F`
+        `}render(){return B`
             <ha-dialog
                 open
                 heading="Pluck Signal"
@@ -5371,7 +5650,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
             >
                 ${this._captures?this._renderCaptures(this._captures):this._renderCommandState()}
             </ha-dialog>
-        `}};cs.styles=n`
+        `}};us.styles=r`
         .field {
             display: block;
             margin: 12px 0;
@@ -5524,12 +5803,12 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
         .create-btn:hover:not(:disabled) {
             opacity: 0.9;
         }
-    `,e([he({attribute:!1})],cs.prototype,"api",void 0),e([he({attribute:!1})],cs.prototype,"blaster",void 0),e([he()],cs.prototype,"integration",void 0),e([pe()],cs.prototype,"_commandName",void 0),e([pe()],cs.prototype,"_busy",void 0),e([pe()],cs.prototype,"_creating",void 0),e([pe()],cs.prototype,"_error",void 0),e([pe()],cs.prototype,"_captures",void 0),e([pe()],cs.prototype,"_aliases",void 0),e([pe()],cs.prototype,"_validations",void 0),cs=e([ue("ir-pluck-signal-dialog")],cs);const hs="M0.861,24c-0.22,0-0.441-0.084-0.609-0.252c-0.336-0.336-0.336-0.882,0-1.218l1.563-1.563c1.648-1.649,3.474-4.166,5.588-7.082c2.984-4.116,6.367-8.781,10.695-13.109c0.081-0.081,0.178-0.145,0.284-0.189l1.283-0.523c0.441-0.18,0.943,0.032,1.123,0.472l-0.472,1.123L19.194,2.116c-4.175,4.199-7.478,8.755-10.397,12.78c-0.275,0.379-0.545,0.752-0.811,1.117c0.365-0.266,0.738-0.536,1.117-0.811C13.128,12.284,17.685,8.98,21.884,4.806l0.457-1.121L23.464,3.212c0.44,0.18,0.652,0.682,0.472,1.123l-0.523,1.283c-0.043,0.106-0.107,0.203-0.188,0.284c-4.329,4.329-8.994,7.711-13.109,10.695c-2.915,2.114-5.433,3.939-7.082,5.588l-1.563,1.563C1.302,23.916,1.082,24,0.861,24z",ps="M7,19V17H9V19H7M11,19V17H13V19H11M15,19V17H17V19H15M7,15V13H9V15H7M11,15V13H13V15H11M15,15V13H17V15H15M7,11V9H9V11H7M11,11V9H13V11H11M15,11V9H17V11H15M7,7V5H9V7H7M11,7V5H13V7H11M15,7V5H17V7H15Z";let gs=class extends re{constructor(){super(...arguments),this.pendingEntity="",this._devices=[],this._hairDevices=[],this._triggers=[],this._loading=!0,this._error=null,this._expandedId=null,this._expandedDevice=null,this._confirmClearAll=!1,this._deleteRemoteId=null,this._deleteRemoteLabel="",this._deleteRemoteCount=0,this._vendorIntegration={},this._editingDeviceId=null,this._editLabel="",this._createRemoteOpen=!1,this._promoteTarget=null,this._pluckDialog=null,this._editSignal=null,this._assignSignal=null,this._deleteSignal=null,this._triggerDialog=null,this._triggerEditDialog=null,this._confirmDeleteTriggerId=null,this._testDialog=null,this._testEmitters=[],this._testingSignalId=null,this._testResult=null,this._remotesVersion=0,this._signalsVersion=0,this._remotesSortable=null,this._signalsSortable=null,this._signalsSortableContainer=null,this._pendingRemotesSave=null,this._pendingSignalsSave=null}connectedCallback(){super.connectedCallback(),this._load()}disconnectedCallback(){super.disconnectedCallback(),this._remotesSortable?.destroy(),this._remotesSortable=null,this._signalsSortable?.destroy(),this._signalsSortable=null,this._signalsSortableContainer=null,null!==this._pendingRemotesSave&&clearTimeout(this._pendingRemotesSave),null!==this._pendingSignalsSave&&clearTimeout(this._pendingSignalsSave)}updated(e){if(super.updated(e),e.has("_editingDeviceId")&&this._editingDeviceId){const e=this.shadowRoot?.querySelector(".rename-input");e?.focus(),e?.select()}this._syncSortables()}_syncSortables(){const e=this.renderRoot.querySelector(".device-list");e&&!this._remotesSortable?this._attachRemotesSortable(e):!e&&this._remotesSortable&&(this._remotesSortable.destroy(),this._remotesSortable=null);const t=this.renderRoot.querySelector(".signal-list"),i=!!this._expandedDevice;!t||!i||this._signalsSortable&&this._signalsSortableContainer===t?t&&i||!this._signalsSortable||(this._signalsSortable.destroy(),this._signalsSortable=null,this._signalsSortableContainer=null):(this._signalsSortable?.destroy(),this._attachSignalsSortable(t))}_attachRemotesSortable(e){this._remotesSortable=di.create(e,{handle:".remote-grip",animation:150,ghostClass:"sortable-ghost",onEnd:t=>{const{oldIndex:i,newIndex:s}=t;if(void 0===i||void 0===s||i===s)return;const a=[...this._devices],[o]=a.splice(i,1);a.splice(s,0,o),this._devices=a,this._remotesSortable?.destroy(),this._remotesSortable=null,this._purgeChildren(e,"ha-card"),this._remotesVersion++,this._scheduleRemotesSave(a.map(e=>e.id))}})}_attachSignalsSortable(e){this._expandedDevice&&(this._signalsSortableContainer=e,this._signalsSortable=di.create(e,{handle:".signal-grip",animation:150,ghostClass:"sortable-ghost",onEnd:t=>{const{oldIndex:i,newIndex:s}=t;if(void 0===i||void 0===s||i===s)return;const a=this._expandedDevice;if(!a)return;const o=[...a.signals],[n]=o.splice(i,1);o.splice(s,0,n),this._expandedDevice={...a,signals:o},this._signalsSortable?.destroy(),this._signalsSortable=null,this._signalsSortableContainer=null,this._purgeChildren(e,".signal-row"),this._signalsVersion++,this._scheduleSignalsSave(a.id,o.map(e=>e.id))}}))}_purgeChildren(e,t){for(const i of Array.from(e.querySelectorAll(t)))i.remove()}_scheduleRemotesSave(e){null!==this._pendingRemotesSave&&clearTimeout(this._pendingRemotesSave),this._pendingRemotesSave=window.setTimeout(async()=>{this._pendingRemotesSave=null;try{await this.api.reorderUnknownDevices("plucked",e)}catch(e){this._error=`Reorder failed: ${e.message}`,await this._load()}},500)}_scheduleSignalsSave(e,t){null!==this._pendingSignalsSave&&clearTimeout(this._pendingSignalsSave),this._pendingSignalsSave=window.setTimeout(async()=>{this._pendingSignalsSave=null;try{await this.api.reorderUnknownSignals(e,t)}catch(e){this._error=`Reorder failed: ${e.message}`,await this._refreshExpanded()}},500)}async _load(){this._loading=!0;try{const[e,t,i,s]=await Promise.all([this.api.getUnknownDevices({include_dismissed:!1,min_hits:0,source:"plucked"}),this.api.listDevices(),this.api.listTriggers(),this.api.listPluckVendors().catch(()=>({vendors:[]}))]);this._devices=e,this._hairDevices=t,this._triggers=i,this._vendorIntegration=this._mapIntegrations(s.vendors),this._error=null}catch(e){this._error=`Failed to load: ${e.message}`}finally{this._loading=!1}}_mapIntegrations(e){const t={};for(const i of e)for(const e of i.blasters)t[e.entity_id]=i.integration;return t}async _refreshExpanded(){if(this._expandedId)try{this._expandedDevice=await this.api.getUnknownDevice(this._expandedId)}catch{this._expandedId=null,this._expandedDevice=null}}openCreateRemote(){this._createRemoteOpen=!0}async _onBlasterCreated(e){this._createRemoteOpen=!1,this.pendingEntity="",await this._load(),this._expandedId=e.detail.id,await this._refreshExpanded()}_openPluckSignal(e,t){t.stopPropagation();const i=e.vendor_entity_id?this._vendorIntegration[e.vendor_entity_id]??"":"";i?this._pluckDialog={device:e,integration:i}:this._error="This blaster's integration is not available right now. Make sure the vendor integration is loaded."}async _onSignalsCreated(){this._pluckDialog=null,await this._refreshExpanded(),await this._load()}_openEditSignal(e,t,i){i.stopPropagation(),this._editSignal={deviceId:e,signal:t}}async _onSignalEdited(){this._editSignal=null,await this._refreshExpanded(),await this._load()}_openDeleteRemote(e){this._deleteRemoteId=e.id,this._deleteRemoteLabel=e.label||"this blaster",this._deleteRemoteCount=e.signals.length}async _confirmDeleteRemote(){const e=this._deleteRemoteId;if(this._deleteRemoteId=null,e)try{await this.api.deletePluckedBlaster(e),this._expandedId===e&&(this._expandedId=null,this._expandedDevice=null),await this._load()}catch(e){this._error=`Delete failed: ${e.message}`}}async _doClearAll(){this._confirmClearAll=!1;try{await this.api.clearUnknowns("plucked"),this._devices=[],this._expandedId=null,this._expandedDevice=null}catch(e){this._error=`Clear failed: ${e.message}`}}_onAliasChanged(e){const{id:t,alias:i}=e.detail;this._expandedDevice&&(this._expandedDevice={...this._expandedDevice,signals:this._expandedDevice.signals.map(e=>e.id===t?{...e,alias:i}:e)})}_startRename(e,t){t.stopPropagation(),this._editingDeviceId=e.id,this._editLabel=e.label??""}async _commitRename(e){const t=this._editLabel.trim();this._editingDeviceId=null;try{const i=await this.api.renameUnknown(e,t),s=this._devices.findIndex(t=>t.id===e);if(s>=0){const e=[...this._devices];e[s]={...e[s],label:i.label},this._devices=e}}catch(e){this._error=`Rename failed: ${e.message}`}}_onRenameKeydown(e,t){"Enter"===t.key?this._commitRename(e):"Escape"===t.key&&(this._editingDeviceId=null)}_openAssign(e,t,i){this._assignSignal={deviceId:e,signal:t,label:i??null}}async _onSignalAssigned(e){this._assignSignal=null,await this._load(),await this._refreshExpanded()}_matchesHairDevice(e){if(!e)return!1;const t=e.toLowerCase();return this._hairDevices.some(e=>e.name.toLowerCase()===t)}_promoteDevice(e,t){t.stopPropagation(),this._promoteTarget=e}async _onDevicePromoted(){this._promoteTarget=null,await this._load()}_openDelete(e,t){this._deleteSignal={deviceId:e,signal:t}}async _confirmDelete(){if(!this._deleteSignal)return;const{deviceId:e,signal:t}=this._deleteSignal;this._deleteSignal=null;try{await this.api.deleteSignal(e,t.id),await this._load(),await this._refreshExpanded()}catch(e){this._error=`Delete failed: ${e.message}`}}_openTestDialog(e){this._testDialog={signal:e}}async _sendTest(e){if(!this._testDialog)return;const{signal:t}=this._testDialog,i=e.detail.emitters;if(0!==i.length){this._testingSignalId=t.id,this._testResult=null,this._testDialog=null;try{const e=(await Promise.allSettled(i.map(e=>this.api.testSignal(t.id,e)))).filter(e=>"fulfilled"===e.status&&e.value.sent).length,s=i.length;this._testResult=e===s?1===s?"Sent!":`Sent! (${e}/${s})`:0===e?"Failed":`Sent (${e}/${s})`}catch{this._testResult="Error"}setTimeout(()=>{this._testResult=null,this._testingSignalId=null},3e3)}}_hasTrigger(e){return this._triggers.some(t=>t.signal_fingerprint===e)}_openTriggerDialog(e,t){const i=this._triggers.find(e=>e.signal_fingerprint===t.fingerprint);i?this._triggerEditDialog=i:this._triggerDialog={signal:t,deviceId:e}}_closeTriggerDialog(){this._triggerDialog=null,this._triggerEditDialog=null}_requestDeleteTrigger(e){this._confirmDeleteTriggerId=e}async _doDeleteTrigger(){if(!this._confirmDeleteTriggerId)return;const e=this._confirmDeleteTriggerId;this._confirmDeleteTriggerId=null,this._triggerEditDialog=null;try{await this.api.deleteTrigger(e),this._triggers=await this.api.listTriggers()}catch{}}async _onTriggerSaved(){this._triggerDialog=null,this._triggerEditDialog=null;try{this._triggers=await this.api.listTriggers()}catch{}}async _toggleExpand(e){if(this._expandedId===e)return this._expandedId=null,void(this._expandedDevice=null);this._expandedId=e,await this._refreshExpanded()}render(){const e=this._devices.length;return F`
+    `,e([he({attribute:!1})],us.prototype,"api",void 0),e([he({attribute:!1})],us.prototype,"blaster",void 0),e([he()],us.prototype,"integration",void 0),e([pe()],us.prototype,"_commandName",void 0),e([pe()],us.prototype,"_busy",void 0),e([pe()],us.prototype,"_creating",void 0),e([pe()],us.prototype,"_error",void 0),e([pe()],us.prototype,"_captures",void 0),e([pe()],us.prototype,"_aliases",void 0),e([pe()],us.prototype,"_validations",void 0),us=e([ue("ir-pluck-signal-dialog")],us);const ms="M0.861,24c-0.22,0-0.441-0.084-0.609-0.252c-0.336-0.336-0.336-0.882,0-1.218l1.563-1.563c1.648-1.649,3.474-4.166,5.588-7.082c2.984-4.116,6.367-8.781,10.695-13.109c0.081-0.081,0.178-0.145,0.284-0.189l1.283-0.523c0.441-0.18,0.943,0.032,1.123,0.472l-0.472,1.123L19.194,2.116c-4.175,4.199-7.478,8.755-10.397,12.78c-0.275,0.379-0.545,0.752-0.811,1.117c0.365-0.266,0.738-0.536,1.117-0.811C13.128,12.284,17.685,8.98,21.884,4.806l0.457-1.121L23.464,3.212c0.44,0.18,0.652,0.682,0.472,1.123l-0.523,1.283c-0.043,0.106-0.107,0.203-0.188,0.284c-4.329,4.329-8.994,7.711-13.109,10.695c-2.915,2.114-5.433,3.939-7.082,5.588l-1.563,1.563C1.302,23.916,1.082,24,0.861,24z",vs="M7,19V17H9V19H7M11,19V17H13V19H11M15,19V17H17V19H15M7,15V13H9V15H7M11,15V13H13V15H11M15,15V13H17V15H15M7,11V9H9V11H7M11,11V9H13V11H11M15,11V9H17V11H15M7,7V5H9V7H7M11,7V5H13V7H11M15,7V5H17V7H15Z";let _s=class extends ne{constructor(){super(...arguments),this.pendingEntity="",this._devices=[],this._hairDevices=[],this._triggers=[],this._loading=!0,this._error=null,this._expandedId=null,this._expandedDevice=null,this._confirmClearAll=!1,this._deleteRemoteId=null,this._deleteRemoteLabel="",this._deleteRemoteCount=0,this._vendorIntegration={},this._editingDeviceId=null,this._editLabel="",this._createRemoteOpen=!1,this._promoteTarget=null,this._pluckDialog=null,this._editSignal=null,this._assignSignal=null,this._deleteSignal=null,this._triggerDialog=null,this._triggerEditDialog=null,this._triggerPopover=null,this._receivers=[],this._unsubUpdated=null,this._confirmDeleteTriggerId=null,this._testDialog=null,this._testEmitters=[],this._testingSignalId=null,this._testResult=null,this._remotesVersion=0,this._signalsVersion=0,this._remotesSortable=null,this._signalsSortable=null,this._signalsSortableContainer=null,this._pendingRemotesSave=null,this._pendingSignalsSave=null,this._onDocClickForPopover=e=>{const t=this.shadowRoot?.querySelector("ir-trigger-popover");t&&e.composedPath().includes(t)||this._closeTriggerPopover()},this._onScrollForPopover=()=>{this._closeTriggerPopover()}}connectedCallback(){super.connectedCallback(),this._load(),this._subscribeUpdated()}disconnectedCallback(){super.disconnectedCallback(),this._unsubscribeUpdated(),this._removePopoverDismiss(),this._remotesSortable?.destroy(),this._remotesSortable=null,this._signalsSortable?.destroy(),this._signalsSortable=null,this._signalsSortableContainer=null,null!==this._pendingRemotesSave&&clearTimeout(this._pendingRemotesSave),null!==this._pendingSignalsSave&&clearTimeout(this._pendingSignalsSave)}updated(e){if(super.updated(e),e.has("_editingDeviceId")&&this._editingDeviceId){const e=this.shadowRoot?.querySelector(".rename-input");e?.focus(),e?.select()}this._syncSortables()}_syncSortables(){const e=this.renderRoot.querySelector(".device-list");e&&!this._remotesSortable?this._attachRemotesSortable(e):!e&&this._remotesSortable&&(this._remotesSortable.destroy(),this._remotesSortable=null);const t=this.renderRoot.querySelector(".signal-list"),i=!!this._expandedDevice;!t||!i||this._signalsSortable&&this._signalsSortableContainer===t?t&&i||!this._signalsSortable||(this._signalsSortable.destroy(),this._signalsSortable=null,this._signalsSortableContainer=null):(this._signalsSortable?.destroy(),this._attachSignalsSortable(t))}_attachRemotesSortable(e){this._remotesSortable=di.create(e,{handle:".remote-grip",animation:150,ghostClass:"sortable-ghost",onEnd:t=>{const{oldIndex:i,newIndex:s}=t;if(void 0===i||void 0===s||i===s)return;const o=[...this._devices],[a]=o.splice(i,1);o.splice(s,0,a),this._devices=o,this._remotesSortable?.destroy(),this._remotesSortable=null,this._purgeChildren(e,"ha-card"),this._remotesVersion++,this._scheduleRemotesSave(o.map(e=>e.id))}})}_attachSignalsSortable(e){this._expandedDevice&&(this._signalsSortableContainer=e,this._signalsSortable=di.create(e,{handle:".signal-grip",animation:150,ghostClass:"sortable-ghost",onEnd:t=>{const{oldIndex:i,newIndex:s}=t;if(void 0===i||void 0===s||i===s)return;const o=this._expandedDevice;if(!o)return;const a=[...o.signals],[r]=a.splice(i,1);a.splice(s,0,r),this._expandedDevice={...o,signals:a},this._signalsSortable?.destroy(),this._signalsSortable=null,this._signalsSortableContainer=null,this._purgeChildren(e,".signal-row"),this._signalsVersion++,this._scheduleSignalsSave(o.id,a.map(e=>e.id))}}))}_purgeChildren(e,t){for(const i of Array.from(e.querySelectorAll(t)))i.remove()}_scheduleRemotesSave(e){null!==this._pendingRemotesSave&&clearTimeout(this._pendingRemotesSave),this._pendingRemotesSave=window.setTimeout(async()=>{this._pendingRemotesSave=null;try{await this.api.reorderUnknownDevices("plucked",e)}catch(e){this._error=`Reorder failed: ${e.message}`,await this._load()}},500)}_scheduleSignalsSave(e,t){null!==this._pendingSignalsSave&&clearTimeout(this._pendingSignalsSave),this._pendingSignalsSave=window.setTimeout(async()=>{this._pendingSignalsSave=null;try{await this.api.reorderUnknownSignals(e,t)}catch(e){this._error=`Reorder failed: ${e.message}`,await this._refreshExpanded()}},500)}async _load(){this._loading=!0;try{const[e,t,i,s]=await Promise.all([this.api.getUnknownDevices({include_dismissed:!1,min_hits:0,source:"plucked"}),this.api.listDevices(),this.api.listTriggers(),this.api.listPluckVendors().catch(()=>({vendors:[]}))]);this._devices=e,this._hairDevices=t,this._triggers=i,this._vendorIntegration=this._mapIntegrations(s.vendors),this._error=null,this.api.listReceivers().then(e=>{this._receivers=e}).catch(()=>{this._receivers=[]})}catch(e){this._error=`Failed to load: ${e.message}`}finally{this._loading=!1}}_mapIntegrations(e){const t={};for(const i of e)for(const e of i.blasters)t[e.entity_id]=i.integration;return t}async _refreshExpanded(){if(this._expandedId)try{this._expandedDevice=await this.api.getUnknownDevice(this._expandedId)}catch{this._expandedId=null,this._expandedDevice=null}}openCreateRemote(){this._createRemoteOpen=!0}async _onBlasterCreated(e){this._createRemoteOpen=!1,this.pendingEntity="",await this._load(),this._expandedId=e.detail.id,await this._refreshExpanded()}_openPluckSignal(e,t){t.stopPropagation();const i=e.vendor_entity_id?this._vendorIntegration[e.vendor_entity_id]??"":"";i?this._pluckDialog={device:e,integration:i}:this._error="This blaster's integration is not available right now. Make sure the vendor integration is loaded."}async _onSignalsCreated(){this._pluckDialog=null,await this._refreshExpanded(),await this._load()}_openEditSignal(e,t,i){i.stopPropagation(),this._editSignal={deviceId:e,signal:t}}async _onSignalEdited(){this._editSignal=null,await this._refreshExpanded(),await this._load()}_openDeleteRemote(e){this._deleteRemoteId=e.id,this._deleteRemoteLabel=e.label||"this blaster",this._deleteRemoteCount=e.signals.length}async _confirmDeleteRemote(){const e=this._deleteRemoteId;if(this._deleteRemoteId=null,e)try{await this.api.deletePluckedBlaster(e),this._expandedId===e&&(this._expandedId=null,this._expandedDevice=null),await this._load()}catch(e){this._error=`Delete failed: ${e.message}`}}async _doClearAll(){this._confirmClearAll=!1;try{await this.api.clearUnknowns("plucked"),this._devices=[],this._expandedId=null,this._expandedDevice=null}catch(e){this._error=`Clear failed: ${e.message}`}}_onAliasChanged(e){const{id:t,alias:i}=e.detail;this._expandedDevice&&(this._expandedDevice={...this._expandedDevice,signals:this._expandedDevice.signals.map(e=>e.id===t?{...e,alias:i}:e)})}_startRename(e,t){t.stopPropagation(),this._editingDeviceId=e.id,this._editLabel=e.label??""}async _commitRename(e){const t=this._editLabel.trim();this._editingDeviceId=null;try{const i=await this.api.renameUnknown(e,t),s=this._devices.findIndex(t=>t.id===e);if(s>=0){const e=[...this._devices];e[s]={...e[s],label:i.label},this._devices=e}}catch(e){this._error=`Rename failed: ${e.message}`}}_onRenameKeydown(e,t){"Enter"===t.key?this._commitRename(e):"Escape"===t.key&&(this._editingDeviceId=null)}_openAssign(e,t,i){this._assignSignal={deviceId:e,signal:t,label:i??null}}async _onSignalAssigned(e){this._assignSignal=null,await this._load(),await this._refreshExpanded()}_matchesHairDevice(e){if(!e)return!1;const t=e.toLowerCase();return this._hairDevices.some(e=>e.name.toLowerCase()===t)}_promoteDevice(e,t){t.stopPropagation(),this._promoteTarget=e}async _onDevicePromoted(){this._promoteTarget=null,await this._load()}_openDelete(e,t){this._deleteSignal={deviceId:e,signal:t}}async _confirmDelete(){if(!this._deleteSignal)return;const{deviceId:e,signal:t}=this._deleteSignal;this._deleteSignal=null;try{await this.api.deleteSignal(e,t.id),await this._load(),await this._refreshExpanded()}catch(e){this._error=`Delete failed: ${e.message}`}}_openTestDialog(e){this._testDialog={signal:e}}async _sendTest(e){if(!this._testDialog)return;const{signal:t}=this._testDialog,i=e.detail.emitters;if(0!==i.length){this._testingSignalId=t.id,this._testResult=null,this._testDialog=null;try{const e=(await Promise.allSettled(i.map(e=>this.api.testSignal(t.id,e)))).filter(e=>"fulfilled"===e.status&&e.value.sent).length,s=i.length;this._testResult=e===s?1===s?"Sent!":`Sent! (${e}/${s})`:0===e?"Failed":`Sent (${e}/${s})`}catch{this._testResult="Error"}setTimeout(()=>{this._testResult=null,this._testingSignalId=null},3e3)}}_hasTrigger(e){return this._triggers.some(t=>t.signal_fingerprint===e)}_triggerCountFor(e){return this._triggers.filter(t=>t.signal_fingerprint===e).length}_openTriggerDialog(e,t,i){const s=this._triggers.filter(e=>e.signal_fingerprint===t.fingerprint);if(0===s.length)return void(this._triggerDialog={signal:t,deviceId:e});const o=i?.currentTarget,a=o?.getBoundingClientRect();this._triggerPopover={deviceId:e,signal:t,top:a?a.bottom+4:120,left:a?Math.max(8,a.right-220):120},this._installPopoverDismiss()}_closeTriggerPopover(){this._triggerPopover=null,this._removePopoverDismiss()}_onPopoverCreateNew(){const e=this._triggerPopover;this._closeTriggerPopover(),e&&(this._triggerDialog={signal:e.signal,deviceId:e.deviceId})}_onPopoverEditTrigger(e){const t=e.detail;this._closeTriggerPopover(),t&&(this._triggerEditDialog=t)}_installPopoverDismiss(){setTimeout(()=>{document.addEventListener("click",this._onDocClickForPopover,!0),window.addEventListener("scroll",this._onScrollForPopover,!0)},0)}_removePopoverDismiss(){document.removeEventListener("click",this._onDocClickForPopover,!0),window.removeEventListener("scroll",this._onScrollForPopover,!0)}async _subscribeUpdated(){try{this._unsubUpdated=await this.api.subscribeSignalUpdated(()=>{this._refreshAfterSignalUpdate()})}catch{}}async _unsubscribeUpdated(){this._unsubUpdated&&(await this._unsubUpdated(),this._unsubUpdated=null)}async _refreshAfterSignalUpdate(){try{this._triggers=await this.api.listTriggers()}catch{}if(this._expandedId)try{this._expandedDevice=await this.api.getUnknownDevice(this._expandedId)}catch{}}_closeTriggerDialog(){this._triggerDialog=null,this._triggerEditDialog=null}_requestDeleteTrigger(e){this._confirmDeleteTriggerId=e}async _doDeleteTrigger(){if(!this._confirmDeleteTriggerId)return;const e=this._confirmDeleteTriggerId;this._confirmDeleteTriggerId=null,this._triggerEditDialog=null;try{await this.api.deleteTrigger(e),this._triggers=await this.api.listTriggers()}catch{}}async _onTriggerSaved(){this._triggerDialog=null,this._triggerEditDialog=null;try{this._triggers=await this.api.listTriggers()}catch{}}async _toggleExpand(e){if(this._expandedId===e)return this._expandedId=null,void(this._expandedDevice=null);this._expandedId=e,await this._refreshExpanded()}render(){const e=this._devices.length;return B`
             <div class="toolbar">
                 <span class="title">
-                    <ha-svg-icon .path=${hs}></ha-svg-icon>
+                    <ha-svg-icon .path=${ms}></ha-svg-icon>
                     HAIR Plucker
-                    ${this._loading?"":F`<span class="count"
+                    ${this._loading?"":B`<span class="count"
                               >(${e} ${1===e?"blaster":"blasters"})</span
                           >`}
                 </span>
@@ -5543,11 +5822,11 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                 </div>
             </div>
 
-            ${this._error?F`<ha-alert alert-type="error">${this._error}</ha-alert>`:""}
+            ${this._error?B`<ha-alert alert-type="error">${this._error}</ha-alert>`:""}
 
-            ${this._loading?F`<div class="loading">Loading...</div>`:0===e?F`
+            ${this._loading?B`<div class="loading">Loading...</div>`:0===e?B`
                         <ha-card class="empty">
-                            <ha-svg-icon class="empty-icon" .path=${hs}></ha-svg-icon>
+                            <ha-svg-icon class="empty-icon" .path=${ms}></ha-svg-icon>
                             <h3>No plucked blasters yet</h3>
                             <p>
                                 The Plucker imports IR codes from your existing
@@ -5558,13 +5837,13 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                 Click "+ Add Blaster" above to mirror a blaster.
                             </p>
                         </ha-card>
-                    `:F`
+                    `:B`
                         <div class="device-list">
                             ${Se(this._remotesVersion,Te(this._devices,e=>e.id,e=>this._renderDevice(e)))}
                         </div>
                     `}
 
-            ${e>0?F`
+            ${e>0?B`
                       <div class="clear-all-row">
                           <button
                               class="action-btn delete-btn"
@@ -5577,12 +5856,12 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                   `:""}
 
             ${this._renderDialogs()}
-        `}_renderDevice(e){const t=this._expandedId===e.id;return F`
+        `}_renderDevice(e){const t=this._expandedId===e.id;return B`
             <ha-card class="device pluck-device">
                 <div class="device-row" @click=${()=>this._toggleExpand(e.id)}>
                     <div class="device-info">
                         <div class="device-header">
-                            ${this._editingDeviceId===e.id?F`<input
+                            ${this._editingDeviceId===e.id?B`<input
                                       class="rename-input"
                                       type="text"
                                       .value=${this._editLabel}
@@ -5590,9 +5869,9 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                       @keydown=${t=>this._onRenameKeydown(e.id,t)}
                                       @blur=${()=>{this._commitRename(e.id)}}
                                       @click=${e=>e.stopPropagation()}
-                                  />`:F`<ha-svg-icon
+                                  />`:B`<ha-svg-icon
                                           class="remote-grip"
-                                          .path=${ps}
+                                          .path=${vs}
                                           title="Drag to reorder"
                                           @click=${e=>e.stopPropagation()}
                                       ></ha-svg-icon>
@@ -5602,7 +5881,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                           @click=${t=>this._startRename(e,t)}
                                           >${e.label??"Blaster"}</span
                                       >`}
-                            ${e.appliance?F`<span
+                            ${e.appliance?B`<span
                                       class="appliance-badge"
                                       @click=${e=>e.stopPropagation()}
                                       >${e.appliance}</span
@@ -5611,11 +5890,11 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                                 ><strong>${e.signal_count}</strong>
                                 ${1===e.signal_count?"signal":"signals"}</span
                             >
-                            ${e.label&&this._matchesHairDevice(e.label)?F`<span
+                            ${e.label&&this._matchesHairDevice(e.label)?B`<span
                                       class="status-badge hair-device"
                                       @click=${e=>e.stopPropagation()}
                                       >HAIR Device</span
-                                  >`:e.label?F`<span
+                                  >`:e.label?B`<span
                                         class="status-badge promote-badge"
                                         title="Create a HAIR device from this blaster"
                                         @click=${t=>this._promoteDevice(e,t)}
@@ -5631,7 +5910,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
 
                 ${t&&this._expandedDevice?this._renderExpanded(this._expandedDevice):""}
             </ha-card>
-        `}_renderExpanded(e){return F`
+        `}_renderExpanded(e){return B`
             <div class="expanded">
                 <div class="signal-header">
                     <span>Signals (${e.signals.length})</span>
@@ -5643,12 +5922,12 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                         + Pluck Signal
                     </button>
                 </div>
-                ${0===e.signals.length?F`<div class="no-signals-row">
+                ${0===e.signals.length?B`<div class="no-signals-row">
                           <span class="no-signals"
                               >No signals yet. Click "+ Pluck Signal" to pull a
                               code off this blaster.</span
                           >
-                      </div>`:F`
+                      </div>`:B`
                           <div class="signal-list">
                               ${Se(this._signalsVersion,Te(e.signals,e=>e.id,t=>this._renderSignal(e.id,t,e.label)))}
                           </div>
@@ -5663,11 +5942,11 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     </button>
                 </div>
             </div>
-        `}_renderSignal(e,t,i){const s=this._testingSignalId===t.id;return F`
+        `}_renderSignal(e,t,i){const s=this._testingSignalId===t.id;return B`
             <div class="signal-row">
                 <ha-svg-icon
                     class="signal-grip"
-                    .path=${ps}
+                    .path=${vs}
                     title="Drag to reorder"
                 ></ha-svg-icon>
                 <div class="signal-info">
@@ -5680,9 +5959,9 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     ></ir-signal-alias>
                 </div>
                 <div class="signal-meta">
-                    ${s&&this._testResult?F`<span class="test-result">${this._testResult}</span>`:F`<span>${Math.round(t.frequency/1e3)} kHz</span>`}
+                    ${s&&this._testResult?B`<span class="test-result">${this._testResult}</span>`:B`<span>${Math.round(t.frequency/1e3)} kHz</span>`}
                 </div>
-                ${t.code?F`<button
+                ${t.code?B`<button
                           title="View or edit code"
                           @click=${i=>this._openEditSignal(e,t,i)}
                           style="background:none;border:none;cursor:pointer;color:var(--secondary-text-color);padding:2px;display:inline-flex;align-items:center"
@@ -5695,10 +5974,13 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                 <div class="signal-actions">
                     <button
                         class="action-btn assign-btn"
-                        title="Assign this signal to a HAIR device"
+                        title=${t.assignment_count&&t.assigned_to?.length?1===t.assignment_count?`Assigned to ${t.assigned_to[0]}`:`Assigned to ${t.assignment_count} commands:\n- ${t.assigned_to.join("\n- ")}`:"Assign this signal to a HAIR device"}
                         @click=${s=>{s.stopPropagation(),this._openAssign(e,t,i)}}
                     >
-                        Assign
+                        Assign<ir-count-dot
+                            color="green"
+                            .count=${t.assignment_count??0}
+                        ></ir-count-dot>
                     </button>
                     <button
                         class="action-btn test-btn"
@@ -5709,11 +5991,14 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                         ${s?"Sending...":"Test"}
                     </button>
                     <button
-                        class="action-btn trigger-btn ${this._hasTrigger(t.fingerprint)?"trigger-on":""}"
-                        title="Create an HA event entity that fires on this signal"
-                        @click=${i=>{i.stopPropagation(),this._openTriggerDialog(e,t)}}
+                        class="action-btn trigger-btn"
+                        title=${this._hasTrigger(t.fingerprint)?"Edit trigger(s) for this signal":"Create an HA event entity that fires on this signal"}
+                        @click=${i=>{i.stopPropagation(),this._openTriggerDialog(e,t,i)}}
                     >
-                        Trigger
+                        Trigger<ir-count-dot
+                            color="yellow"
+                            .count=${this._triggerCountFor(t.fingerprint)}
+                        ></ir-count-dot>
                     </button>
                     <button
                         class="action-btn delete-btn"
@@ -5723,15 +6008,15 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                     </button>
                 </div>
             </div>
-        `}_renderDialogs(){return F`
-            ${this._createRemoteOpen?F`<ir-pluck-add-remote-dialog
+        `}_renderDialogs(){return B`
+            ${this._createRemoteOpen?B`<ir-pluck-add-remote-dialog
                       .api=${this.api}
                       .pendingEntity=${this.pendingEntity}
                       @blaster-created=${this._onBlasterCreated}
                       @closed=${()=>{this._createRemoteOpen=!1,this.pendingEntity=""}}
                   ></ir-pluck-add-remote-dialog>`:""}
 
-            ${this._promoteTarget?F`<ir-promote-dialog
+            ${this._promoteTarget?B`<ir-promote-dialog
                       .api=${this.api}
                       .hass=${this.hass}
                       .suggestedName=${this._promoteTarget.label??""}
@@ -5739,7 +6024,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                       @closed=${()=>this._promoteTarget=null}
                   ></ir-promote-dialog>`:""}
 
-            ${this._pluckDialog?F`<ir-pluck-signal-dialog
+            ${this._pluckDialog?B`<ir-pluck-signal-dialog
                       .api=${this.api}
                       .blaster=${this._pluckDialog.device}
                       .integration=${this._pluckDialog.integration}
@@ -5747,7 +6032,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                       @closed=${()=>this._pluckDialog=null}
                   ></ir-pluck-signal-dialog>`:""}
 
-            ${this._editSignal?F`<ir-signal-editor
+            ${this._editSignal?B`<ir-signal-editor
                       .api=${this.api}
                       .deviceId=${this._editSignal.deviceId}
                       .signalId=${this._editSignal.signal.id}
@@ -5761,7 +6046,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                       @closed=${()=>this._editSignal=null}
                   ></ir-signal-editor>`:""}
 
-            ${this._assignSignal?F`<ir-assign-signal-dialog
+            ${this._assignSignal?B`<ir-assign-signal-dialog
                       .api=${this.api}
                       .hass=${this.hass}
                       .unknownDeviceId=${this._assignSignal.deviceId}
@@ -5772,7 +6057,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                       @closed=${()=>this._assignSignal=null}
                   ></ir-assign-signal-dialog>`:""}
 
-            ${this._deleteSignal?F`<ir-confirm-dialog
+            ${this._deleteSignal?B`<ir-confirm-dialog
                       title="Delete Signal"
                       message="Remove this signal permanently? This cannot be undone."
                       confirmLabel="Delete"
@@ -5781,7 +6066,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                       @closed=${()=>this._deleteSignal=null}
                   ></ir-confirm-dialog>`:""}
 
-            ${this._confirmClearAll?F`<ir-confirm-dialog
+            ${this._confirmClearAll?B`<ir-confirm-dialog
                       title="Clear All Plucked"
                       message="Remove all plucked blasters and their signals? This cannot be undone. Sniffed and clipped signals are not affected."
                       confirmLabel="Clear All"
@@ -5790,7 +6075,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                       @closed=${()=>this._confirmClearAll=!1}
                   ></ir-confirm-dialog>`:""}
 
-            ${this._deleteRemoteId?F`<ir-confirm-dialog
+            ${this._deleteRemoteId?B`<ir-confirm-dialog
                       title="Delete Blaster"
                       message=${this._deleteRemoteCount>0?`Remove "${this._deleteRemoteLabel}" and its ${this._deleteRemoteCount} ${1===this._deleteRemoteCount?"signal":"signals"}? This cannot be undone.`:`Remove "${this._deleteRemoteLabel}"? This cannot be undone.`}
                       confirmLabel="Delete"
@@ -5799,7 +6084,16 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                       @closed=${()=>this._deleteRemoteId=null}
                   ></ir-confirm-dialog>`:""}
 
-            ${this._triggerDialog?F`<ir-trigger-dialog
+            ${this._triggerPopover?B`<ir-trigger-popover
+                      .triggers=${this._triggers.filter(e=>e.signal_fingerprint===this._triggerPopover.signal.fingerprint)}
+                      .receivers=${this._receivers}
+                      .top=${this._triggerPopover.top}
+                      .left=${this._triggerPopover.left}
+                      @create-new=${this._onPopoverCreateNew}
+                      @edit-trigger=${this._onPopoverEditTrigger}
+                  ></ir-trigger-popover>`:""}
+
+            ${this._triggerDialog?B`<ir-trigger-dialog
                       .api=${this.api}
                       .signalFingerprint=${this._triggerDialog.signal.fingerprint}
                       .protocol=${this._triggerDialog.signal.protocol}
@@ -5810,7 +6104,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                       @closed=${this._closeTriggerDialog}
                   ></ir-trigger-dialog>`:""}
 
-            ${this._triggerEditDialog?F`<ir-trigger-dialog
+            ${this._triggerEditDialog?B`<ir-trigger-dialog
                       .api=${this.api}
                       .trigger=${this._triggerEditDialog}
                       @trigger-saved=${this._onTriggerSaved}
@@ -5818,7 +6112,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                       @trigger-delete=${e=>this._requestDeleteTrigger(e.detail.triggerId)}
                   ></ir-trigger-dialog>`:""}
 
-            ${this._confirmDeleteTriggerId?F`<ir-confirm-dialog
+            ${this._confirmDeleteTriggerId?B`<ir-confirm-dialog
                       title="Delete Trigger"
                       message="Remove this trigger? The associated HA event entity will also be removed."
                       confirmLabel="Delete"
@@ -5827,7 +6121,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                       @closed=${()=>this._confirmDeleteTriggerId=null}
                   ></ir-confirm-dialog>`:""}
 
-            ${this._testDialog?F`<ir-test-emitter-dialog
+            ${this._testDialog?B`<ir-test-emitter-dialog
                       .api=${this.api}
                       .hass=${this.hass}
                       .value=${this._testEmitters}
@@ -5835,7 +6129,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                       @send=${this._sendTest}
                       @closed=${()=>this._testDialog=null}
                   ></ir-test-emitter-dialog>`:""}
-        `}};gs.styles=n`
+        `}};_s.styles=r`
         :host {
             display: block;
         }
@@ -6170,6 +6464,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
         .action-btn.assign-btn {
             color: #2e7d32;
             border-color: rgba(46, 125, 50, 0.3);
+            position: relative;
         }
         .action-btn.assign-btn:hover {
             background: rgba(46, 125, 50, 0.08);
@@ -6180,14 +6475,10 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
         .action-btn.trigger-btn {
             color: #b89930;
             border-color: rgba(184, 153, 48, 0.3);
+            position: relative;
         }
         .action-btn.trigger-btn:hover {
             background: rgba(184, 153, 48, 0.08);
-        }
-        .action-btn.trigger-btn.trigger-on {
-            color: #fff;
-            background: #b89930;
-            border-color: #b89930;
         }
         .action-btn.delete-btn {
             color: #e65100;
@@ -6196,7 +6487,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
         .action-btn.delete-btn:hover {
             background: rgba(230, 81, 0, 0.08);
         }
-    `,e([he({attribute:!1})],gs.prototype,"api",void 0),e([he({attribute:!1})],gs.prototype,"hass",void 0),e([he()],gs.prototype,"pendingEntity",void 0),e([pe()],gs.prototype,"_devices",void 0),e([pe()],gs.prototype,"_hairDevices",void 0),e([pe()],gs.prototype,"_triggers",void 0),e([pe()],gs.prototype,"_loading",void 0),e([pe()],gs.prototype,"_error",void 0),e([pe()],gs.prototype,"_expandedId",void 0),e([pe()],gs.prototype,"_expandedDevice",void 0),e([pe()],gs.prototype,"_confirmClearAll",void 0),e([pe()],gs.prototype,"_deleteRemoteId",void 0),e([pe()],gs.prototype,"_deleteRemoteLabel",void 0),e([pe()],gs.prototype,"_deleteRemoteCount",void 0),e([pe()],gs.prototype,"_editingDeviceId",void 0),e([pe()],gs.prototype,"_editLabel",void 0),e([pe()],gs.prototype,"_createRemoteOpen",void 0),e([pe()],gs.prototype,"_promoteTarget",void 0),e([pe()],gs.prototype,"_pluckDialog",void 0),e([pe()],gs.prototype,"_editSignal",void 0),e([pe()],gs.prototype,"_assignSignal",void 0),e([pe()],gs.prototype,"_deleteSignal",void 0),e([pe()],gs.prototype,"_triggerDialog",void 0),e([pe()],gs.prototype,"_triggerEditDialog",void 0),e([pe()],gs.prototype,"_confirmDeleteTriggerId",void 0),e([pe()],gs.prototype,"_testDialog",void 0),e([pe()],gs.prototype,"_testEmitters",void 0),e([pe()],gs.prototype,"_testingSignalId",void 0),e([pe()],gs.prototype,"_testResult",void 0),e([pe()],gs.prototype,"_remotesVersion",void 0),e([pe()],gs.prototype,"_signalsVersion",void 0),gs=e([ue("ir-pluck")],gs);let us=class extends re{constructor(){super(...arguments),this.narrow=!1,this._activeTab="devices",this._devices=[],this._expandedDeviceId=null,this._loading=!0,this._error=null,this._addDialogOpen=!1,this._pluckersAvailable=!1,this._pendingPluckEntity="",this._api=null}connectedCallback(){super.connectedCallback(),this.hass&&this._init()}updated(e){e.has("hass")&&this.hass&&!this._api&&this._init()}_init(){this._api=new me(this.hass),this._refreshDevices(),this._checkPluckers()}async _checkPluckers(){if(this._api){try{const{vendors:e}=await this._api.listPluckVendors();this._pluckersAvailable=e.length>0}catch{this._pluckersAvailable=!1}"plucker"!==this._activeTab||this._pluckersAvailable||this._switchTab("devices")}}_tagline(){return{devices:"Manage your IR devices and the hardware that drives them.",sniffer:"Capture IR codes live from the air.",clips:"Build remotes by pasting known IR codes.",plucker:"Pluck IR codes from existing blasters."}[this._activeTab]}async _refreshDevices(){if(this._api){this._loading=!0;try{this._devices=await this._api.listDevices(),this._error=null}catch(e){this._error=`Failed to load devices: ${e.message}`}finally{this._loading=!1}}}_toggleDevice(e){this._expandedDeviceId=this._expandedDeviceId===e?null:e}_openAddDialog(){this._addDialogOpen=!0}_onNavigatePlucker(e){this._pendingPluckEntity=e.detail?.vendor_entity_id??"",this._switchTab("plucker")}_closeAddDialog(){this._addDialogOpen=!1}async _onDeviceCreated(e){this._addDialogOpen=!1,await this._refreshDevices(),this._expandedDeviceId=e.detail.id}async _onDeviceChanged(){await this._refreshDevices()}async _onDeviceDeleted(){this._expandedDeviceId=null,await this._refreshDevices()}_switchTab(e){this._expandedDeviceId=null,this._activeTab=e,"devices"===e&&this._refreshDevices()}_openHaSidebar(){this.dispatchEvent(new Event("hass-toggle-menu",{bubbles:!0,composed:!0}))}render(){return this._api?F`
+    `,e([he({attribute:!1})],_s.prototype,"api",void 0),e([he({attribute:!1})],_s.prototype,"hass",void 0),e([he()],_s.prototype,"pendingEntity",void 0),e([pe()],_s.prototype,"_devices",void 0),e([pe()],_s.prototype,"_hairDevices",void 0),e([pe()],_s.prototype,"_triggers",void 0),e([pe()],_s.prototype,"_loading",void 0),e([pe()],_s.prototype,"_error",void 0),e([pe()],_s.prototype,"_expandedId",void 0),e([pe()],_s.prototype,"_expandedDevice",void 0),e([pe()],_s.prototype,"_confirmClearAll",void 0),e([pe()],_s.prototype,"_deleteRemoteId",void 0),e([pe()],_s.prototype,"_deleteRemoteLabel",void 0),e([pe()],_s.prototype,"_deleteRemoteCount",void 0),e([pe()],_s.prototype,"_editingDeviceId",void 0),e([pe()],_s.prototype,"_editLabel",void 0),e([pe()],_s.prototype,"_createRemoteOpen",void 0),e([pe()],_s.prototype,"_promoteTarget",void 0),e([pe()],_s.prototype,"_pluckDialog",void 0),e([pe()],_s.prototype,"_editSignal",void 0),e([pe()],_s.prototype,"_assignSignal",void 0),e([pe()],_s.prototype,"_deleteSignal",void 0),e([pe()],_s.prototype,"_triggerDialog",void 0),e([pe()],_s.prototype,"_triggerEditDialog",void 0),e([pe()],_s.prototype,"_triggerPopover",void 0),e([pe()],_s.prototype,"_receivers",void 0),e([pe()],_s.prototype,"_confirmDeleteTriggerId",void 0),e([pe()],_s.prototype,"_testDialog",void 0),e([pe()],_s.prototype,"_testEmitters",void 0),e([pe()],_s.prototype,"_testingSignalId",void 0),e([pe()],_s.prototype,"_testResult",void 0),e([pe()],_s.prototype,"_remotesVersion",void 0),e([pe()],_s.prototype,"_signalsVersion",void 0),_s=e([ue("ir-pluck")],_s);let bs=class extends ne{constructor(){super(...arguments),this.narrow=!1,this._activeTab="devices",this._devices=[],this._expandedDeviceId=null,this._loading=!0,this._error=null,this._addDialogOpen=!1,this._pluckersAvailable=!1,this._pendingPluckEntity="",this._api=null}connectedCallback(){super.connectedCallback(),this.hass&&this._init()}updated(e){e.has("hass")&&this.hass&&!this._api&&this._init()}_init(){this._api=new me(this.hass),this._refreshDevices(),this._checkPluckers()}async _checkPluckers(){if(this._api){try{const{vendors:e}=await this._api.listPluckVendors();this._pluckersAvailable=e.length>0}catch{this._pluckersAvailable=!1}"plucker"!==this._activeTab||this._pluckersAvailable||this._switchTab("devices")}}_tagline(){return{devices:"Manage your IR devices and the hardware that drives them.",sniffer:"Capture IR codes live from the air.",clips:"Build remotes by pasting known IR codes.",plucker:"Pluck IR codes from existing blasters."}[this._activeTab]}async _refreshDevices(){if(this._api){this._loading=!0;try{this._devices=await this._api.listDevices(),this._error=null}catch(e){this._error=`Failed to load devices: ${e.message}`}finally{this._loading=!1}}}_toggleDevice(e){this._expandedDeviceId=this._expandedDeviceId===e?null:e}_openAddDialog(){this._addDialogOpen=!0}_onNavigatePlucker(e){this._pendingPluckEntity=e.detail?.vendor_entity_id??"",this._switchTab("plucker")}_closeAddDialog(){this._addDialogOpen=!1}async _onDeviceCreated(e){this._addDialogOpen=!1,await this._refreshDevices(),this._expandedDeviceId=e.detail.id}async _onDeviceChanged(){await this._refreshDevices()}async _onDeviceDeleted(){this._expandedDeviceId=null,await this._refreshDevices()}_switchTab(e){this._expandedDeviceId=null,this._activeTab=e,"devices"===e&&this._refreshDevices()}_openHaSidebar(){this.dispatchEvent(new Event("hass-toggle-menu",{bubbles:!0,composed:!0}))}render(){return this._api?B`
             <ha-top-app-bar-fixed>
                 <ha-menu-button
                     slot="navigationIcon"
@@ -6243,7 +6534,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                 >
                     Clipper
                 </button>
-                ${this._pluckersAvailable?F`<button
+                ${this._pluckersAvailable?B`<button
                           class="tab ${"plucker"===this._activeTab?"active":""}"
                           @click=${()=>this._switchTab("plucker")}
                       >
@@ -6254,8 +6545,8 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
             <div class="tab-tagline">${this._tagline()}</div>
 
             <div class="content">
-                ${this._error?F`<ha-alert alert-type="error">${this._error}</ha-alert>`:""}
-                ${"devices"===this._activeTab?F`
+                ${this._error?B`<ha-alert alert-type="error">${this._error}</ha-alert>`:""}
+                ${"devices"===this._activeTab?B`
                           <ir-device-list
                               .devices=${this._devices}
                               .hass=${this.hass}
@@ -6271,17 +6562,17 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                               @add-device=${this._openAddDialog}
                           ></ir-device-list>
 
-                      `:"sniffer"===this._activeTab?F`
+                      `:"sniffer"===this._activeTab?B`
                             <ir-signal-monitor
                                 .api=${this._api}
                                 .hass=${this.hass}
                             ></ir-signal-monitor>
-                        `:"clips"===this._activeTab?F`
+                        `:"clips"===this._activeTab?B`
                               <ir-clips
                                   .api=${this._api}
                                   .hass=${this.hass}
                               ></ir-clips>
-                          `:F`
+                          `:B`
                               <ir-pluck
                                   .api=${this._api}
                                   .hass=${this.hass}
@@ -6290,7 +6581,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
                           `}
             </div>
 
-            ${this._addDialogOpen?F`
+            ${this._addDialogOpen?B`
                       <ir-add-device-dialog
                           .api=${this._api}
                           .hass=${this.hass}
@@ -6301,7 +6592,7 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
 
             <div class="version-footer">v${"0.5.6"}</div>
             </ha-top-app-bar-fixed>
-        `:F`<div class="loading">Loading…</div>`}};us.styles=n`
+        `:B`<div class="loading">Loading…</div>`}};bs.styles=r`
         :host {
             display: block;
             background: var(--primary-background-color);
@@ -6447,4 +6738,4 @@ function e(e,t,i,s){var a,o=arguments.length,n=o<3?t:null===s?s=Object.getOwnPro
         .mobile-nav-button ha-svg-icon {
             --mdc-icon-size: 22px;
         }
-    `,e([he({attribute:!1})],us.prototype,"hass",void 0),e([he({attribute:!1})],us.prototype,"narrow",void 0),e([he({attribute:!1})],us.prototype,"route",void 0),e([he({attribute:!1})],us.prototype,"panel",void 0),e([pe()],us.prototype,"_activeTab",void 0),e([pe()],us.prototype,"_devices",void 0),e([pe()],us.prototype,"_expandedDeviceId",void 0),e([pe()],us.prototype,"_loading",void 0),e([pe()],us.prototype,"_error",void 0),e([pe()],us.prototype,"_addDialogOpen",void 0),e([pe()],us.prototype,"_pluckersAvailable",void 0),e([pe()],us.prototype,"_pendingPluckEntity",void 0),us=e([ue("ha-panel-ir-devices")],us);export{us as HaPanelIrDevices};
+    `,e([he({attribute:!1})],bs.prototype,"hass",void 0),e([he({attribute:!1})],bs.prototype,"narrow",void 0),e([he({attribute:!1})],bs.prototype,"route",void 0),e([he({attribute:!1})],bs.prototype,"panel",void 0),e([pe()],bs.prototype,"_activeTab",void 0),e([pe()],bs.prototype,"_devices",void 0),e([pe()],bs.prototype,"_expandedDeviceId",void 0),e([pe()],bs.prototype,"_loading",void 0),e([pe()],bs.prototype,"_error",void 0),e([pe()],bs.prototype,"_addDialogOpen",void 0),e([pe()],bs.prototype,"_pluckersAvailable",void 0),e([pe()],bs.prototype,"_pendingPluckEntity",void 0),bs=e([ue("ha-panel-ir-devices")],bs);export{bs as HaPanelIrDevices};

--- a/custom_components/hair/frontend/src/api.ts
+++ b/custom_components/hair/frontend/src/api.ts
@@ -27,6 +27,7 @@ import type {
     ReceiverInfo,
     SignalRemovedEvent,
     SignalSourceId,
+    SignalUpdatedEvent,
     TestSignalResult,
     TriggerFiredEvent,
     UnknownDevice,
@@ -606,6 +607,22 @@ export class HairApi {
     }
 
     /**
+     * Subscribe to signal-updated events (fired when a signal's assignment
+     * set changes: an assign, or a device command referencing it is added or
+     * removed). Backed by the ``hair_signal_updated`` HA bus event. The
+     * Sniffer/Clipper/Plucker wire this to refresh the green Assign badge and
+     * yellow trigger dot live across browser tabs. Returns an unsubscribe fn.
+     */
+    async subscribeSignalUpdated(
+        onEvent: (event: SignalUpdatedEvent) => void,
+    ): Promise<() => Promise<void>> {
+        return this.hass.connection.subscribeEvents<SignalUpdatedEvent>(
+            (ev) => onEvent(ev.data),
+            "hair_signal_updated",
+        );
+    }
+
+    /**
      * Subscribe to dismiss-activity events. Fires (rate-limited) when a
      * signal arrives from a remote whose device fingerprint is in the
      * dismiss set. Backed by the ``hair_dismiss_activity`` HA bus event
@@ -642,6 +659,7 @@ export class HairApi {
         min_hits?: number;
         source_device_id?: string | null;
         source_command_id?: string | null;
+        receiver_entity_ids?: string[];
     }): Promise<IRTrigger> {
         return this.hass.connection.sendMessagePromise<IRTrigger>({
             type: "hair/trigger/create",
@@ -655,6 +673,7 @@ export class HairApi {
             name: string;
             min_hits: number;
             enabled: boolean;
+            receiver_entity_ids: string[];
         }>,
     ): Promise<IRTrigger> {
         return this.hass.connection.sendMessagePromise<IRTrigger>({

--- a/custom_components/hair/frontend/src/ir-clips.ts
+++ b/custom_components/hair/frontend/src/ir-clips.ts
@@ -22,10 +22,13 @@ import "./ir-signal-alias.js";
 import "./ir-signal-editor.js";
 import "./ir-test-emitter-dialog.js";
 import "./ir-trigger-dialog.js";
+import "./ir-count-dot.js";
+import "./ir-trigger-popover.js";
 import type {
     AssignResult,
     DeviceSummary,
     IRTrigger,
+    ReceiverInfo,
     UnknownDevice,
     UnknownDeviceSummary,
     UnknownSignal,
@@ -97,6 +100,14 @@ export class IrClips extends LitElement {
     @state() private _deleteSignal: { deviceId: string; signal: UnknownSignal } | null = null;
     @state() private _triggerDialog: { signal: UnknownSignal; deviceId: string } | null = null;
     @state() private _triggerEditDialog: IRTrigger | null = null;
+    @state() private _triggerPopover: {
+        deviceId: string;
+        signal: UnknownSignal;
+        top: number;
+        left: number;
+    } | null = null;
+    @state() private _receivers: ReceiverInfo[] = [];
+    private _unsubUpdated: (() => Promise<void>) | null = null;
     @state() private _confirmDeleteTriggerId: string | null = null;
     @state() private _testDialog: { signal: UnknownSignal } | null = null;
     @state() private _testEmitters: string[] = [];
@@ -115,10 +126,13 @@ export class IrClips extends LitElement {
     connectedCallback(): void {
         super.connectedCallback();
         void this._load();
+        void this._subscribeUpdated();
     }
 
     disconnectedCallback(): void {
         super.disconnectedCallback();
+        void this._unsubscribeUpdated();
+        this._removePopoverDismiss();
         this._remotesSortable?.destroy();
         this._remotesSortable = null;
         this._signalsSortable?.destroy();
@@ -267,6 +281,14 @@ export class IrClips extends LitElement {
             this._hairDevices = hairDevs;
             this._triggers = triggers;
             this._error = null;
+            this.api
+                .listReceivers()
+                .then((r) => {
+                    this._receivers = r;
+                })
+                .catch(() => {
+                    this._receivers = [];
+                });
         } catch (err) {
             this._error = `Failed to load: ${(err as Error).message}`;
         } finally {
@@ -479,14 +501,105 @@ export class IrClips extends LitElement {
         return this._triggers.some((t) => t.signal_fingerprint === fingerprint);
     }
 
-    private _openTriggerDialog(deviceId: string, signal: UnknownSignal): void {
-        const existing = this._triggers.find(
+    private _triggerCountFor(fingerprint: string): number {
+        return this._triggers.filter(
+            (t) => t.signal_fingerprint === fingerprint,
+        ).length;
+    }
+
+    private _openTriggerDialog(
+        deviceId: string,
+        signal: UnknownSignal,
+        ev?: Event,
+    ): void {
+        const matches = this._triggers.filter(
             (t) => t.signal_fingerprint === signal.fingerprint,
         );
-        if (existing) {
-            this._triggerEditDialog = existing;
-        } else {
+        if (matches.length === 0) {
             this._triggerDialog = { signal, deviceId };
+            return;
+        }
+        const btn = ev?.currentTarget as HTMLElement | undefined;
+        const rect = btn?.getBoundingClientRect();
+        this._triggerPopover = {
+            deviceId,
+            signal,
+            top: rect ? rect.bottom + 4 : 120,
+            left: rect ? Math.max(8, rect.right - 220) : 120,
+        };
+        this._installPopoverDismiss();
+    }
+
+    private _closeTriggerPopover(): void {
+        this._triggerPopover = null;
+        this._removePopoverDismiss();
+    }
+
+    private _onPopoverCreateNew(): void {
+        const p = this._triggerPopover;
+        this._closeTriggerPopover();
+        if (p) this._triggerDialog = { signal: p.signal, deviceId: p.deviceId };
+    }
+
+    private _onPopoverEditTrigger(ev: CustomEvent): void {
+        const t = ev.detail as IRTrigger | undefined;
+        this._closeTriggerPopover();
+        if (t) this._triggerEditDialog = t;
+    }
+
+    private _onDocClickForPopover = (ev: Event): void => {
+        const pop = this.shadowRoot?.querySelector("ir-trigger-popover");
+        if (pop && ev.composedPath().includes(pop)) return;
+        this._closeTriggerPopover();
+    };
+
+    private _onScrollForPopover = (): void => {
+        this._closeTriggerPopover();
+    };
+
+    private _installPopoverDismiss(): void {
+        setTimeout(() => {
+            document.addEventListener("click", this._onDocClickForPopover, true);
+            window.addEventListener("scroll", this._onScrollForPopover, true);
+        }, 0);
+    }
+
+    private _removePopoverDismiss(): void {
+        document.removeEventListener("click", this._onDocClickForPopover, true);
+        window.removeEventListener("scroll", this._onScrollForPopover, true);
+    }
+
+    private async _subscribeUpdated(): Promise<void> {
+        try {
+            this._unsubUpdated = await this.api.subscribeSignalUpdated(() => {
+                void this._refreshAfterSignalUpdate();
+            });
+        } catch {
+            // Non-fatal.
+        }
+    }
+
+    private async _unsubscribeUpdated(): Promise<void> {
+        if (this._unsubUpdated) {
+            await this._unsubUpdated();
+            this._unsubUpdated = null;
+        }
+    }
+
+    private async _refreshAfterSignalUpdate(): Promise<void> {
+        try {
+            this._triggers = await this.api.listTriggers();
+        } catch {
+            // Non-fatal.
+        }
+        if (this._expandedId) {
+            try {
+                this._expandedDevice = await this.api.getUnknownDevice(
+                    this._expandedId,
+                );
+            } catch {
+                // Non-fatal.
+            }
         }
     }
 
@@ -778,12 +891,19 @@ export class IrClips extends LitElement {
                 <div class="signal-actions">
                     <button
                         class="action-btn assign-btn"
-                        title="Assign this signal to a HAIR device"
+                        title=${sig.assignment_count && sig.assigned_to?.length
+                            ? (sig.assignment_count === 1
+                                ? `Assigned to ${sig.assigned_to[0]}`
+                                : `Assigned to ${sig.assignment_count} commands:\n- ${sig.assigned_to.join("\n- ")}`)
+                            : "Assign this signal to a HAIR device"}
                         @click=${(e: Event) => {
                             e.stopPropagation();
                             this._openAssign(deviceId, sig, label);
                         }}
-                    >Assign</button>
+                    >Assign<ir-count-dot
+                            color="green"
+                            .count=${sig.assignment_count ?? 0}
+                        ></ir-count-dot></button>
                     <button
                         class="action-btn test-btn"
                         ?disabled=${isTesting}
@@ -794,13 +914,18 @@ export class IrClips extends LitElement {
                         }}
                     >${isTesting ? "Sending..." : "Test"}</button>
                     <button
-                        class="action-btn trigger-btn ${this._hasTrigger(sig.fingerprint) ? "trigger-on" : ""}"
-                        title="Create an HA event entity that fires on this signal"
+                        class="action-btn trigger-btn"
+                        title=${this._hasTrigger(sig.fingerprint)
+                            ? "Edit trigger(s) for this signal"
+                            : "Create an HA event entity that fires on this signal"}
                         @click=${(e: Event) => {
                             e.stopPropagation();
-                            this._openTriggerDialog(deviceId, sig);
+                            this._openTriggerDialog(deviceId, sig, e);
                         }}
-                    >Trigger</button>
+                    >Trigger<ir-count-dot
+                            color="yellow"
+                            .count=${this._triggerCountFor(sig.fingerprint)}
+                        ></ir-count-dot></button>
                     <button
                         class="action-btn delete-btn"
                         @click=${(e: Event) => {
@@ -907,6 +1032,21 @@ export class IrClips extends LitElement {
                       @confirmed=${this._confirmDeleteRemote}
                       @closed=${() => (this._deleteRemoteId = null)}
                   ></ir-confirm-dialog>`
+                : ""}
+
+            ${this._triggerPopover
+                ? html`<ir-trigger-popover
+                      .triggers=${this._triggers.filter(
+                          (t) =>
+                              t.signal_fingerprint ===
+                              this._triggerPopover!.signal.fingerprint,
+                      )}
+                      .receivers=${this._receivers}
+                      .top=${this._triggerPopover.top}
+                      .left=${this._triggerPopover.left}
+                      @create-new=${this._onPopoverCreateNew}
+                      @edit-trigger=${this._onPopoverEditTrigger}
+                  ></ir-trigger-popover>`
                 : ""}
 
             ${this._triggerDialog
@@ -1328,6 +1468,7 @@ export class IrClips extends LitElement {
         .action-btn.assign-btn {
             color: #2e7d32;
             border-color: rgba(46, 125, 50, 0.3);
+            position: relative;
         }
         .action-btn.assign-btn:hover {
             background: rgba(46, 125, 50, 0.08);
@@ -1338,14 +1479,10 @@ export class IrClips extends LitElement {
         .action-btn.trigger-btn {
             color: #b89930;
             border-color: rgba(184, 153, 48, 0.3);
+            position: relative;
         }
         .action-btn.trigger-btn:hover {
             background: rgba(184, 153, 48, 0.08);
-        }
-        .action-btn.trigger-btn.trigger-on {
-            color: #fff;
-            background: #b89930;
-            border-color: #b89930;
         }
         .action-btn.delete-btn {
             color: #e65100;

--- a/custom_components/hair/frontend/src/ir-command-row.ts
+++ b/custom_components/hair/frontend/src/ir-command-row.ts
@@ -5,6 +5,7 @@
  */
 import { LitElement, html, css } from "lit";
 import { customElement, property, state } from "./decorators.js";
+import "./ir-count-dot.js";
 import type { IRCommand } from "./types.js";
 
 // mdi:content-copy -- shared view/edit glyph (matches the signal rows).
@@ -29,6 +30,10 @@ export class IrCommandRow extends LitElement {
 
     /** Whether this command already has an associated trigger. */
     @property({ type: Boolean }) public hasTrigger = false;
+
+    /** Number of triggers bound to this command's signal (yellow dot count).
+     * Falls back to hasTrigger (0/1) when the parent doesn't supply a count. */
+    @property({ type: Number }) public triggerCount = 0;
 
     /** Whether to show the action-mapping ("ACTIONS") button. Hidden for
      *  device types whose platform exposes no mappable feature actions
@@ -81,10 +86,20 @@ export class IrCommandRow extends LitElement {
         )}</span>`;
     }
 
-    private _emit(name: string) {
+    private _emit(name: string, ev?: Event) {
+        // When the originating click is passed (the Trigger button), include
+        // the button's viewport rect so the parent can position the trigger
+        // popover next to it (mirrors the catalog views' currentTarget rect).
+        const buttonRect =
+            (ev?.currentTarget as HTMLElement | undefined)?.getBoundingClientRect() ??
+            null;
         this.dispatchEvent(
             new CustomEvent(name, {
-                detail: { templateName: this.templateName, command: this.command },
+                detail: {
+                    templateName: this.templateName,
+                    command: this.command,
+                    buttonRect,
+                },
                 bubbles: true,
                 composed: true,
             }),
@@ -238,11 +253,15 @@ export class IrCommandRow extends LitElement {
                                   @click=${() => this._emit("test")}
                               >Test</button>
                               <button
-                                  class="action-btn trigger-btn ${this.hasTrigger ? "trigger-on" : ""}"
+                                  class="action-btn trigger-btn"
                                   ?disabled=${this.busy}
-                                  @click=${() => this._emit("toggle-trigger")}
+                                  @click=${(e: Event) => this._emit("toggle-trigger", e)}
                                   title=${this.hasTrigger ? "Edit trigger" : "Create trigger"}
-                              >Trigger</button>
+                              >Trigger<ir-count-dot
+                                      color="yellow"
+                                      .count=${this.triggerCount ||
+                                      (this.hasTrigger ? 1 : 0)}
+                                  ></ir-count-dot></button>
                               <button
                                   class="action-btn delete-btn"
                                   ?disabled=${this.busy}
@@ -466,19 +485,12 @@ export class IrCommandRow extends LitElement {
             background: rgba(var(--rgb-primary-color, 33, 150, 243), 0.12);
         }
         .action-btn.trigger-btn {
+            position: relative;
             color: #b89930;
             border-color: rgba(184, 153, 48, 0.3);
         }
         .action-btn.trigger-btn:hover {
             background: rgba(184, 153, 48, 0.08);
-        }
-        .action-btn.trigger-btn.trigger-on {
-            color: #fff;
-            background: #b89930;
-            border-color: #b89930;
-        }
-        .action-btn.trigger-btn.trigger-on:hover {
-            background: #a08328;
         }
         .action-btn.delete-btn {
             color: #e65100;

--- a/custom_components/hair/frontend/src/ir-count-dot.ts
+++ b/custom_components/hair/frontend/src/ir-count-dot.ts
@@ -1,0 +1,115 @@
+/**
+ * Shared count-aware corner dot for action buttons.
+ *
+ * Renders nothing for count < 1, a bare 8px dot for count === 1, and a
+ * numbered 10px badge for count >= 2 (stretching to a pill for double
+ * digits). Colour is the only difference between the green Assign dot and
+ * the yellow Trigger dot.
+ *
+ * The calling button is responsible for positioning: it sets
+ * ``position: relative`` and places the dot in its top-right corner via its
+ * own CSS. Keeping the offset out of this component lets it ride on buttons
+ * of any width.
+ *
+ * Usage:
+ *   <ir-count-dot color="green" .count=${sig.assignment_count ?? 0}></ir-count-dot>
+ *   <ir-count-dot color="yellow" .count=${triggerCount}></ir-count-dot>
+ */
+import { LitElement, html, css } from "lit";
+import { customElement, property } from "./decorators.js";
+
+type DotColor = "green" | "yellow";
+
+@customElement("ir-count-dot")
+export class IrCountDot extends LitElement {
+    @property({ type: String }) color: DotColor = "green";
+    @property({ type: Number }) count = 0;
+
+    render() {
+        if (this.count < 1) return html``;
+        if (this.count === 1) {
+            return html`<span class="dot bare ${this.color}"></span>`;
+        }
+        const isMulti = this.count >= 10;
+        return html`<span
+            class="dot badge ${this.color} ${isMulti ? "multi-digit" : ""}"
+            ><span class="digit">${this.count}</span></span
+        >`;
+    }
+
+    static styles = css`
+        /* The host generates no box; each dot is absolutely positioned against
+           the calling button (which sets position: relative). This keeps the
+           dot out of inline flow, so a numbered badge cannot pick up a
+           line-box strut and drift downward the way an inline-flex child does. */
+        :host {
+            display: contents;
+        }
+        .dot {
+            position: absolute;
+            pointer-events: none;
+            box-shadow: 0 0 0 1.5px var(--card-background-color);
+        }
+        /* Bare 8px dot for count === 1, centered on the button's top-right
+           corner: top/right -4 with an 8px box puts the centre on the corner. */
+        .dot.bare {
+            top: -4px;
+            right: -4px;
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+        }
+        /* Numbered 10px badge for count 2..9. Anchored at -5 (not -4) so the
+           larger box stays centered on the same corner point as the bare dot
+           instead of reading as sunk toward the label. */
+        .dot.badge {
+            top: -5px;
+            right: -5px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 10px;
+            height: 10px;
+            border-radius: 50%;
+            color: #ffffff;
+            /* 8px (not 7px) rasterises crisply at this size and reads as
+               centred; 7px snapped to the pixel grid and looked off. */
+            font-size: 8px;
+            font-weight: 500;
+            line-height: 1;
+            /* The action buttons set letter-spacing, which inherits here and
+               adds phantom space to the RIGHT of the single digit -- the flex
+               box then centres [digit + that space], shoving the digit left.
+               Reset it so the digit centres on its own advance. */
+            letter-spacing: normal;
+        }
+        /* A digit glyph has no descender, so flex-centring the line box leaves
+           the number riding ~0.5px above the badge's true centre. Nudge just
+           the digit down half a pixel so it sits dead-centre in the circle. */
+        .dot.badge .digit {
+            display: block;
+            transform: translateY(0.5px);
+        }
+        /* Double-digit stretch for count >= 10 (wider pill, pulled out a touch
+           further so it clears the corner). */
+        .dot.badge.multi-digit {
+            right: -6px;
+            min-width: 10px;
+            padding: 0 3px;
+            border-radius: 5px;
+        }
+        /* Colour variants */
+        .dot.green {
+            background: #2e7d32;
+        }
+        .dot.yellow {
+            background: #b89930;
+        }
+    `;
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "ir-count-dot": IrCountDot;
+    }
+}

--- a/custom_components/hair/frontend/src/ir-device-detail.ts
+++ b/custom_components/hair/frontend/src/ir-device-detail.ts
@@ -13,8 +13,17 @@ import "./ir-confirm-dialog.js";
 import "./ir-emitter-picker.js";
 import "./ir-signal-editor.js";
 import "./ir-trigger-dialog.js";
+import "./ir-trigger-popover.js";
+import { popoverStyles } from "./ir-popover-styles.js";
 import type { HairApi } from "./api.js";
-import type { ActionOption, IRCommand, IRDevice, IRTrigger, DeviceTypeId } from "./types.js";
+import type {
+    ActionOption,
+    IRCommand,
+    IRDevice,
+    IRTrigger,
+    DeviceTypeId,
+    ReceiverInfo,
+} from "./types.js";
 
 // MDI: drag (six-dot grip)
 const ICON_GRIP =
@@ -62,6 +71,14 @@ export class IrDeviceDetail extends LitElement {
     @state() private _triggerCommand: IRCommand | null = null;
     @state() private _triggerEdit: IRTrigger | null = null;
     @state() private _confirmDeleteTriggerId: string | null = null;
+    // Trigger picker popover (v0.5.7): shown when a command already has 1+
+    // triggers; zero-trigger click opens the Create dialog directly.
+    @state() private _triggerPopover: {
+        command: IRCommand;
+        top: number;
+        left: number;
+    } | null = null;
+    @state() private _receivers: ReceiverInfo[] = [];
 
     // Command reorder (SortableJS lifecycle)
     private _sortable: Sortable | null = null;
@@ -254,6 +271,15 @@ export class IrDeviceDetail extends LitElement {
         super.connectedCallback();
         void this._loadActionOptions();
         void this._loadTriggers();
+        // Best-effort: receiver names for the trigger popover's scope labels.
+        this.api
+            .listReceivers()
+            .then((r) => {
+                this._receivers = r;
+            })
+            .catch(() => {
+                this._receivers = [];
+            });
     }
 
     updated(changed: Map<string, unknown>): void {
@@ -290,19 +316,86 @@ export class IrDeviceDetail extends LitElement {
         return this._triggers.some((t) => t.source_command_id === cmd.id);
     }
 
+    /** Count triggers bound to a command (yellow dot; multiple legal in v0.5.7). */
+    private _commandTriggerCount(cmd: IRCommand): number {
+        return this._triggers.filter((t) => t.source_command_id === cmd.id).length;
+    }
+
     private _onToggleTrigger(ev: CustomEvent): void {
         const cmd = ev.detail?.command as IRCommand | null;
         if (!cmd) return;
 
-        // If a trigger already exists for this command, open edit mode.
-        const existing = this._triggers.find(
+        const matches = this._triggers.filter(
             (t) => t.source_command_id === cmd.id,
         );
-        if (existing) {
-            this._triggerEdit = existing;
-        } else {
+        // Zero triggers: open the Create dialog directly (no popover).
+        if (matches.length === 0) {
             this._triggerCommand = cmd;
+            return;
         }
+        // 1+ triggers: show the picker popover near the command's Trigger button.
+        const rect = ev.detail?.buttonRect as DOMRect | null;
+        this._triggerPopover = {
+            command: cmd,
+            top: rect ? rect.bottom + 4 : 120,
+            left: rect ? Math.max(8, rect.right - 220) : 120,
+        };
+        this._installTriggerPopoverDismiss();
+    }
+
+    private _triggersForCommand(cmd: IRCommand): IRTrigger[] {
+        return this._triggers.filter((t) => t.source_command_id === cmd.id);
+    }
+
+    private _closeTriggerPopover(): void {
+        this._triggerPopover = null;
+        this._removeTriggerPopoverDismiss();
+    }
+
+    private _onTriggerPopoverCreateNew(): void {
+        const p = this._triggerPopover;
+        this._closeTriggerPopover();
+        if (p) this._triggerCommand = p.command;
+    }
+
+    private _onTriggerPopoverEdit(ev: CustomEvent): void {
+        const t = ev.detail as IRTrigger | undefined;
+        this._closeTriggerPopover();
+        if (t) this._triggerEdit = t;
+    }
+
+    private _onDocClickForTriggerPopover = (ev: Event): void => {
+        const pop = this.shadowRoot?.querySelector("ir-trigger-popover");
+        if (pop && ev.composedPath().includes(pop)) return;
+        this._closeTriggerPopover();
+    };
+
+    private _onScrollForTriggerPopover = (): void => {
+        this._closeTriggerPopover();
+    };
+
+    private _installTriggerPopoverDismiss(): void {
+        setTimeout(() => {
+            document.addEventListener(
+                "click",
+                this._onDocClickForTriggerPopover,
+                true,
+            );
+            window.addEventListener(
+                "scroll",
+                this._onScrollForTriggerPopover,
+                true,
+            );
+        }, 0);
+    }
+
+    private _removeTriggerPopoverDismiss(): void {
+        document.removeEventListener(
+            "click",
+            this._onDocClickForTriggerPopover,
+            true,
+        );
+        window.removeEventListener("scroll", this._onScrollForTriggerPopover, true);
     }
 
     private _closeTriggerDialog(): void {
@@ -408,6 +501,7 @@ export class IrDeviceDetail extends LitElement {
             document.removeEventListener("click", this._dismissHandler, true);
             this._dismissHandler = null;
         }
+        this._removeTriggerPopoverDismiss();
         this._sortable?.destroy();
         this._sortable = null;
         this._cancelPendingReorderSave();
@@ -846,6 +940,7 @@ export class IrDeviceDetail extends LitElement {
                                           .busy=${this._busy}
                                           .actionLabel=${this._getActionLabel(cmd.name)}
                                           .hasTrigger=${this._commandHasTrigger(cmd)}
+                                          .triggerCount=${this._commandTriggerCount(cmd)}
                                           .showActionMapping=${this.device.device_type !== "other"}
                                           @map-action=${this._onMapAction}
                                           @test=${this._onTest}
@@ -987,6 +1082,20 @@ export class IrDeviceDetail extends LitElement {
                       ></ir-signal-editor>
                   `
                 : ""}
+            ${this._triggerPopover
+                ? html`
+                      <ir-trigger-popover
+                          .triggers=${this._triggersForCommand(
+                              this._triggerPopover.command,
+                          )}
+                          .receivers=${this._receivers}
+                          .top=${this._triggerPopover.top}
+                          .left=${this._triggerPopover.left}
+                          @create-new=${this._onTriggerPopoverCreateNew}
+                          @edit-trigger=${this._onTriggerPopoverEdit}
+                      ></ir-trigger-popover>
+                  `
+                : ""}
             ${this._triggerCommand
                 ? html`
                       <ir-trigger-dialog
@@ -1030,7 +1139,9 @@ export class IrDeviceDetail extends LitElement {
         `;
     }
 
-    static styles = css`
+    static styles = [
+        popoverStyles,
+        css`
         :host {
             display: block;
         }
@@ -1193,66 +1304,9 @@ export class IrDeviceDetail extends LitElement {
         ir-command-row.sortable-ghost {
             opacity: 0.4;
         }
-        /* --- Action popover --- */
-        .action-popover {
-            position: fixed;
-            z-index: 50;
-            min-width: 200px;
-            max-width: 280px;
-            background: var(--card-background-color, #1c1c1c);
-            border: 1px solid var(--divider-color);
-            border-radius: 6px;
-            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
-            padding: 4px 0;
-            overflow: auto;
-            max-height: 320px;
-        }
-        .popover-header {
-            font-size: 0.7rem;
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
-            color: var(--secondary-text-color);
-            padding: 6px 12px 4px;
-        }
-        .popover-item {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            width: 100%;
-            padding: 7px 12px;
-            background: none;
-            border: none;
-            color: var(--primary-text-color);
-            font-size: 0.82rem;
-            font-family: inherit;
-            cursor: pointer;
-            text-align: left;
-            transition: background 100ms ease;
-        }
-        .popover-item:hover {
-            background: var(--secondary-background-color);
-        }
-        .popover-item.active {
-            color: var(--primary-color);
-            font-weight: 500;
-        }
-        .popover-item.clear {
-            color: var(--secondary-text-color);
-            font-style: italic;
-            border-bottom: 1px solid var(--divider-color);
-            margin-bottom: 2px;
-        }
-        .popover-check {
-            color: var(--primary-color);
-            font-size: 0.9rem;
-        }
-        .popover-existing {
-            font-size: 0.72rem;
-            color: var(--secondary-text-color);
-            font-style: italic;
-            margin-left: 8px;
-            flex-shrink: 0;
-        }
+        /* Action-popover styles live in the shared ir-popover-styles module
+           (spread into static styles below) so ir-trigger-popover reuses the
+           exact same treatment. */
         .empty {
             color: var(--secondary-text-color);
             font-style: italic;
@@ -1290,7 +1344,8 @@ export class IrDeviceDetail extends LitElement {
             box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
             z-index: 100;
         }
-    `;
+    `,
+    ];
 }
 
 declare global {

--- a/custom_components/hair/frontend/src/ir-pluck.ts
+++ b/custom_components/hair/frontend/src/ir-pluck.ts
@@ -25,11 +25,14 @@ import "./ir-signal-alias.js";
 import "./ir-signal-editor.js";
 import "./ir-test-emitter-dialog.js";
 import "./ir-trigger-dialog.js";
+import "./ir-count-dot.js";
+import "./ir-trigger-popover.js";
 import type {
     AssignResult,
     DeviceSummary,
     IRTrigger,
     PluckVendor,
+    ReceiverInfo,
     UnknownDevice,
     UnknownDeviceSummary,
     UnknownSignal,
@@ -89,6 +92,14 @@ export class IrPluck extends LitElement {
     @state() private _triggerDialog: { signal: UnknownSignal; deviceId: string } | null =
         null;
     @state() private _triggerEditDialog: IRTrigger | null = null;
+    @state() private _triggerPopover: {
+        deviceId: string;
+        signal: UnknownSignal;
+        top: number;
+        left: number;
+    } | null = null;
+    @state() private _receivers: ReceiverInfo[] = [];
+    private _unsubUpdated: (() => Promise<void>) | null = null;
     @state() private _confirmDeleteTriggerId: string | null = null;
     @state() private _testDialog: { signal: UnknownSignal } | null = null;
     @state() private _testEmitters: string[] = [];
@@ -107,10 +118,13 @@ export class IrPluck extends LitElement {
     connectedCallback(): void {
         super.connectedCallback();
         void this._load();
+        void this._subscribeUpdated();
     }
 
     disconnectedCallback(): void {
         super.disconnectedCallback();
+        void this._unsubscribeUpdated();
+        this._removePopoverDismiss();
         this._remotesSortable?.destroy();
         this._remotesSortable = null;
         this._signalsSortable?.destroy();
@@ -267,6 +281,14 @@ export class IrPluck extends LitElement {
             this._triggers = triggers;
             this._vendorIntegration = this._mapIntegrations(vendors.vendors);
             this._error = null;
+            this.api
+                .listReceivers()
+                .then((r) => {
+                    this._receivers = r;
+                })
+                .catch(() => {
+                    this._receivers = [];
+                });
         } catch (err) {
             this._error = `Failed to load: ${(err as Error).message}`;
         } finally {
@@ -506,14 +528,105 @@ export class IrPluck extends LitElement {
         return this._triggers.some((t) => t.signal_fingerprint === fingerprint);
     }
 
-    private _openTriggerDialog(deviceId: string, signal: UnknownSignal): void {
-        const existing = this._triggers.find(
+    private _triggerCountFor(fingerprint: string): number {
+        return this._triggers.filter(
+            (t) => t.signal_fingerprint === fingerprint,
+        ).length;
+    }
+
+    private _openTriggerDialog(
+        deviceId: string,
+        signal: UnknownSignal,
+        ev?: Event,
+    ): void {
+        const matches = this._triggers.filter(
             (t) => t.signal_fingerprint === signal.fingerprint,
         );
-        if (existing) {
-            this._triggerEditDialog = existing;
-        } else {
+        if (matches.length === 0) {
             this._triggerDialog = { signal, deviceId };
+            return;
+        }
+        const btn = ev?.currentTarget as HTMLElement | undefined;
+        const rect = btn?.getBoundingClientRect();
+        this._triggerPopover = {
+            deviceId,
+            signal,
+            top: rect ? rect.bottom + 4 : 120,
+            left: rect ? Math.max(8, rect.right - 220) : 120,
+        };
+        this._installPopoverDismiss();
+    }
+
+    private _closeTriggerPopover(): void {
+        this._triggerPopover = null;
+        this._removePopoverDismiss();
+    }
+
+    private _onPopoverCreateNew(): void {
+        const p = this._triggerPopover;
+        this._closeTriggerPopover();
+        if (p) this._triggerDialog = { signal: p.signal, deviceId: p.deviceId };
+    }
+
+    private _onPopoverEditTrigger(ev: CustomEvent): void {
+        const t = ev.detail as IRTrigger | undefined;
+        this._closeTriggerPopover();
+        if (t) this._triggerEditDialog = t;
+    }
+
+    private _onDocClickForPopover = (ev: Event): void => {
+        const pop = this.shadowRoot?.querySelector("ir-trigger-popover");
+        if (pop && ev.composedPath().includes(pop)) return;
+        this._closeTriggerPopover();
+    };
+
+    private _onScrollForPopover = (): void => {
+        this._closeTriggerPopover();
+    };
+
+    private _installPopoverDismiss(): void {
+        setTimeout(() => {
+            document.addEventListener("click", this._onDocClickForPopover, true);
+            window.addEventListener("scroll", this._onScrollForPopover, true);
+        }, 0);
+    }
+
+    private _removePopoverDismiss(): void {
+        document.removeEventListener("click", this._onDocClickForPopover, true);
+        window.removeEventListener("scroll", this._onScrollForPopover, true);
+    }
+
+    private async _subscribeUpdated(): Promise<void> {
+        try {
+            this._unsubUpdated = await this.api.subscribeSignalUpdated(() => {
+                void this._refreshAfterSignalUpdate();
+            });
+        } catch {
+            // Non-fatal.
+        }
+    }
+
+    private async _unsubscribeUpdated(): Promise<void> {
+        if (this._unsubUpdated) {
+            await this._unsubUpdated();
+            this._unsubUpdated = null;
+        }
+    }
+
+    private async _refreshAfterSignalUpdate(): Promise<void> {
+        try {
+            this._triggers = await this.api.listTriggers();
+        } catch {
+            // Non-fatal.
+        }
+        if (this._expandedId) {
+            try {
+                this._expandedDevice = await this.api.getUnknownDevice(
+                    this._expandedId,
+                );
+            } catch {
+                // Non-fatal.
+            }
         }
     }
 
@@ -797,13 +910,20 @@ export class IrPluck extends LitElement {
                 <div class="signal-actions">
                     <button
                         class="action-btn assign-btn"
-                        title="Assign this signal to a HAIR device"
+                        title=${sig.assignment_count && sig.assigned_to?.length
+                            ? (sig.assignment_count === 1
+                                ? `Assigned to ${sig.assigned_to[0]}`
+                                : `Assigned to ${sig.assignment_count} commands:\n- ${sig.assigned_to.join("\n- ")}`)
+                            : "Assign this signal to a HAIR device"}
                         @click=${(e: Event) => {
                             e.stopPropagation();
                             this._openAssign(deviceId, sig, label);
                         }}
                     >
-                        Assign
+                        Assign<ir-count-dot
+                            color="green"
+                            .count=${sig.assignment_count ?? 0}
+                        ></ir-count-dot>
                     </button>
                     <button
                         class="action-btn test-btn"
@@ -817,16 +937,19 @@ export class IrPluck extends LitElement {
                         ${isTesting ? "Sending..." : "Test"}
                     </button>
                     <button
-                        class="action-btn trigger-btn ${this._hasTrigger(sig.fingerprint)
-                            ? "trigger-on"
-                            : ""}"
-                        title="Create an HA event entity that fires on this signal"
+                        class="action-btn trigger-btn"
+                        title=${this._hasTrigger(sig.fingerprint)
+                            ? "Edit trigger(s) for this signal"
+                            : "Create an HA event entity that fires on this signal"}
                         @click=${(e: Event) => {
                             e.stopPropagation();
-                            this._openTriggerDialog(deviceId, sig);
+                            this._openTriggerDialog(deviceId, sig, e);
                         }}
                     >
-                        Trigger
+                        Trigger<ir-count-dot
+                            color="yellow"
+                            .count=${this._triggerCountFor(sig.fingerprint)}
+                        ></ir-count-dot>
                     </button>
                     <button
                         class="action-btn delete-btn"
@@ -939,6 +1062,21 @@ export class IrPluck extends LitElement {
                       @confirmed=${this._confirmDeleteRemote}
                       @closed=${() => (this._deleteRemoteId = null)}
                   ></ir-confirm-dialog>`
+                : ""}
+
+            ${this._triggerPopover
+                ? html`<ir-trigger-popover
+                      .triggers=${this._triggers.filter(
+                          (t) =>
+                              t.signal_fingerprint ===
+                              this._triggerPopover!.signal.fingerprint,
+                      )}
+                      .receivers=${this._receivers}
+                      .top=${this._triggerPopover.top}
+                      .left=${this._triggerPopover.left}
+                      @create-new=${this._onPopoverCreateNew}
+                      @edit-trigger=${this._onPopoverEditTrigger}
+                  ></ir-trigger-popover>`
                 : ""}
 
             ${this._triggerDialog
@@ -1325,6 +1463,7 @@ export class IrPluck extends LitElement {
         .action-btn.assign-btn {
             color: #2e7d32;
             border-color: rgba(46, 125, 50, 0.3);
+            position: relative;
         }
         .action-btn.assign-btn:hover {
             background: rgba(46, 125, 50, 0.08);
@@ -1335,14 +1474,10 @@ export class IrPluck extends LitElement {
         .action-btn.trigger-btn {
             color: #b89930;
             border-color: rgba(184, 153, 48, 0.3);
+            position: relative;
         }
         .action-btn.trigger-btn:hover {
             background: rgba(184, 153, 48, 0.08);
-        }
-        .action-btn.trigger-btn.trigger-on {
-            color: #fff;
-            background: #b89930;
-            border-color: #b89930;
         }
         .action-btn.delete-btn {
             color: #e65100;

--- a/custom_components/hair/frontend/src/ir-popover-styles.ts
+++ b/custom_components/hair/frontend/src/ir-popover-styles.ts
@@ -1,0 +1,102 @@
+/**
+ * Shared popover styles.
+ *
+ * Lit CSS is component-scoped: a `static styles = css\`...\`` block in one
+ * component cannot be imported by a sibling. This module exports the
+ * `.action-popover` styling (originally inline in ir-device-detail.ts) as a
+ * tagged-template `css` result so every component that hosts a popover can
+ * spread it: `static styles = [popoverStyles, css\`...\`]`.
+ *
+ * Consumers: ir-device-detail (action-mapping popover), ir-trigger-popover
+ * (trigger picker). Keep visual parity with the original device-detail block.
+ */
+import { css } from "lit";
+
+export const popoverStyles = css`
+    .action-popover {
+        position: fixed;
+        z-index: 50;
+        min-width: 200px;
+        max-width: 280px;
+        background: var(--card-background-color, #1c1c1c);
+        border: 1px solid var(--divider-color);
+        border-radius: 6px;
+        box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+        padding: 4px 0;
+        overflow: auto;
+        max-height: 320px;
+    }
+    .popover-header {
+        font-size: 0.7rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--secondary-text-color);
+        padding: 6px 12px 4px;
+    }
+    .popover-item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        width: 100%;
+        padding: 7px 12px;
+        background: none;
+        border: none;
+        color: var(--primary-text-color);
+        font-size: 0.82rem;
+        font-family: inherit;
+        cursor: pointer;
+        text-align: left;
+        transition: background 100ms ease;
+    }
+    .popover-item:hover {
+        background: var(--secondary-background-color);
+    }
+    .popover-item.active {
+        color: var(--primary-color);
+        font-weight: 500;
+    }
+    .popover-item.clear {
+        color: var(--secondary-text-color);
+        font-style: italic;
+        border-bottom: 1px solid var(--divider-color);
+        margin-bottom: 2px;
+    }
+    .popover-check {
+        color: var(--primary-color);
+        font-size: 0.9rem;
+    }
+    .popover-existing {
+        font-size: 0.72rem;
+        color: var(--secondary-text-color);
+        font-style: italic;
+        margin-left: 8px;
+        flex-shrink: 0;
+    }
+    /* Trigger-popover extras (v0.5.7) */
+    .popover-item.accent {
+        color: var(--primary-color);
+        font-weight: 500;
+    }
+    .popover-divider {
+        height: 1px;
+        background: var(--divider-color);
+        margin: 2px 0;
+    }
+    .popover-row {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 2px;
+        min-width: 0;
+    }
+    .popover-name {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 240px;
+    }
+    .popover-scope {
+        font-size: 0.7rem;
+        color: var(--secondary-text-color);
+    }
+`;

--- a/custom_components/hair/frontend/src/ir-receiver-picker.ts
+++ b/custom_components/hair/frontend/src/ir-receiver-picker.ts
@@ -1,0 +1,210 @@
+/**
+ * Reusable multi-receiver picker with chip-based UI.
+ *
+ * The mirror image of ir-emitter-picker: it lists native
+ * ``InfraredReceiverEntity`` instances (from ``api.listReceivers()``) so a
+ * trigger can be scoped to fire only when specific receivers observe the
+ * signal. Empty selection = "Any receiver" (backward-compat: fires on any
+ * capture). Unlike the emitter picker there is NO auto-select -- leaving the
+ * field empty is the meaningful default.
+ *
+ * Usage:
+ *   <ir-receiver-picker
+ *       .api=${this.api}
+ *       .value=${["infrared.garage_receiver"]}
+ *       @receivers-changed=${(e) => this._ids = e.detail.value}
+ *   ></ir-receiver-picker>
+ *
+ * Fires `receivers-changed` with detail: { value: string[] }
+ */
+import { LitElement, html, css } from "lit";
+import { customElement, property, state } from "./decorators.js";
+import type { HairApi } from "./api.js";
+import type { ReceiverInfo } from "./types.js";
+
+@customElement("ir-receiver-picker")
+export class IrReceiverPicker extends LitElement {
+    /** HAIR API client. Required -- the receiver list comes from it. */
+    @property({ attribute: false }) public api?: HairApi;
+
+    /** Currently selected receiver entity IDs. */
+    @property({ attribute: false }) public value: string[] = [];
+
+    /** Disable all interactions. */
+    @property({ type: Boolean }) public disabled = false;
+
+    @state() private _receivers: ReceiverInfo[] = [];
+    private _receiversLoaded = false;
+
+    updated(changed: Map<string, unknown>): void {
+        super.updated(changed);
+        if (changed.has("api") && this.api && !this._receiversLoaded) {
+            this._receiversLoaded = true;
+            void this._loadReceivers();
+        }
+    }
+
+    private async _loadReceivers(): Promise<void> {
+        if (!this.api) return;
+        try {
+            this._receivers = await this.api.listReceivers();
+        } catch {
+            // Pre-2026.6 HA versions don't expose receivers; treat as empty.
+            this._receivers = [];
+        }
+    }
+
+    private _receiverName(entityId: string): string {
+        const match = this._receivers.find((r) => r.entity_id === entityId);
+        return match?.name ?? entityId;
+    }
+
+    private _onAdd(e: Event): void {
+        const select = e.target as HTMLSelectElement;
+        const entityId = select.value;
+        if (!entityId) return;
+        select.value = "";
+        if (this.value.includes(entityId)) return;
+        this._fireChange([...this.value, entityId]);
+    }
+
+    private _onRemove(entityId: string): void {
+        this._fireChange(this.value.filter((id) => id !== entityId));
+    }
+
+    private _fireChange(newValue: string[]): void {
+        this.value = newValue;
+        this.dispatchEvent(
+            new CustomEvent("receivers-changed", {
+                detail: { value: newValue },
+                bubbles: true,
+                composed: true,
+            }),
+        );
+    }
+
+    render() {
+        const available = this._receivers.filter(
+            (r) => !this.value.includes(r.entity_id),
+        );
+
+        return html`
+            <label>Via receiver(s):</label>
+
+            ${this.value.length > 0
+                ? html`
+                      <div class="chips">
+                          ${this.value.map(
+                              (id) => html`
+                                  <span class="chip">
+                                      <span class="chip-name"
+                                          >${this._receiverName(id)}</span
+                                      >
+                                      ${!this.disabled
+                                          ? html`<button
+                                                class="chip-remove"
+                                                @click=${() => this._onRemove(id)}
+                                                title="Remove"
+                                            >
+                                                &times;
+                                            </button>`
+                                          : ""}
+                                  </span>
+                              `,
+                          )}
+                      </div>
+                  `
+                : ""}
+
+            ${this._receivers.length === 0
+                ? html`<div class="no-receivers">No IR receivers found.</div>`
+                : available.length > 0
+                  ? html`
+                        <select @change=${this._onAdd} ?disabled=${this.disabled}>
+                            <option value="">+ Add receiver...</option>
+                            ${available.map(
+                                (r) => html`
+                                    <option value=${r.entity_id}>
+                                        ${r.name}
+                                    </option>
+                                `,
+                            )}
+                        </select>
+                    `
+                  : html`<div class="all-selected">All receivers selected.</div>`}
+        `;
+    }
+
+    static styles = css`
+        :host {
+            display: block;
+        }
+        label {
+            display: var(--picker-label-display, block);
+            font-size: 0.82rem;
+            font-weight: 500;
+            color: var(--primary-text-color);
+            margin-bottom: 6px;
+        }
+        .chips {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin-bottom: 8px;
+        }
+        .chip {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            background: var(--secondary-background-color);
+            color: var(--primary-color);
+            font-size: 0.82rem;
+            font-weight: 500;
+            padding: 4px 8px;
+            border-radius: 4px;
+            line-height: 1;
+        }
+        .chip-name {
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            max-width: 200px;
+        }
+        .chip-remove {
+            background: none;
+            border: none;
+            color: inherit;
+            font-size: 1rem;
+            cursor: pointer;
+            padding: 0 2px;
+            line-height: 1;
+            opacity: 0.65;
+            transition: opacity 120ms ease;
+        }
+        .chip-remove:hover {
+            opacity: 1;
+        }
+        select {
+            width: 100%;
+            padding: 6px 8px;
+            border-radius: 4px;
+            border: 1px solid var(--divider-color);
+            background: var(--card-background-color);
+            color: var(--primary-text-color);
+            font-family: inherit;
+            font-size: 0.85rem;
+        }
+        .no-receivers,
+        .all-selected {
+            font-size: 0.8rem;
+            color: var(--secondary-text-color);
+            font-style: italic;
+        }
+    `;
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "ir-receiver-picker": IrReceiverPicker;
+    }
+}

--- a/custom_components/hair/frontend/src/ir-signal-monitor.ts
+++ b/custom_components/hair/frontend/src/ir-signal-monitor.ts
@@ -16,10 +16,13 @@ import "./ir-signal-alias.js";
 import "./ir-signal-editor.js";
 import "./ir-test-emitter-dialog.js";
 import "./ir-trigger-dialog.js";
+import "./ir-count-dot.js";
+import "./ir-trigger-popover.js";
 import type {
     AssignResult,
     DeviceSummary,
     IRTrigger,
+    ReceiverInfo,
     SignalRemovedEvent,
     UnknownDeviceSummary,
     UnknownDevice,
@@ -129,6 +132,17 @@ export class IrSignalMonitor extends LitElement {
     } | null = null;
     @state() private _triggerEditDialog: IRTrigger | null = null;
     @state() private _confirmDeleteTriggerId: string | null = null;
+    // Trigger picker popover (v0.5.7): shown when 1+ triggers already bind a
+    // signal's fingerprint; zero-trigger click opens the Create dialog directly.
+    @state() private _triggerPopover: {
+        deviceId: string;
+        signal: UnknownSignal;
+        top: number;
+        left: number;
+    } | null = null;
+    // Receiver list for the popover's scope subtitles (best-effort load).
+    @state() private _receivers: ReceiverInfo[] = [];
+    private _unsubUpdated: (() => Promise<void>) | null = null;
 
     // Inline rename state
     @state() private _editingDeviceId: string | null = null;
@@ -190,6 +204,7 @@ export class IrSignalMonitor extends LitElement {
         void this._subscribeLive();
         void this._subscribeRemoved();
         void this._subscribeDismissActivity();
+        void this._subscribeUpdated();
     }
 
     protected updated(changed: PropertyValues): void {
@@ -210,6 +225,8 @@ export class IrSignalMonitor extends LitElement {
         void this._unsubscribeLive();
         void this._unsubscribeRemoved();
         void this._unsubscribeDismissActivity();
+        void this._unsubscribeUpdated();
+        this._removePopoverDismiss();
         if (this._dismissGlowTimer !== null) {
             clearTimeout(this._dismissGlowTimer);
             this._dismissGlowTimer = null;
@@ -352,6 +369,16 @@ export class IrSignalMonitor extends LitElement {
             this._triggers = triggers;
             this._hasReceivers = status.has_receivers;
             this._error = null;
+            // Best-effort: receiver names for the trigger popover scope labels.
+            // Never let a pre-2026.6 HA (no receiver API) break the main load.
+            this.api
+                .listReceivers()
+                .then((r) => {
+                    this._receivers = r;
+                })
+                .catch(() => {
+                    this._receivers = [];
+                });
         } catch (err) {
             this._error = `Failed to load: ${(err as Error).message}`;
         } finally {
@@ -646,15 +673,113 @@ export class IrSignalMonitor extends LitElement {
         return this._triggers.some((t) => t.signal_fingerprint === fingerprint);
     }
 
-    private _openTriggerDialog(deviceId: string, signal: UnknownSignal): void {
-        // If a trigger already exists for this fingerprint, open edit mode.
-        const existing = this._triggers.find(
+    /** Count triggers bound to a fingerprint (yellow dot count). */
+    private _triggerCountFor(fingerprint: string): number {
+        return this._triggers.filter(
+            (t) => t.signal_fingerprint === fingerprint,
+        ).length;
+    }
+
+    private _openTriggerDialog(
+        deviceId: string,
+        signal: UnknownSignal,
+        ev?: Event,
+    ): void {
+        const matches = this._triggers.filter(
             (t) => t.signal_fingerprint === signal.fingerprint,
         );
-        if (existing) {
-            this._triggerEditDialog = existing;
-        } else {
+        // Zero triggers: open the Create dialog directly (no popover).
+        if (matches.length === 0) {
             this._triggerDialog = { signal, deviceId };
+            return;
+        }
+        // 1+ triggers: show the picker popover near the Trigger button.
+        const btn = ev?.currentTarget as HTMLElement | undefined;
+        const rect = btn?.getBoundingClientRect();
+        this._triggerPopover = {
+            deviceId,
+            signal,
+            top: rect ? rect.bottom + 4 : 120,
+            left: rect ? Math.max(8, rect.right - 220) : 120,
+        };
+        this._installPopoverDismiss();
+    }
+
+    private _closeTriggerPopover(): void {
+        this._triggerPopover = null;
+        this._removePopoverDismiss();
+    }
+
+    private _onPopoverCreateNew(): void {
+        const p = this._triggerPopover;
+        this._closeTriggerPopover();
+        if (p) this._triggerDialog = { signal: p.signal, deviceId: p.deviceId };
+    }
+
+    private _onPopoverEditTrigger(ev: CustomEvent): void {
+        const t = ev.detail as IRTrigger | undefined;
+        this._closeTriggerPopover();
+        if (t) this._triggerEditDialog = t;
+    }
+
+    // Dismiss the popover on an outside click or any scroll (bound refs so
+    // add/removeEventListener pair up).
+    private _onDocClickForPopover = (ev: Event): void => {
+        const pop = this.shadowRoot?.querySelector("ir-trigger-popover");
+        if (pop && ev.composedPath().includes(pop)) return;
+        this._closeTriggerPopover();
+    };
+
+    private _onScrollForPopover = (): void => {
+        this._closeTriggerPopover();
+    };
+
+    private _installPopoverDismiss(): void {
+        // Defer so the click that opened the popover doesn't immediately close it.
+        setTimeout(() => {
+            document.addEventListener("click", this._onDocClickForPopover, true);
+            window.addEventListener("scroll", this._onScrollForPopover, true);
+        }, 0);
+    }
+
+    private _removePopoverDismiss(): void {
+        document.removeEventListener("click", this._onDocClickForPopover, true);
+        window.removeEventListener("scroll", this._onScrollForPopover, true);
+    }
+
+    private async _subscribeUpdated(): Promise<void> {
+        try {
+            this._unsubUpdated = await this.api.subscribeSignalUpdated(() => {
+                void this._refreshAfterSignalUpdate();
+            });
+        } catch {
+            // Non-fatal.
+        }
+    }
+
+    private async _unsubscribeUpdated(): Promise<void> {
+        if (this._unsubUpdated) {
+            await this._unsubUpdated();
+            this._unsubUpdated = null;
+        }
+    }
+
+    /** A signal's assignment set changed: refresh triggers + the expanded
+     * device so the green Assign and yellow trigger dots reflect it live. */
+    private async _refreshAfterSignalUpdate(): Promise<void> {
+        try {
+            this._triggers = await this.api.listTriggers();
+        } catch {
+            // Non-fatal.
+        }
+        if (this._expandedId) {
+            try {
+                this._expandedDevice = await this.api.getUnknownDevice(
+                    this._expandedId,
+                );
+            } catch {
+                // Non-fatal.
+            }
         }
     }
 
@@ -1018,6 +1143,22 @@ export class IrSignalMonitor extends LitElement {
                   `
                 : ""}
 
+            ${this._triggerPopover
+                ? html`
+                      <ir-trigger-popover
+                          .triggers=${this._triggers.filter(
+                              (t) =>
+                                  t.signal_fingerprint ===
+                                  this._triggerPopover!.signal.fingerprint,
+                          )}
+                          .receivers=${this._receivers}
+                          .top=${this._triggerPopover.top}
+                          .left=${this._triggerPopover.left}
+                          @create-new=${this._onPopoverCreateNew}
+                          @edit-trigger=${this._onPopoverEditTrigger}
+                      ></ir-trigger-popover>
+                  `
+                : ""}
             ${this._triggerDialog
                 ? html`
                       <ir-trigger-dialog
@@ -1237,10 +1378,17 @@ export class IrSignalMonitor extends LitElement {
                                             this._openAssign(device.id, sig, device.label);
                                         }}
                                         ?disabled=${device.dismissed}
-                                        title=${device.dismissed
-                                            ? "Restore this remote first"
-                                            : "Assign this signal to a HAIR device"}
-                                    >Assign</button>
+                                        title=${sig.assignment_count && sig.assigned_to?.length
+                                            ? (sig.assignment_count === 1
+                                                ? `Assigned to ${sig.assigned_to[0]}`
+                                                : `Assigned to ${sig.assignment_count} commands:\n- ${sig.assigned_to.join("\n- ")}`)
+                                            : (device.dismissed
+                                                ? "Restore this remote first"
+                                                : "Assign this signal to a HAIR device")}
+                                    >Assign<ir-count-dot
+                                            color="green"
+                                            .count=${sig.assignment_count ?? 0}
+                                        ></ir-count-dot></button>
                                     <button
                                         class="action-btn test-btn"
                                         @click=${(e: Event) => {
@@ -1255,16 +1403,21 @@ export class IrSignalMonitor extends LitElement {
                                         ? (this._testResult ?? "Sending...")
                                         : "Test"}</button>
                                     <button
-                                        class="action-btn trigger-btn ${this._hasTrigger(sig.fingerprint) ? "trigger-on" : ""}"
+                                        class="action-btn trigger-btn"
                                         @click=${(e: Event) => {
                                             e.stopPropagation();
-                                            this._openTriggerDialog(device.id, sig);
+                                            this._openTriggerDialog(device.id, sig, e);
                                         }}
                                         ?disabled=${device.dismissed}
-                                        title=${device.dismissed
-                                            ? "Restore this remote first"
-                                            : "Create an HA event entity that fires on this signal"}
-                                    >Trigger</button>
+                                        title=${this._hasTrigger(sig.fingerprint)
+                                            ? "Edit trigger(s) for this signal"
+                                            : (device.dismissed
+                                                ? "Restore this remote first"
+                                                : "Create an HA event entity that fires on this signal")}
+                                    >Trigger<ir-count-dot
+                                            color="yellow"
+                                            .count=${this._triggerCountFor(sig.fingerprint)}
+                                        ></ir-count-dot></button>
                                     <button
                                         class="action-btn delete-btn"
                                         @click=${(e: Event) => {
@@ -1686,6 +1839,7 @@ export class IrSignalMonitor extends LitElement {
         .action-btn.assign-btn {
             color: #2e7d32;
             border-color: rgba(46, 125, 50, 0.3);
+            position: relative; /* anchor for the green assignment dot */
         }
         .action-btn.assign-btn:hover {
             background: rgba(46, 125, 50, 0.08);
@@ -1696,17 +1850,10 @@ export class IrSignalMonitor extends LitElement {
         .action-btn.trigger-btn {
             color: #b89930;
             border-color: rgba(184, 153, 48, 0.3);
+            position: relative; /* anchor for the yellow trigger dot */
         }
         .action-btn.trigger-btn:hover {
             background: rgba(184, 153, 48, 0.08);
-        }
-        .action-btn.trigger-btn.trigger-on {
-            color: #fff;
-            background: #b89930;
-            border-color: #b89930;
-        }
-        .action-btn.trigger-btn.trigger-on:hover {
-            background: #a08328;
         }
         .action-btn.delete-btn {
             color: #e65100;

--- a/custom_components/hair/frontend/src/ir-trigger-dialog.ts
+++ b/custom_components/hair/frontend/src/ir-trigger-dialog.ts
@@ -10,6 +10,7 @@
  */
 import { LitElement, html, css } from "lit";
 import { customElement, property, state } from "./decorators.js";
+import "./ir-receiver-picker.js";
 import type { HairApi } from "./api.js";
 import type { IRTrigger } from "./types.js";
 
@@ -34,6 +35,7 @@ export class IrTriggerDialog extends LitElement {
 
     @state() private _name = "";
     @state() private _minHits = 1;
+    @state() private _receiverIds: string[] = [];
     @state() private _busy = false;
     @state() private _error: string | null = null;
 
@@ -42,6 +44,7 @@ export class IrTriggerDialog extends LitElement {
         if (this.trigger) {
             this._name = this.trigger.name;
             this._minHits = this.trigger.min_hits;
+            this._receiverIds = [...(this.trigger.receiver_entity_ids ?? [])];
         }
     }
 
@@ -66,6 +69,7 @@ export class IrTriggerDialog extends LitElement {
                 saved = await this.api.updateTrigger(this.trigger.id, {
                     name,
                     min_hits: this._minHits,
+                    receiver_entity_ids: this._receiverIds,
                 });
             } else {
                 // Create mode -- signalFingerprint may be empty when
@@ -77,6 +81,7 @@ export class IrTriggerDialog extends LitElement {
                     min_hits: this._minHits,
                     source_device_id: this.sourceDeviceId,
                     source_command_id: this.sourceCommandId,
+                    receiver_entity_ids: this._receiverIds,
                 };
                 if (this.signalFingerprint) {
                     payload.signal_fingerprint = this.signalFingerprint;
@@ -217,6 +222,22 @@ export class IrTriggerDialog extends LitElement {
                         ?disabled=${this._busy}
                     />
 
+                    <!-- Receiver scope -->
+                    <div class="receiver-field">
+                        <ir-receiver-picker
+                            .api=${this.api}
+                            .value=${this._receiverIds}
+                            ?disabled=${this._busy}
+                            @receivers-changed=${(e: CustomEvent) => {
+                                this._receiverIds = e.detail.value;
+                            }}
+                        ></ir-receiver-picker>
+                        <p class="field-hint scope-hint">
+                            Fires once per press, regardless of how many scoped
+                            receivers observe the signal.
+                        </p>
+                    </div>
+
                     ${this._error
                         ? html`<p class="error">${this._error}</p>`
                         : ""}
@@ -353,6 +374,13 @@ export class IrTriggerDialog extends LitElement {
         }
         .hits-input {
             width: 80px;
+        }
+        .receiver-field {
+            margin-bottom: 14px;
+        }
+        .scope-hint {
+            margin: 6px 0 0;
+            margin-left: 0;
         }
         .error {
             color: #e65100;

--- a/custom_components/hair/frontend/src/ir-trigger-popover.ts
+++ b/custom_components/hair/frontend/src/ir-trigger-popover.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared trigger-picker popover.
+ *
+ * Rendered when a signal row's Trigger button is clicked and one or more
+ * triggers already bind that signal's fingerprint (the zero-trigger case
+ * bypasses the popover and opens the Create dialog directly). Hosts the
+ * "+ new trigger" action plus one row per existing trigger, each showing its
+ * receiver scope. Emits `create-new` and `edit-trigger` (detail = the
+ * trigger) for the parent to handle.
+ *
+ * The parent owns position (`top`/`left`) and dismiss-on-outside-click /
+ * dismiss-on-scroll, mirroring the action-popover pattern in
+ * ir-device-detail.ts.
+ */
+import { LitElement, html, css } from "lit";
+import { customElement, property } from "./decorators.js";
+import { popoverStyles } from "./ir-popover-styles.js";
+import type { IRTrigger, ReceiverInfo } from "./types.js";
+
+@customElement("ir-trigger-popover")
+export class IrTriggerPopover extends LitElement {
+    @property({ attribute: false }) triggers: IRTrigger[] = [];
+    @property({ attribute: false }) receivers: ReceiverInfo[] = [];
+    @property({ type: Number }) top = 0;
+    @property({ type: Number }) left = 0;
+
+    render() {
+        return html`
+            <div
+                class="action-popover"
+                style="top:${this.top}px; left:${this.left}px"
+            >
+                <div class="popover-header">Triggers</div>
+                <button
+                    class="popover-item accent"
+                    @click=${() => this._emit("create-new")}
+                >
+                    <span>+ new trigger</span>
+                </button>
+                <div class="popover-divider"></div>
+                ${this.triggers.map(
+                    (t) => html`
+                        <button
+                            class="popover-item"
+                            @click=${() => this._emit("edit-trigger", t)}
+                        >
+                            <span class="popover-row">
+                                <span class="popover-name">${t.name}</span>
+                                <span class="popover-scope"
+                                    >${this._renderScope(t)}</span
+                                >
+                            </span>
+                        </button>
+                    `,
+                )}
+            </div>
+        `;
+    }
+
+    private _renderScope(t: IRTrigger): string {
+        const ids = t.receiver_entity_ids ?? [];
+        if (ids.length === 0) return "Any receiver";
+        if (ids.length === 1) return this._friendly(ids[0]);
+        return `${this._friendly(ids[0])} + ${ids.length - 1} more`;
+    }
+
+    private _friendly(entityId: string): string {
+        const match = this.receivers.find((r) => r.entity_id === entityId);
+        return match?.name ?? entityId;
+    }
+
+    private _emit(kind: string, trigger?: IRTrigger): void {
+        this.dispatchEvent(
+            new CustomEvent(kind, {
+                detail: trigger,
+                bubbles: true,
+                composed: true,
+            }),
+        );
+    }
+
+    static styles = [
+        popoverStyles,
+        css`
+            :host {
+                display: contents;
+            }
+        `,
+    ];
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "ir-trigger-popover": IrTriggerPopover;
+    }
+}

--- a/custom_components/hair/frontend/src/types.ts
+++ b/custom_components/hair/frontend/src/types.ts
@@ -196,6 +196,11 @@ export interface UnknownSignal {
     repeat_count?: number;
     send_count?: number;
     observed_repeat_count?: number;
+    // Assignment provenance (dots polish, v0.5.7). Number of HAIR device
+    // commands whose fingerprint matches this signal, and their
+    // "<device>.<command>" labels for the green Assign dot's tooltip.
+    assignment_count?: number;
+    assigned_to?: string[];
 }
 
 export interface UnknownDeviceSummary {
@@ -346,6 +351,8 @@ export interface IRTrigger {
     source_command_id: string | null;
     created_at: string;
     updated_at: string;
+    // Receiver scope (location-aware triggers, v0.5.7). Empty = any receiver.
+    receiver_entity_ids: string[];
 }
 
 export interface TriggerFiredEvent {
@@ -356,4 +363,18 @@ export interface TriggerFiredEvent {
     code: string | null;
     source_remote: string | null;
     timestamp: string;
+    // Location-aware fields (v0.5.7). Null for legacy captures or a receiver
+    // whose device has no HA area assignment.
+    receiver_entity_id: string | null;
+    receiver_area_id: string | null;
+    receiver_area_name: string | null;
+}
+
+/**
+ * Fired when a signal's assignment set changes (assign, or a device command
+ * referencing it is added/removed). Lets the Sniffer/Clipper/Plucker refresh
+ * the green Assign badge and yellow trigger dot on other browser tabs.
+ */
+export interface SignalUpdatedEvent {
+    signal_fingerprint: string;
 }

--- a/custom_components/hair/manifest.json
+++ b/custom_components/hair/manifest.json
@@ -1,7 +1,7 @@
 {
     "domain": "hair",
     "name": "HAIR",
-    "version": "0.5.6",
+    "version": "0.5.7",
     "documentation": "https://github.com/DAB-LABS/HAIR",
     "issue_tracker": "https://github.com/DAB-LABS/HAIR/issues",
     "dependencies": ["infrared"],

--- a/custom_components/hair/models.py
+++ b/custom_components/hair/models.py
@@ -393,6 +393,11 @@ class IRTrigger:
     source_command_id: str | None = None
     created_at: str = field(default_factory=_now_iso)
     updated_at: str = field(default_factory=_now_iso)
+    # Location-aware trigger scope (v0.5.7). Empty = fires on any receiver
+    # (backward-compatible with pre-0.5.7 triggers). Non-empty = fires only
+    # when the capturing receiver's entity_id is in this list. Legacy captures
+    # (receiver_entity_id None) never match a scoped trigger.
+    receiver_entity_ids: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -407,6 +412,7 @@ class IRTrigger:
             "source_command_id": self.source_command_id,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
+            "receiver_entity_ids": list(self.receiver_entity_ids),
         }
 
     @classmethod
@@ -423,7 +429,23 @@ class IRTrigger:
             source_command_id=data.get("source_command_id"),
             created_at=data.get("created_at") or _now_iso(),
             updated_at=data.get("updated_at") or _now_iso(),
+            # Absent (pre-0.5.7 record) or null both resolve to [] = unscoped.
+            receiver_entity_ids=list(data.get("receiver_entity_ids") or []),
         )
+
+    def matches_receiver(self, receiver_entity_id: str | None) -> bool:
+        """Return True if this trigger's scope matches the capturing receiver.
+
+        Empty ``receiver_entity_ids`` = unscoped = matches any receiver,
+        including None (legacy captures). A non-empty list matches only when
+        ``receiver_entity_id`` is in the list; legacy captures (None) never
+        match a scoped trigger.
+        """
+        if not self.receiver_entity_ids:
+            return True
+        if receiver_entity_id is None:
+            return False
+        return receiver_entity_id in self.receiver_entity_ids
 
 
 @dataclass

--- a/custom_components/hair/signal_monitor.py
+++ b/custom_components/hair/signal_monitor.py
@@ -33,6 +33,7 @@ from .const import (
     EVENT_DISMISS_ACTIVITY,
     EVENT_SIGNAL_DETECTED,
     EVENT_SIGNAL_REMOVED,
+    EVENT_SIGNAL_UPDATED,
     LEGACY_ESPHOME_IR_EVENT,
     MAX_DITTO_COUNT,
     MAX_SEND_COUNT,
@@ -220,7 +221,9 @@ class SignalMonitor:
         self._rate_buckets: dict[str, list[float]] = defaultdict(list)
 
         # Repeat suppression: fingerprint -> last event time (monotonic).
-        self._last_seen_times: dict[str, float] = {}
+        # Keyed by (fingerprint, receiver_key) so cross-receiver captures of
+        # the same press are not dropped as storage-path repeats (v0.5.7).
+        self._last_seen_times: dict[tuple[str, str], float] = {}
 
         # Per-device-fingerprint rate limit for the dismiss-activity bus
         # event push. Separate from ``_rate_buckets`` so the dismiss-activity
@@ -245,22 +248,25 @@ class SignalMonitor:
         # Capture-side NEC ditto observation (v0.5.5). In-memory only; does
         # not persist across restarts.
         #
-        # Sentinel-aware single anchor. Written synchronously in
-        # _on_received_signal the moment a non-repeat signal arrives, then
+        # Per-receiver ditto anchors (v0.5.7). Keyed by receiver_entity_id, or
+        # the "__legacy__" sentinel for legacy captures, so two receivers
+        # observing the same physical press keep independent attribution
+        # instead of corrupting a shared single anchor. Written synchronously
+        # in _on_received_signal the moment a non-repeat signal arrives, then
         # filled with the persisted signal_id once _process_parsed_signal
-        # completes, or invalidated to None if that path returns early for
-        # dismiss / rate-limit / known-command / repeat-suppress.
-        #   None                   -- no anchor active
-        #   (None, t, dev_fp)      -- main frame in flight (sentinel)
-        #   (signal_id, t, dev_fp) -- anchor live and writable
-        # The dev_fp slot is unread today; reserved for a v2 per-receiver
-        # attribution refinement so that upgrade does not change the shape.
-        self._ditto_anchor: tuple[str | None, float, str | None] | None = None
-        # Running count of dittos in the current burst; resets per main frame.
-        self._ditto_running_count: int = 0
-        # Timestamp of the most recent attributed ditto, for the inter-frame
-        # gate. None at the start of each burst.
-        self._last_ditto_monotonic: float | None = None
+        # completes, or removed if that path returns early.
+        #   value (None, t, dev_fp)      -- main frame in flight (sentinel)
+        #   value (signal_id, t, dev_fp) -- anchor live and writable
+        # The dev_fp slot is unread today; kept for shape stability.
+        self._ditto_anchor: dict[
+            str, tuple[str | None, float, str | None]
+        ] = {}
+        # Running ditto count in the current burst, per receiver; reset on each
+        # new main frame.
+        self._ditto_running_count: dict[str, int] = {}
+        # Timestamp of the most recent attributed ditto per receiver, for the
+        # inter-frame gate. Key absent = no ditto yet in this burst.
+        self._last_ditto_monotonic: dict[str, float] = {}
 
     @property
     def bridge_active_device_ids(self) -> set[str]:
@@ -339,10 +345,15 @@ class SignalMonitor:
             return
 
         for receiver_entity_id in receivers:
+            # rid=... binds the loop var by value (avoids late-binding) and
+            # threads the capturing receiver's entity_id into the callback so
+            # location-aware triggers know where the signal was received.
             unsub = async_subscribe_receiver(
                 self._hass,
                 receiver_entity_id,
-                self._on_received_signal,
+                lambda sig, rid=receiver_entity_id: self._on_received_signal(
+                    sig, rid
+                ),
             )
             self._unsubs.append(unsub)
 
@@ -433,9 +444,13 @@ class SignalMonitor:
         if parsed is None:
             return
 
-        await self._process_parsed_signal(parsed)
+        # Legacy captures cannot reliably map to an infrared.* receiver entity,
+        # so scoped triggers will not match them; unscoped triggers still fire.
+        await self._process_parsed_signal(parsed, receiver_entity_id=None)
 
-    async def _process_parsed_signal(self, parsed: Any) -> None:
+    async def _process_parsed_signal(
+        self, parsed: Any, receiver_entity_id: str | None = None
+    ) -> None:
         """Shared signal processing pipeline for both native and legacy paths.
 
         Steps:
@@ -450,6 +465,9 @@ class SignalMonitor:
         11. Fire HA event
         12. Notify subscribers
         """
+        # Per-receiver key for ditto attribution + repeat suppression (v0.5.7).
+        rid_key = receiver_entity_id or "__legacy__"
+
         # Step 1: Compute fingerprints + byte-hash + protocol decode. This
         # pure normalization lives in the module-level normalize() so the
         # Plucker can reuse it without the route/store/push half below.
@@ -465,10 +483,13 @@ class SignalMonitor:
         decoded_fingerprint = n.decoded_fingerprint
 
         # Step 2: Check triggers (before known-command skip so triggers
-        # work for both assigned commands and unknown signals).
+        # work for both assigned commands and unknown signals). Threads the
+        # capturing receiver so scoped triggers can match and the payload
+        # carries receiver + area (v0.5.7).
         if self._trigger_manager is not None:
-            self._trigger_manager.on_signal(
-                sig_fp, parsed.protocol, parsed.code, dev_fp
+            self._trigger_manager.on_signal_captured(
+                sig_fp, parsed.protocol, parsed.code, dev_fp,
+                receiver_entity_id,
             )
 
         # Step 3: Check known commands. The matcher returns the matched
@@ -481,7 +502,7 @@ class SignalMonitor:
             self._matches_known_command(sig_fp, byte_hash, decoded_fingerprint)
             is not None
         ):
-            self._ditto_anchor = None  # invalidate the in-flight ditto sentinel
+            self._ditto_anchor.pop(rid_key, None)  # invalidate this receiver's sentinel
             return
 
         # Step 4: Check dismiss list.
@@ -500,17 +521,18 @@ class SignalMonitor:
                     EVENT_DISMISS_ACTIVITY,
                     {"device_fingerprint": dev_fp},
                 )
-            self._ditto_anchor = None  # invalidate the in-flight ditto sentinel
+            self._ditto_anchor.pop(rid_key, None)  # invalidate this receiver's sentinel
             return
 
         # Step 5: Rate limit.
         if not self._check_rate_limit(sig_fp):
-            self._ditto_anchor = None  # invalidate the in-flight ditto sentinel
+            self._ditto_anchor.pop(rid_key, None)  # invalidate this receiver's sentinel
             return
 
-        # Step 6: Repeat suppression.
-        if not self._check_repeat(sig_fp):
-            self._ditto_anchor = None  # invalidate the in-flight ditto sentinel
+        # Step 6: Repeat suppression (per receiver, so cross-receiver captures
+        # of the same press are not dropped as storage-path repeats).
+        if not self._check_repeat(sig_fp, receiver_entity_id):
+            self._ditto_anchor.pop(rid_key, None)  # invalidate this receiver's sentinel
             return
 
         # Steps 7-9: Find/create device and signal (locked).
@@ -566,9 +588,10 @@ class SignalMonitor:
         # entry point and are still correct. If the sentinel was already
         # invalidated (an early return, or a racing main frame), do not
         # resurrect it -- the next press starts a fresh anchor.
-        if self._ditto_anchor is not None:
-            _, t_anchor, dev_fp_anchor = self._ditto_anchor
-            self._ditto_anchor = (signal.id, t_anchor, dev_fp_anchor)
+        anchor = self._ditto_anchor.get(rid_key)
+        if anchor is not None:
+            _, t_anchor, dev_fp_anchor = anchor
+            self._ditto_anchor[rid_key] = (signal.id, t_anchor, dev_fp_anchor)
 
         # Step 10: Schedule save.
         self._signal_store.schedule_save()
@@ -597,17 +620,21 @@ class SignalMonitor:
     # Native receiver callback (HA 2026.6+)
     # -----------------------------------------------------------------
 
-    def _on_received_signal(self, signal: Any) -> None:
+    def _on_received_signal(
+        self, signal: Any, receiver_entity_id: str | None = None
+    ) -> None:
         """Handle a signal from the native ``InfraredReceiverEntity`` API.
 
         Called synchronously by HA's ``@callback`` subscription system.
-        Converts the ``InfraredReceivedSignal`` to Pronto hex at the
-        entry point, then schedules the async processing pipeline.
+        ``receiver_entity_id`` is threaded in by the per-receiver subscription
+        closure so ditto attribution and location-aware triggers know which
+        receiver captured the signal.
         """
-        # NEC ditto (short repeat frame): attribute it to the most recent
-        # main frame instead of dropping it on the floor (v0.5.5).
+        rid_key = receiver_entity_id or "__legacy__"
+        # NEC ditto (short repeat frame): attribute it to the most recent main
+        # frame on the SAME receiver instead of dropping it (v0.5.5/0.5.7).
         if EventParser.is_native_repeat(signal):
-            self._maybe_attribute_repeat_frame()
+            self._maybe_attribute_repeat_frame(rid_key)
             return
 
         parsed = EventParser.parse_received_signal(signal)
@@ -616,35 +643,39 @@ class SignalMonitor:
 
         # Sentinel write BEFORE scheduling the async work, so a ditto arriving
         # between this callback and the async-task completion sees "main frame
-        # in flight, hold off" rather than the stale previous anchor. The
-        # signal_id stays None until _process_parsed_signal confirms
-        # persistence (or invalidates the anchor on an early return). The
-        # dev_fp is computed here too; this duplicates the call inside
-        # normalize() -- acceptable cost for the race fix.
+        # in flight, hold off" rather than the stale previous anchor. Keyed per
+        # receiver. signal_id stays None until _process_parsed_signal confirms
+        # persistence (or removes the anchor on an early return). The dev_fp is
+        # computed here too; duplicates the normalize() call -- acceptable for
+        # the race fix.
         n_dev_fp = EventParser.device_fingerprint(
             parsed.protocol,
             EventParser.extract_device_address(parsed.protocol, parsed.code),
             parsed.raw_timings,
             code=parsed.code,
         )
-        self._ditto_anchor = (None, time.monotonic(), n_dev_fp)
-        self._ditto_running_count = 0
-        self._last_ditto_monotonic = None
+        self._ditto_anchor[rid_key] = (None, time.monotonic(), n_dev_fp)
+        self._ditto_running_count[rid_key] = 0
+        self._last_ditto_monotonic.pop(rid_key, None)
 
-        self._hass.async_create_task(self._process_parsed_signal(parsed))
+        self._hass.async_create_task(
+            self._process_parsed_signal(parsed, receiver_entity_id)
+        )
 
-    def _maybe_attribute_repeat_frame(self) -> None:
+    def _maybe_attribute_repeat_frame(self, rid_key: str) -> None:
         """Attribute an incoming short signal (NEC ditto) to the most recent
-        main-frame arrival, if it is within the attribution window AND the
-        inter-frame gate is satisfied. Updates ``observed_repeat_count`` on the
-        stored signal with max-merge (high water mark) semantics.
+        main-frame arrival ON THE SAME RECEIVER, if it is within the
+        attribution window AND the inter-frame gate is satisfied. Updates
+        ``observed_repeat_count`` on the stored signal with max-merge (high
+        water mark) semantics.
 
-        v1 of ditto observation is native-only; the legacy ESPHome bridge
-        (``_on_ir_event``) gets the same treatment if a user requests it.
+        Per-receiver (v0.5.7): ``rid_key`` selects this receiver's anchor so
+        concurrent presses on different receivers do not corrupt each other.
         """
-        if self._ditto_anchor is None:
+        anchor = self._ditto_anchor.get(rid_key)
+        if anchor is None:
             return
-        signal_id, last_main_monotonic, _ = self._ditto_anchor
+        signal_id, last_main_monotonic, _ = anchor
 
         # Sentinel: the main frame has not been persisted yet. Drop -- we
         # cannot attribute to a signal_id we do not have.
@@ -660,15 +691,13 @@ class SignalMonitor:
         # Gate 2: inter-frame staleness. NEC dittos arrive ~110ms apart; a gap
         # > DITTO_INTER_FRAME_MAX_S means the burst is over and this short
         # signal starts a new orphan burst until the next main-frame anchor.
-        if (
-            self._last_ditto_monotonic is not None
-            and now - self._last_ditto_monotonic > DITTO_INTER_FRAME_MAX_S
-        ):
+        last_ditto = self._last_ditto_monotonic.get(rid_key)
+        if last_ditto is not None and now - last_ditto > DITTO_INTER_FRAME_MAX_S:
             return
 
-        self._ditto_running_count += 1
-        new_count = self._ditto_running_count
-        self._last_ditto_monotonic = now
+        new_count = self._ditto_running_count.get(rid_key, 0) + 1
+        self._ditto_running_count[rid_key] = new_count
+        self._last_ditto_monotonic[rid_key] = now
 
         # Locate the stored UnknownSignal by id and max-merge the count.
         for device in self._signal_store.get_all_devices():
@@ -762,19 +791,24 @@ class SignalMonitor:
     # Repeat suppression
     # -----------------------------------------------------------------
 
-    def _check_repeat(self, fingerprint: str) -> bool:
+    def _check_repeat(
+        self, fingerprint: str, receiver_entity_id: str | None = None
+    ) -> bool:
         """Return True if the event is NOT a repeat (passes suppression).
 
-        Suppresses duplicate fingerprints within ``SIGNAL_REPEAT_SUPPRESS_MS``.
+        Suppresses duplicate fingerprints within ``SIGNAL_REPEAT_SUPPRESS_MS``,
+        keyed per receiver (v0.5.7) so the same press captured by two receivers
+        is not dropped -- each receiver's captures suppress only their own.
         """
+        key = (fingerprint, receiver_entity_id or "__legacy__")
         now = time.monotonic()
-        last = self._last_seen_times.get(fingerprint)
+        last = self._last_seen_times.get(key)
         suppress_s = SIGNAL_REPEAT_SUPPRESS_MS / 1000.0
 
         if last is not None and (now - last) < suppress_s:
             return False
 
-        self._last_seen_times[fingerprint] = now
+        self._last_seen_times[key] = now
         return True
 
     # -----------------------------------------------------------------
@@ -913,6 +947,12 @@ class SignalMonitor:
                 return {"success": False, "code": "save_failed",
                         "error": "Failed to save command"}
 
+        # Assignment set for this signal changed -- notify other browser tabs
+        # so the green Assign badge / trigger dot refresh live (v0.5.7). Fired
+        # outside the lock; the payload is fingerprint-only.
+        self._hass.bus.async_fire(
+            EVENT_SIGNAL_UPDATED, {"signal_fingerprint": signal.fingerprint}
+        )
         return {"success": True, "command_id": command_id}
 
     async def assign_to_new_device(
@@ -1007,6 +1047,10 @@ class SignalMonitor:
 
         # HAIR store persisted -- safe to register in HA now.
         # (Outside the lock since HA registry ops don't touch our stores.)
+        # Notify other tabs that this signal's assignment set changed (v0.5.7).
+        self._hass.bus.async_fire(
+            EVENT_SIGNAL_UPDATED, {"signal_fingerprint": signal.fingerprint}
+        )
         return {
             "success": True,
             "command_id": command_id,

--- a/custom_components/hair/storage.py
+++ b/custom_components/hair/storage.py
@@ -322,11 +322,31 @@ class HAIRStore:
     def get_trigger_by_fingerprint(
         self, fingerprint: str
     ) -> IRTrigger | None:
-        """Find a trigger by signal fingerprint."""
+        """Find a trigger by signal fingerprint (first match).
+
+        Retained for callers that only need existence. Prefer
+        :meth:`get_triggers_by_fingerprint` where multiple scoped triggers per
+        fingerprint are possible (v0.5.7).
+        """
         for t in self._triggers.values():
             if t.signal_fingerprint == fingerprint:
                 return t
         return None
+
+    def get_triggers_by_fingerprint(
+        self, fingerprint: str
+    ) -> list[IRTrigger]:
+        """Return all triggers bound to a signal fingerprint.
+
+        Multiple triggers per fingerprint are legal (v0.5.7 location-aware
+        scoping): one signal can drive several triggers with different receiver
+        scopes. Returns every match so callers can present or scope them all.
+        """
+        return [
+            t
+            for t in self._triggers.values()
+            if t.signal_fingerprint == fingerprint
+        ]
 
     def get_triggers_for_signal(
         self, protocol: str | None, code: str | None, fingerprint: str

--- a/custom_components/hair/tests/test_capture_dittos.py
+++ b/custom_components/hair/tests/test_capture_dittos.py
@@ -90,9 +90,23 @@ def _decoded_sig(sig_id="s1", **overrides):
     return UnknownSignal(**fields)
 
 
+# v0.5.7: ditto-anchor state is per-receiver (dict keyed by receiver_entity_id,
+# or the "__legacy__" sentinel for the ESPHome-bridge / no-receiver path). These
+# capture-attribution tests exercise a single receiver, so they key everything on
+# the legacy sentinel.
+_RID = "__legacy__"
+
+
+def _set_anchor(monitor, anchor, running=0, last=None):
+    """Seed the per-receiver ditto state for the legacy sentinel receiver."""
+    monitor._ditto_anchor = {_RID: anchor}
+    monitor._ditto_running_count = {_RID: running}
+    monitor._last_ditto_monotonic = {} if last is None else {_RID: last}
+
+
 def _fire_ditto(monitor, now):
     with patch(_MONO, return_value=now):
-        monitor._maybe_attribute_repeat_frame()
+        monitor._maybe_attribute_repeat_frame(_RID)
 
 
 # ---------------------------------------------------------------------------
@@ -103,9 +117,7 @@ def _fire_ditto(monitor, now):
 def test_ditto_attribution_within_window(fake_hass):
     sig = _sig("s1")
     monitor, _ = _monitor(fake_hass, sig)
-    monitor._ditto_anchor = ("s1", 0.0, "df")
-    monitor._ditto_running_count = 0
-    monitor._last_ditto_monotonic = None
+    _set_anchor(monitor, ("s1", 0.0, "df"))
     _fire_ditto(monitor, 0.2)  # 200ms, inside the 1.0s window
     assert sig.observed_repeat_count == 1
 
@@ -113,7 +125,7 @@ def test_ditto_attribution_within_window(fake_hass):
 def test_ditto_attribution_outside_window(fake_hass):
     sig = _sig("s1")
     monitor, _ = _monitor(fake_hass, sig)
-    monitor._ditto_anchor = ("s1", 0.0, "df")
+    _set_anchor(monitor, ("s1", 0.0, "df"))
     # Past REPEAT_ATTRIBUTION_WINDOW (1.0s): the main-frame window gate refuses.
     _fire_ditto(monitor, REPEAT_ATTRIBUTION_WINDOW + 0.5)
     assert sig.observed_repeat_count == 0
@@ -126,9 +138,7 @@ def test_ditto_attribution_different_device(fake_hass):
     sig_a = _sig("sA")
     sig_b = _sig("sB")
     monitor, _ = _monitor(fake_hass, sig_a, sig_b)
-    monitor._ditto_anchor = ("sB", 0.0, "dfB")
-    monitor._ditto_running_count = 0
-    monitor._last_ditto_monotonic = None
+    _set_anchor(monitor, ("sB", 0.0, "dfB"))
     _fire_ditto(monitor, 0.1)
     assert sig_b.observed_repeat_count == 1
     assert sig_a.observed_repeat_count == 0
@@ -138,9 +148,7 @@ def test_ditto_max_merge(fake_hass):
     # An earlier hold observed 5; a later 2-ditto tap must not lower it.
     sig = _sig("s1", observed=5)
     monitor, _ = _monitor(fake_hass, sig)
-    monitor._ditto_anchor = ("s1", 0.0, "df")
-    monitor._ditto_running_count = 0
-    monitor._last_ditto_monotonic = None
+    _set_anchor(monitor, ("s1", 0.0, "df"))
     _fire_ditto(monitor, 0.10)
     _fire_ditto(monitor, 0.21)
     assert sig.observed_repeat_count == 5
@@ -149,9 +157,7 @@ def test_ditto_max_merge(fake_hass):
 def test_ditto_inter_frame_gate_stops_burst(fake_hass):
     sig = _sig("s1")
     monitor, _ = _monitor(fake_hass, sig)
-    monitor._ditto_anchor = ("s1", 0.0, "df")
-    monitor._ditto_running_count = 0
-    monitor._last_ditto_monotonic = None
+    _set_anchor(monitor, ("s1", 0.0, "df"))
     # 5 dittos at ~110ms intervals all attribute.
     for i in range(5):
         _fire_ditto(monitor, 0.05 + i * 0.11)
@@ -166,13 +172,11 @@ def test_ditto_dropped_during_sentinel_window(fake_hass):
     sig = _sig("s1")
     monitor, _ = _monitor(fake_hass, sig)
     # Sentinel: main frame in flight, signal_id is None -> drop the ditto.
-    monitor._ditto_anchor = (None, 0.0, "df")
+    _set_anchor(monitor, (None, 0.0, "df"))
     _fire_ditto(monitor, 0.1)
     assert sig.observed_repeat_count == 0
     # Pipeline confirms the anchor; subsequent dittos now attribute.
-    monitor._ditto_anchor = ("s1", 0.0, "df")
-    monitor._ditto_running_count = 0
-    monitor._last_ditto_monotonic = None
+    _set_anchor(monitor, ("s1", 0.0, "df"))
     _fire_ditto(monitor, 0.2)
     assert sig.observed_repeat_count == 1
 
@@ -187,22 +191,20 @@ async def test_dismiss_invalidates_anchor_no_inflation(fake_hass):
 
     # D's main frame wrote a sentinel synchronously; the async pipeline's
     # dismiss early-return must invalidate it before any ditto attributes.
-    monitor._ditto_anchor = (None, 0.0, "dfD")
+    _set_anchor(monitor, (None, 0.0, "dfD"))
     parsed = CaptureResult(
         protocol="PRONTO", code=_PRONTO_A,
         raw_timings=[560, -560, 560, -1690], frequency=38000,
     )
     await monitor._process_parsed_signal(parsed)
-    assert monitor._ditto_anchor is None
+    assert monitor._ditto_anchor.get(_RID) is None
 
     # D's dittos drop (anchor is None).
     _fire_ditto(monitor, 0.1)
     assert sig_n.observed_repeat_count == 0
 
     # N's main frame sets a fresh confirmed anchor; its dittos attribute to N.
-    monitor._ditto_anchor = ("sN", 1.0, "dfN")
-    monitor._ditto_running_count = 0
-    monitor._last_ditto_monotonic = None
+    _set_anchor(monitor, ("sN", 1.0, "dfN"))
     _fire_ditto(monitor, 1.1)
     assert sig_n.observed_repeat_count == 1
 

--- a/custom_components/hair/tests/test_dots_assignments.py
+++ b/custom_components/hair/tests/test_dots_assignments.py
@@ -1,0 +1,186 @@
+"""Tests for the v0.5.7 dots polish backend + hair_signal_updated event.
+
+Covers:
+- ``_assignment_index`` / ``_augment_signals_with_assignments`` count math
+  (dots plan acceptance #10: 0, 1, and 3 assignments across 2 devices),
+- the ``hair_signal_updated`` bus event firing on assign and command delete.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.hair.const import DOMAIN, EVENT_SIGNAL_UPDATED
+from custom_components.hair.event_parser import EventParser
+from custom_components.hair.models import (
+    IRCommand,
+    IRDevice,
+    UnknownDevice,
+    UnknownSignal,
+)
+from custom_components.hair.signal_monitor import SignalMonitor
+from custom_components.hair.signal_store import SignalStore
+from custom_components.hair.websocket_api import (
+    _assignment_index,
+    _augment_signals_with_assignments,
+    ws_delete_command,
+)
+
+_CODE_A = "0000 006D 0002 0000 0020 0040 0020 0040"
+_CODE_B = "0000 006D 0002 0000 0030 0050 0030 0050"
+
+
+def _fp(code: str) -> str:
+    return EventParser.signal_fingerprint("PRONTO", code, None)
+
+
+def _cmd(name: str, code: str) -> IRCommand:
+    return IRCommand(name=name, protocol="PRONTO", code=code)
+
+
+# ---------------------------------------------------------------------------
+# Assignment-count math
+# ---------------------------------------------------------------------------
+
+
+class TestAssignmentIndex:
+    def test_zero_assignments(self):
+        assert _assignment_index([]) == {}
+
+    def test_single_assignment(self):
+        d = IRDevice(id="d1", name="TV", commands=[_cmd("Power", _CODE_A)])
+        idx = _assignment_index([d])
+        assert idx[_fp(_CODE_A)] == ["TV.Power"]
+
+    def test_three_assignments_across_two_devices(self):
+        d1 = IRDevice(
+            id="d1",
+            name="TV",
+            commands=[_cmd("Power", _CODE_A), _cmd("Mute", _CODE_A)],
+        )
+        d2 = IRDevice(id="d2", name="AVR", commands=[_cmd("Power", _CODE_A)])
+        idx = _assignment_index([d1, d2])
+        assert idx[_fp(_CODE_A)] == ["TV.Power", "TV.Mute", "AVR.Power"]
+
+    def test_distinct_codes_indexed_separately(self):
+        d = IRDevice(
+            id="d1",
+            name="TV",
+            commands=[_cmd("Power", _CODE_A), _cmd("Vol", _CODE_B)],
+        )
+        idx = _assignment_index([d])
+        assert idx[_fp(_CODE_A)] == ["TV.Power"]
+        assert idx[_fp(_CODE_B)] == ["TV.Vol"]
+
+
+class TestAugmentSignals:
+    def test_augments_count_and_list(self):
+        fp = _fp(_CODE_A)
+        device_dict = {
+            "signals": [
+                {"fingerprint": fp},
+                {"fingerprint": "unassigned_fp"},
+            ]
+        }
+        _augment_signals_with_assignments(device_dict, {fp: ["TV.Power", "AVR.Power"]})
+        assert device_dict["signals"][0]["assignment_count"] == 2
+        assert device_dict["signals"][0]["assigned_to"] == ["TV.Power", "AVR.Power"]
+        assert device_dict["signals"][1]["assignment_count"] == 0
+        assert device_dict["signals"][1]["assigned_to"] == []
+
+    def test_no_signals_key_is_safe(self):
+        d: dict = {}
+        _augment_signals_with_assignments(d, {})
+        assert d == {}
+
+
+# ---------------------------------------------------------------------------
+# hair_signal_updated bus event
+# ---------------------------------------------------------------------------
+
+
+def _signal(sig_id: str = "s1", code: str = _CODE_A) -> UnknownSignal:
+    return UnknownSignal(
+        id=sig_id, fingerprint=sig_id, protocol="PRONTO", code=code
+    )
+
+
+def _monitor_with_signal(fake_hass, signal: UnknownSignal):
+    store = SignalStore(fake_hass)
+    store._loaded = True
+    store.schedule_save = MagicMock()
+    store.async_save = AsyncMock()
+    hair = MagicMock()
+    hair.get_device = MagicMock(return_value=None)
+    hair.async_save = AsyncMock()
+    hair.match_command = MagicMock(return_value=None)
+    monitor = SignalMonitor(fake_hass, store, hair)
+    store.add_device(
+        UnknownDevice(
+            id="ud0", fingerprint="d0", source="manual", signals=[signal]
+        )
+    )
+    return monitor, store, hair
+
+
+@pytest.mark.asyncio
+async def test_assign_to_new_device_fires_signal_updated(fake_hass):
+    sig = _signal("s1")
+    monitor, _store, _hair = _monitor_with_signal(fake_hass, sig)
+    res = await monitor.assign_to_new_device(
+        device_id="ud0",
+        signal_id="s1",
+        device_name="TV",
+        device_type="media_player",
+        emitter_entity_ids=["infrared.e"],
+        command_name="Power",
+        command_category="custom",
+    )
+    assert res["success"]
+    fired = [
+        c.args
+        for c in fake_hass.bus.async_fire.call_args_list
+        if c.args and c.args[0] == EVENT_SIGNAL_UPDATED
+    ]
+    assert fired, "expected a hair_signal_updated event"
+    assert fired[-1][1] == {"signal_fingerprint": sig.fingerprint}
+
+
+@pytest.mark.asyncio
+async def test_ws_delete_command_fires_signal_updated(fake_hass):
+    code = _CODE_A
+    device = IRDevice(
+        id="hd1", name="TV", commands=[IRCommand(id="c1", name="Power",
+                                                 protocol="PRONTO", code=code)]
+    )
+    dm = MagicMock()
+    dm.get_device = MagicMock(return_value=device)
+    dm.async_remove_command = AsyncMock(return_value=True)
+    fake_hass.data[DOMAIN] = {
+        "e1": {
+            "device_manager": dm,
+            "config_entry": MagicMock(),
+        }
+    }
+    conn = MagicMock()
+    conn.send_result = MagicMock()
+    conn.send_error = MagicMock()
+    await ws_delete_command(
+        fake_hass,
+        conn,
+        {
+            "id": 1,
+            "type": "hair/command/delete",
+            "device_id": "hd1",
+            "command_id": "c1",
+        },
+    )
+    conn.send_error.assert_not_called()
+    fired = [
+        c.args
+        for c in fake_hass.bus.async_fire.call_args_list
+        if c.args and c.args[0] == EVENT_SIGNAL_UPDATED
+    ]
+    assert fired, "expected a hair_signal_updated event on command delete"
+    assert fired[-1][1] == {"signal_fingerprint": _fp(code)}

--- a/custom_components/hair/tests/test_location_aware_triggers.py
+++ b/custom_components/hair/tests/test_location_aware_triggers.py
@@ -1,0 +1,323 @@
+"""Tests for v0.5.7 location-aware triggers.
+
+Covers the Section 7 matrix from
+``docs/internal/plans/location-aware-triggers.md``:
+- receiver scope matching (5.1),
+- multi-receiver 60ms dedup composed with min_hits,
+- receiver + area fields in the fire payload,
+- entity/device/area registry resolution at fire time,
+- IRTrigger.from_dict lazy migration of receiver_entity_ids.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.hair.models import IRTrigger
+from custom_components.hair.storage import HAIRStore
+from custom_components.hair.trigger_manager import TriggerManager
+
+
+@pytest.fixture
+def mock_hass():
+    hass = MagicMock()
+    hass.bus = MagicMock()
+    return hass
+
+
+@pytest.fixture
+def mock_store(mock_hass):
+    store = HAIRStore(mock_hass)
+    store._loaded = True
+    return store
+
+
+@pytest.fixture
+def manager(mock_hass, mock_store):
+    return TriggerManager(mock_hass, mock_store)
+
+
+class _FakeClock:
+    """Controllable monotonic clock for TriggerManager time-based logic."""
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.t = start
+
+    def monotonic(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    fake = _FakeClock()
+    monkeypatch.setattr("custom_components.hair.trigger_manager.time", fake)
+    return fake
+
+
+def _trigger(
+    *,
+    name: str = "T",
+    fingerprint: str = "fp1",
+    protocol: str = "pronto",
+    code: str = "c1",
+    min_hits: int = 1,
+    receivers: list[str] | None = None,
+) -> IRTrigger:
+    return IRTrigger(
+        name=name,
+        signal_fingerprint=fingerprint,
+        protocol=protocol,
+        code=code,
+        min_hits=min_hits,
+        receiver_entity_ids=receivers or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# 7.1 matches_receiver (scope matrix)
+# ---------------------------------------------------------------------------
+
+
+class TestMatchesReceiver:
+    def test_unscoped_matches_any_including_none(self):
+        t = _trigger(receivers=[])
+        assert t.matches_receiver("infrared.garage")
+        assert t.matches_receiver("infrared.kitchen")
+        assert t.matches_receiver(None)  # legacy capture
+
+    def test_scoped_matches_only_listed(self):
+        t = _trigger(receivers=["infrared.garage"])
+        assert t.matches_receiver("infrared.garage")
+        assert not t.matches_receiver("infrared.kitchen")
+
+    def test_scoped_never_matches_legacy_none(self):
+        t = _trigger(receivers=["infrared.garage"])
+        assert not t.matches_receiver(None)
+
+    def test_scoped_multi_receiver_union(self):
+        t = _trigger(receivers=["infrared.garage", "infrared.kitchen"])
+        assert t.matches_receiver("infrared.garage")
+        assert t.matches_receiver("infrared.kitchen")
+        assert not t.matches_receiver("infrared.den")
+
+
+# ---------------------------------------------------------------------------
+# Scope firing
+# ---------------------------------------------------------------------------
+
+
+class TestScopeFiring:
+    def test_scoped_fires_only_for_matching_receiver(
+        self, manager, mock_store, clock
+    ):
+        t = _trigger(receivers=["infrared.garage"])
+        mock_store.add_trigger(t)
+
+        # Non-matching receiver -> no fire.
+        assert (
+            manager.on_signal_captured("fp1", "pronto", "c1", None, "infrared.kitchen")
+            == []
+        )
+        clock.advance(1.0)
+        # Matching receiver -> fires.
+        assert t.id in manager.on_signal_captured(
+            "fp1", "pronto", "c1", None, "infrared.garage"
+        )
+
+    def test_scoped_does_not_match_legacy_none(self, manager, mock_store, clock):
+        t = _trigger(receivers=["infrared.garage"])
+        mock_store.add_trigger(t)
+        assert manager.on_signal_captured("fp1", "pronto", "c1", None, None) == []
+
+    def test_unscoped_fires_for_legacy_none(self, manager, mock_store, clock):
+        t = _trigger(receivers=[])
+        mock_store.add_trigger(t)
+        assert t.id in manager.on_signal_captured("fp1", "pronto", "c1", None, None)
+
+    def test_two_scoped_triggers_same_fingerprint_fire_independently(
+        self, manager, mock_store, clock
+    ):
+        garage = _trigger(name="Garage", receivers=["infrared.garage"])
+        kitchen = _trigger(name="Kitchen", receivers=["infrared.kitchen"])
+        mock_store.add_trigger(garage)
+        mock_store.add_trigger(kitchen)
+
+        fired_g = manager.on_signal_captured(
+            "fp1", "pronto", "c1", None, "infrared.garage"
+        )
+        assert fired_g == [garage.id]
+        clock.advance(1.0)
+        fired_k = manager.on_signal_captured(
+            "fp1", "pronto", "c1", None, "infrared.kitchen"
+        )
+        assert fired_k == [kitchen.id]
+
+
+# ---------------------------------------------------------------------------
+# 7.2 Multi-receiver dedup composed with min_hits
+# ---------------------------------------------------------------------------
+
+
+class TestMultiReceiverDedup:
+    def test_same_press_two_receivers_fires_once(self, manager, mock_store, clock):
+        t = _trigger(min_hits=1, receivers=[])
+        mock_store.add_trigger(t)
+
+        # First receiver sees the press -> fire.
+        assert t.id in manager.on_signal_captured(
+            "fp1", "pronto", "c1", None, "infrared.garage"
+        )
+        # Second receiver sees the SAME press 20ms later -> within dedup -> no fire.
+        clock.advance(0.02)
+        assert (
+            manager.on_signal_captured("fp1", "pronto", "c1", None, "infrared.kitchen")
+            == []
+        )
+
+    def test_distinct_presses_beyond_window_each_fire(
+        self, manager, mock_store, clock
+    ):
+        t = _trigger(min_hits=1, receivers=[])
+        mock_store.add_trigger(t)
+        assert t.id in manager.on_signal_captured("fp1", "pronto", "c1", None, "g")
+        clock.advance(0.2)  # > 60ms dedup window
+        assert t.id in manager.on_signal_captured("fp1", "pronto", "c1", None, "g")
+
+    def test_min_hits_two_receivers_of_one_press_count_once(
+        self, manager, mock_store, clock
+    ):
+        t = _trigger(min_hits=2, receivers=[])
+        mock_store.add_trigger(t)
+
+        # Press 1 observed by two receivers within the window -> one hit, no fire.
+        assert manager.on_signal_captured("fp1", "pronto", "c1", None, "g") == []
+        clock.advance(0.02)
+        assert manager.on_signal_captured("fp1", "pronto", "c1", None, "k") == []
+        # Press 2 (a real second press) -> second hit -> fires.
+        clock.advance(1.0)
+        assert t.id in manager.on_signal_captured("fp1", "pronto", "c1", None, "g")
+
+
+# ---------------------------------------------------------------------------
+# 7.4 Fire payload additions + area resolution
+# ---------------------------------------------------------------------------
+
+
+class TestFirePayload:
+    def test_payload_carries_receiver_and_area(
+        self, manager, mock_store, mock_hass, clock
+    ):
+        t = _trigger(min_hits=1, receivers=["infrared.garage"])
+        mock_store.add_trigger(t)
+        with patch.object(
+            manager, "_resolve_receiver_area", return_value=("area_g", "Garage")
+        ):
+            manager.on_signal_captured(
+                "fp1", "pronto", "c1", None, "infrared.garage"
+            )
+        data = mock_hass.bus.async_fire.call_args[0][1]
+        assert data["receiver_entity_id"] == "infrared.garage"
+        assert data["receiver_area_id"] == "area_g"
+        assert data["receiver_area_name"] == "Garage"
+
+    def test_payload_none_for_legacy_capture(
+        self, manager, mock_store, mock_hass, clock
+    ):
+        t = _trigger(min_hits=1, receivers=[])
+        mock_store.add_trigger(t)
+        manager.on_signal_captured("fp1", "pronto", "c1", None, None)
+        data = mock_hass.bus.async_fire.call_args[0][1]
+        assert data["receiver_entity_id"] is None
+        assert data["receiver_area_id"] is None
+        assert data["receiver_area_name"] is None
+
+
+class TestResolveReceiverArea:
+    def test_none_receiver_short_circuits(self, manager):
+        assert manager._resolve_receiver_area(None) == (None, None)
+
+    def test_full_chain_resolves(self, manager, monkeypatch):
+        ent_reg = MagicMock()
+        ent_reg.async_get.return_value = SimpleNamespace(device_id="dev1")
+        dev_reg = MagicMock()
+        dev_reg.async_get.return_value = SimpleNamespace(area_id="area1")
+        area_reg = MagicMock()
+        area_reg.async_get_area.return_value = SimpleNamespace(name="Garage")
+        monkeypatch.setattr(
+            "custom_components.hair.trigger_manager.er.async_get",
+            lambda _h: ent_reg,
+        )
+        monkeypatch.setattr(
+            "custom_components.hair.trigger_manager.dr.async_get",
+            lambda _h: dev_reg,
+        )
+        monkeypatch.setattr(
+            "custom_components.hair.trigger_manager.ar.async_get",
+            lambda _h: area_reg,
+        )
+        assert manager._resolve_receiver_area("infrared.garage") == (
+            "area1",
+            "Garage",
+        )
+
+    def test_deviceless_entity_returns_none(self, manager, monkeypatch):
+        ent_reg = MagicMock()
+        ent_reg.async_get.return_value = SimpleNamespace(device_id=None)
+        monkeypatch.setattr(
+            "custom_components.hair.trigger_manager.er.async_get",
+            lambda _h: ent_reg,
+        )
+        assert manager._resolve_receiver_area("infrared.x") == (None, None)
+
+    def test_area_rename_reflected_on_next_fire(self, manager, monkeypatch):
+        """Area is resolved fresh at fire time -- a rename shows up next fire."""
+        ent_reg = MagicMock()
+        ent_reg.async_get.return_value = SimpleNamespace(device_id="dev1")
+        dev_reg = MagicMock()
+        dev_reg.async_get.return_value = SimpleNamespace(area_id="area1")
+        area_reg = MagicMock()
+        area_reg.async_get_area.return_value = SimpleNamespace(name="Garage")
+        monkeypatch.setattr(
+            "custom_components.hair.trigger_manager.er.async_get", lambda _h: ent_reg
+        )
+        monkeypatch.setattr(
+            "custom_components.hair.trigger_manager.dr.async_get", lambda _h: dev_reg
+        )
+        monkeypatch.setattr(
+            "custom_components.hair.trigger_manager.ar.async_get", lambda _h: area_reg
+        )
+        assert manager._resolve_receiver_area("x")[1] == "Garage"
+        # Rename the area in the registry -- next resolution reflects it.
+        area_reg.async_get_area.return_value = SimpleNamespace(name="Workshop")
+        assert manager._resolve_receiver_area("x")[1] == "Workshop"
+
+
+# ---------------------------------------------------------------------------
+# 7.5 from_dict lazy migration
+# ---------------------------------------------------------------------------
+
+
+class TestFromDictMigration:
+    def test_missing_key_defaults_empty(self):
+        t = IRTrigger.from_dict({"name": "Legacy"})
+        assert t.receiver_entity_ids == []
+
+    def test_null_key_defaults_empty(self):
+        t = IRTrigger.from_dict({"name": "X", "receiver_entity_ids": None})
+        assert t.receiver_entity_ids == []
+
+    def test_reads_present_key(self):
+        t = IRTrigger.from_dict(
+            {"name": "X", "receiver_entity_ids": ["infrared.a", "infrared.b"]}
+        )
+        assert t.receiver_entity_ids == ["infrared.a", "infrared.b"]
+
+    def test_roundtrip_preserves(self):
+        t = _trigger(receivers=["infrared.garage"])
+        restored = IRTrigger.from_dict(t.to_dict())
+        assert restored.receiver_entity_ids == ["infrared.garage"]

--- a/custom_components/hair/tests/test_signal_monitor.py
+++ b/custom_components/hair/tests/test_signal_monitor.py
@@ -156,7 +156,7 @@ class TestDecodeAtCaptureAndForgeGuard:
             _make_event(_nec_event("0x1234"), user_id="attacker")
         )
         assert store.get_all_devices() == []
-        trigger_mgr.on_signal.assert_not_called()
+        trigger_mgr.on_signal_captured.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_esphome_event_without_user_context_processed(self):
@@ -684,8 +684,10 @@ class TestRepeatSuppression:
         assert monitor._check_repeat("fp1")
         assert not monitor._check_repeat("fp1")
 
-        # Simulate time beyond suppression window.
-        monitor._last_seen_times["fp1"] = (
+        # Simulate time beyond suppression window. The suppression map is keyed
+        # per (fingerprint, receiver); a bare-fingerprint capture uses the
+        # "__legacy__" sentinel (v0.5.7 per-receiver suppression).
+        monitor._last_seen_times[("fp1", "__legacy__")] = (
             time.monotonic() - (SIGNAL_REPEAT_SUPPRESS_MS / 1000.0) - 0.01
         )
         assert monitor._check_repeat("fp1")

--- a/custom_components/hair/tests/test_trigger_manager.py
+++ b/custom_components/hair/tests/test_trigger_manager.py
@@ -1,7 +1,6 @@
 """Tests for HAIR TriggerManager."""
 from __future__ import annotations
 
-import time
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -28,6 +27,34 @@ def mock_store(mock_hass):
 @pytest.fixture
 def manager(mock_hass, mock_store):
     return TriggerManager(mock_hass, mock_store)
+
+
+class _FakeClock:
+    """Controllable monotonic clock for TriggerManager's time-based logic.
+
+    The 60ms multi-receiver dedup and the 5s min_hits reset window both read
+    ``time.monotonic``. Real distinct presses are hundreds of ms apart; these
+    tests fire synchronously, so a fake clock lets them advance time
+    deterministically past the dedup window between distinct presses.
+    """
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.t = start
+
+    def monotonic(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    fake = _FakeClock()
+    monkeypatch.setattr(
+        "custom_components.hair.trigger_manager.time", fake
+    )
+    return fake
 
 
 def _make_trigger(
@@ -71,16 +98,22 @@ class TestRewire:
         assert t.code == "0000 0001"  # untouched
         mock_store.async_save.assert_not_awaited()
 
-    async def test_skips_collision_and_reports(self, manager, mock_store):
+    async def test_rewires_all_matching_even_on_collision(
+        self, manager, mock_store
+    ):
+        """v0.5.7: multiple triggers per fingerprint are legal (they may carry
+        different receiver scopes), so a fingerprint collision no longer blocks
+        the rewire. Every trigger bound to the old fingerprint is repointed."""
         mock_store.async_save = AsyncMock()
         bound = _make_trigger(name="A", fingerprint="OLD")
         owner = _make_trigger(name="B", fingerprint="NEW")
         mock_store.add_trigger(bound)
         mock_store.add_trigger(owner)
         result = await manager.rewire("OLD", "NEW", "PRONTO", "0000 DDDD")
-        assert result == {"rewired": [], "skipped": ["A"]}
-        assert bound.signal_fingerprint == "OLD"  # left alone, no duplicate
-        mock_store.async_save.assert_not_awaited()
+        assert result == {"rewired": ["A"], "skipped": []}
+        assert bound.signal_fingerprint == "NEW"  # rewired despite collision
+        assert owner.signal_fingerprint == "NEW"  # untouched (already NEW)
+        mock_store.async_save.assert_awaited_once()
 
     async def test_ignores_unbound_triggers(self, manager, mock_store):
         mock_store.async_save = AsyncMock()
@@ -160,6 +193,16 @@ class TestTriggerStorage:
         assert found is t
         assert mock_store.get_trigger_by_fingerprint("other") is None
 
+    def test_get_triggers_by_fingerprint_returns_all(self, mock_store):
+        """v0.5.7: multiple triggers per fingerprint (different scopes)."""
+        a = _make_trigger(name="Garage", fingerprint="shared_fp")
+        b = _make_trigger(name="Kitchen", fingerprint="shared_fp")
+        mock_store.add_trigger(a)
+        mock_store.add_trigger(b)
+        matches = mock_store.get_triggers_by_fingerprint("shared_fp")
+        assert {t.name for t in matches} == {"Garage", "Kitchen"}
+        assert mock_store.get_triggers_by_fingerprint("none") == []
+
     def test_get_triggers_for_signal_by_code(self, mock_store):
         t = _make_trigger(protocol="pronto", code="ABCD")
         mock_store.add_trigger(t)
@@ -189,71 +232,82 @@ class TestTriggerStorage:
 
 
 class TestTriggerManagerHitCounting:
-    """Test hit counting with min_hits and 5s reset window."""
+    """Test hit counting with min_hits and 5s reset window.
 
-    def test_min_hits_1_fires_immediately(self, manager, mock_store):
+    Distinct presses are spaced past the 60ms multi-receiver dedup window via
+    the ``clock`` fixture, matching real-world press timing.
+    """
+
+    def test_min_hits_1_fires_immediately(self, manager, mock_store, clock):
         t = _make_trigger(min_hits=1)
         mock_store.add_trigger(t)
-        fired = manager.on_signal("fp1", "pronto", "0000 0001")
+        fired = manager.on_signal_captured("fp1", "pronto", "0000 0001")
         assert t.id in fired
 
-    def test_min_hits_3_requires_three_hits(self, manager, mock_store):
+    def test_min_hits_3_requires_three_hits(self, manager, mock_store, clock):
         t = _make_trigger(min_hits=3)
         mock_store.add_trigger(t)
 
         # Hits 1 and 2 should not fire.
-        assert manager.on_signal("fp1", "pronto", "0000 0001") == []
-        assert manager.on_signal("fp1", "pronto", "0000 0001") == []
+        assert manager.on_signal_captured("fp1", "pronto", "0000 0001") == []
+        clock.advance(1.0)
+        assert manager.on_signal_captured("fp1", "pronto", "0000 0001") == []
+        clock.advance(1.0)
 
         # Hit 3 should fire.
-        fired = manager.on_signal("fp1", "pronto", "0000 0001")
+        fired = manager.on_signal_captured("fp1", "pronto", "0000 0001")
         assert t.id in fired
 
-    def test_counter_resets_after_fire(self, manager, mock_store):
+    def test_counter_resets_after_fire(self, manager, mock_store, clock):
         t = _make_trigger(min_hits=2)
         mock_store.add_trigger(t)
 
-        assert manager.on_signal("fp1", "pronto", "0000 0001") == []
-        fired = manager.on_signal("fp1", "pronto", "0000 0001")
+        assert manager.on_signal_captured("fp1", "pronto", "0000 0001") == []
+        clock.advance(1.0)
+        fired = manager.on_signal_captured("fp1", "pronto", "0000 0001")
         assert t.id in fired
+        clock.advance(1.0)
 
         # Counter should have reset; next single hit should not fire.
-        assert manager.on_signal("fp1", "pronto", "0000 0001") == []
+        assert manager.on_signal_captured("fp1", "pronto", "0000 0001") == []
+        clock.advance(1.0)
         # But second hit should fire again.
-        fired = manager.on_signal("fp1", "pronto", "0000 0001")
+        fired = manager.on_signal_captured("fp1", "pronto", "0000 0001")
         assert t.id in fired
 
-    def test_reset_window_clears_counter(self, manager, mock_store):
+    def test_reset_window_clears_counter(self, manager, mock_store, clock):
         t = _make_trigger(min_hits=3)
         mock_store.add_trigger(t)
 
         # Two hits within window.
-        manager.on_signal("fp1", "pronto", "0000 0001")
-        manager.on_signal("fp1", "pronto", "0000 0001")
+        manager.on_signal_captured("fp1", "pronto", "0000 0001")
+        clock.advance(1.0)
+        manager.on_signal_captured("fp1", "pronto", "0000 0001")
 
         # Simulate 6 seconds passing (beyond 5s window).
         state = manager._hit_states[t.id]
-        state.last_hit = time.monotonic() - 6
+        state.last_hit = clock.monotonic() - 6
+        clock.advance(1.0)
 
         # Next hit should reset counter to 1 (not accumulate to 3).
-        fired = manager.on_signal("fp1", "pronto", "0000 0001")
+        fired = manager.on_signal_captured("fp1", "pronto", "0000 0001")
         assert fired == []
         assert state.count == 1
 
-    def test_disabled_trigger_does_not_fire(self, manager, mock_store):
+    def test_disabled_trigger_does_not_fire(self, manager, mock_store, clock):
         t = _make_trigger(min_hits=1, enabled=False)
         mock_store.add_trigger(t)
-        fired = manager.on_signal("fp1", "pronto", "0000 0001")
+        fired = manager.on_signal_captured("fp1", "pronto", "0000 0001")
         assert fired == []
 
-    def test_no_triggers_returns_empty(self, manager):
-        fired = manager.on_signal("fp1", "pronto", "0000 0001")
+    def test_no_triggers_returns_empty(self, manager, clock):
+        fired = manager.on_signal_captured("fp1", "pronto", "0000 0001")
         assert fired == []
 
-    def test_fires_ha_bus_event(self, manager, mock_store, mock_hass):
+    def test_fires_ha_bus_event(self, manager, mock_store, mock_hass, clock):
         t = _make_trigger(min_hits=1)
         mock_store.add_trigger(t)
-        manager.on_signal("fp1", "pronto", "0000 0001", "dev_fp")
+        manager.on_signal_captured("fp1", "pronto", "0000 0001", "dev_fp")
 
         mock_hass.bus.async_fire.assert_called_once()
         call_args = mock_hass.bus.async_fire.call_args
@@ -261,29 +315,33 @@ class TestTriggerManagerHitCounting:
         event_data = call_args[0][1]
         assert event_data["trigger_id"] == t.id
         assert event_data["trigger_name"] == t.name
+        # Location-aware fields present (None for an unscoped/legacy capture).
+        assert event_data["receiver_entity_id"] is None
+        assert event_data["receiver_area_id"] is None
+        assert event_data["receiver_area_name"] is None
 
-    def test_entity_callback_called(self, manager, mock_store):
+    def test_entity_callback_called(self, manager, mock_store, clock):
         t = _make_trigger(min_hits=1)
         mock_store.add_trigger(t)
 
         cb = MagicMock()
         manager.register_entity_callback(cb)
 
-        manager.on_signal("fp1", "pronto", "0000 0001")
+        manager.on_signal_captured("fp1", "pronto", "0000 0001")
         cb.assert_called_once()
         assert cb.call_args[0][0] == t.id
 
-    def test_ws_subscriber_notified(self, manager, mock_store):
+    def test_ws_subscriber_notified(self, manager, mock_store, clock):
         t = _make_trigger(min_hits=1)
         mock_store.add_trigger(t)
 
         cb = MagicMock()
         manager.subscribe(cb)
 
-        manager.on_signal("fp1", "pronto", "0000 0001")
+        manager.on_signal_captured("fp1", "pronto", "0000 0001")
         cb.assert_called_once()
 
-    def test_unsubscribe(self, manager, mock_store):
+    def test_unsubscribe(self, manager, mock_store, clock):
         t = _make_trigger(min_hits=1)
         mock_store.add_trigger(t)
 
@@ -291,5 +349,5 @@ class TestTriggerManagerHitCounting:
         manager.subscribe(cb)
         manager.unsubscribe(cb)
 
-        manager.on_signal("fp1", "pronto", "0000 0001")
+        manager.on_signal_captured("fp1", "pronto", "0000 0001")
         cb.assert_not_called()

--- a/custom_components/hair/trigger_manager.py
+++ b/custom_components/hair/trigger_manager.py
@@ -2,6 +2,14 @@
 
 Tracks per-trigger hit counts and fires HA event entities when the
 configured ``min_hits`` threshold is reached within the reset window.
+
+v0.5.7 (location-aware triggers): each capture is threaded with the
+receiver that observed it. Triggers gain an optional receiver scope
+(``matches_receiver``); the fire payload carries the receiver entity plus
+its resolved area. A single physical press captured by several receivers
+within ``MULTI_RECEIVER_DEDUP_WINDOW_S`` counts once per (trigger,
+fingerprint) so multi-receiver setups do not double-count toward
+``min_hits`` or double-fire.
 """
 from __future__ import annotations
 
@@ -9,19 +17,43 @@ import contextlib
 import logging
 import time
 from collections.abc import Callable
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import (
+    area_registry as ar,
+)
+from homeassistant.helpers import (
+    device_registry as dr,
+)
+from homeassistant.helpers import (
+    entity_registry as er,
+)
 
 from .const import (
     EVENT_TRIGGER_FIRED,
+    MULTI_RECEIVER_DEDUP_WINDOW_S,
     TRIGGER_HIT_RESET_WINDOW_S,
 )
 from .models import IRTrigger
 from .storage import HAIRStore
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class _RecentObservation:
+    """Observations of a fingerprint within the dedup window, per receiver.
+
+    Best-effort tracking used only for the informational log line when a
+    scoped trigger fires while other receivers also observed the press.
+    """
+
+    first_receiver: str | None = None
+    observed_at: float = 0.0
+    other_observers: list[str] = field(default_factory=list)
 
 
 class _HitState:
@@ -49,8 +81,9 @@ class _HitState:
 class TriggerManager:
     """Manages trigger matching, hit counting, and event firing.
 
-    Call ``on_signal()`` from the signal monitor for every parsed IR
-    reception. The manager checks all enabled triggers, tracks hits,
+    Call ``on_signal_captured()`` from the signal monitor for every parsed
+    IR reception. The manager checks all enabled triggers, applies receiver
+    scope, tracks hits (deduplicated across receivers of the same press),
     and fires the corresponding event entity when thresholds are met.
     """
 
@@ -59,6 +92,18 @@ class TriggerManager:
         self._store = store
         self._hit_states: dict[str, _HitState] = {}
         self._subscribers: list[Callable[[dict[str, Any]], None]] = []
+
+        # Multi-receiver dedup (v0.5.7). A single physical press captured by
+        # several receivers within MULTI_RECEIVER_DEDUP_WINDOW_S counts once
+        # per (trigger_id, fingerprint): the second and later observations are
+        # gated out before the hit increment, so min_hits still counts distinct
+        # presses and a matching trigger fires at most once per press.
+        self._recent_fires: dict[tuple[str, str], float] = {}
+        # Best-effort per-fingerprint observation tracking for the diagnostic
+        # log line only.
+        self._pending_obs: dict[str, _RecentObservation] = {}
+        # Prune counter: _maybe_prune_recent_fires runs every 100 calls.
+        self._call_counter: int = 0
 
         # Callback for event entity platform to register its trigger handler.
         self._entity_fire_callback: Callable[[str, dict[str, Any]], None] | None = None
@@ -73,27 +118,66 @@ class TriggerManager:
         """
         self._entity_fire_callback = callback
 
-    def on_signal(
+    def on_signal_captured(
         self,
         fingerprint: str,
         protocol: str | None,
         code: str | None,
         source_device_fp: str | None = None,
+        receiver_entity_id: str | None = None,
     ) -> list[str]:
         """Process an incoming signal against all enabled triggers.
 
-        Returns list of trigger IDs that fired (for caller awareness).
+        Threads the capturing ``receiver_entity_id`` (or ``None`` for legacy
+        ESPHome-bridge captures). Applies each trigger's receiver scope, then
+        the existing ``min_hits`` accumulation, with a 60ms cross-receiver
+        dedup so one physical press counts once per (trigger, fingerprint).
+
+        Returns the list of trigger IDs that fired (for caller awareness).
         """
-        triggers = self._store.get_triggers_for_signal(
-            protocol, code, fingerprint
-        )
+        now = time.monotonic()
+
+        self._call_counter += 1
+        if self._call_counter % 100 == 0:
+            self._maybe_prune_recent_fires()
+
+        # Track observations of this fingerprint for the diagnostic log line.
+        obs = self._pending_obs.get(fingerprint)
+        if obs is None or (now - obs.observed_at) > MULTI_RECEIVER_DEDUP_WINDOW_S:
+            obs = _RecentObservation(
+                first_receiver=receiver_entity_id, observed_at=now
+            )
+            self._pending_obs[fingerprint] = obs
+        elif (
+            receiver_entity_id
+            and receiver_entity_id != obs.first_receiver
+            and receiver_entity_id not in obs.other_observers
+        ):
+            obs.other_observers.append(receiver_entity_id)
+
+        triggers = self._store.get_triggers_for_signal(protocol, code, fingerprint)
         if not triggers:
             return []
 
-        now = time.monotonic()
         fired_ids: list[str] = []
+        # Resolve the receiver's area lazily -- only if a trigger actually
+        # fires -- so the registry chain isn't walked on every capture.
+        area_resolved = False
+        area_id: str | None = None
+        area_name: str | None = None
 
         for trigger in triggers:
+            if not trigger.matches_receiver(receiver_entity_id):
+                continue
+
+            # Cross-receiver dedup: within the window, a repeat capture of the
+            # same press for this (trigger, fingerprint) is skipped entirely --
+            # no hit increment, no fire -- so min_hits counts distinct presses.
+            key = (trigger.id, fingerprint)
+            if now - self._recent_fires.get(key, 0.0) < MULTI_RECEIVER_DEDUP_WINDOW_S:
+                continue
+            self._recent_fires[key] = now
+
             state = self._hit_states.get(trigger.id)
             if state is None:
                 state = _HitState()
@@ -102,17 +186,82 @@ class TriggerManager:
             count = state.increment(now)
 
             if count >= trigger.min_hits:
-                self._fire_trigger(trigger, count, source_device_fp)
+                if not area_resolved:
+                    area_id, area_name = self._resolve_receiver_area(
+                        receiver_entity_id
+                    )
+                    area_resolved = True
+                self._fire_trigger(
+                    trigger,
+                    count,
+                    source_device_fp,
+                    receiver_entity_id,
+                    area_id,
+                    area_name,
+                )
                 state.reset()
                 fired_ids.append(trigger.id)
 
+                # Diagnostic: a scoped trigger fired while other receivers also
+                # observed the same press within the dedup window.
+                if trigger.receiver_entity_ids and obs.other_observers:
+                    _LOGGER.info(
+                        "Trigger '%s' fired from %s; signal also observed by %s",
+                        trigger.name,
+                        receiver_entity_id or "<unknown>",
+                        ", ".join(obs.other_observers),
+                    )
+
         return fired_ids
+
+    def _maybe_prune_recent_fires(self) -> None:
+        """Evict stale ``_recent_fires`` entries (older than 5x the window).
+
+        Called every 100 captures from ``on_signal_captured``. Bounded and
+        cheap; keeps the dedup map from growing with the number of distinct
+        (trigger, fingerprint) pairs seen over the process lifetime.
+        """
+        now = time.monotonic()
+        cutoff = 5 * MULTI_RECEIVER_DEDUP_WINDOW_S
+        self._recent_fires = {
+            k: v for k, v in self._recent_fires.items() if now - v < cutoff
+        }
+
+    def _resolve_receiver_area(
+        self, receiver_entity_id: str | None
+    ) -> tuple[str | None, str | None]:
+        """Resolve a receiver entity to its ``(area_id, area_name)``.
+
+        Walks the entity -> device -> area registry chain at fire time (not
+        persisted on the trigger) so area renames and device moves are
+        reflected without any migration. Returns ``(None, None)`` when the
+        receiver is unknown, deviceless, or unassigned to an area. Registry
+        accessors are synchronous.
+        """
+        if not receiver_entity_id:
+            return None, None
+        ent_reg = er.async_get(self._hass)
+        dev_reg = dr.async_get(self._hass)
+        area_reg = ar.async_get(self._hass)
+
+        entity_entry = ent_reg.async_get(receiver_entity_id)
+        if entity_entry is None or entity_entry.device_id is None:
+            return None, None
+        device_entry = dev_reg.async_get(entity_entry.device_id)
+        if device_entry is None or device_entry.area_id is None:
+            return None, None
+        area_id = device_entry.area_id
+        area = area_reg.async_get_area(area_id)
+        return area_id, (area.name if area else None)
 
     def _fire_trigger(
         self,
         trigger: IRTrigger,
         hit_count: int,
         source_device_fp: str | None,
+        receiver_entity_id: str | None = None,
+        receiver_area_id: str | None = None,
+        receiver_area_name: str | None = None,
     ) -> None:
         """Fire the HA event and notify subscribers."""
         now_iso = datetime.now(UTC).isoformat()
@@ -124,6 +273,11 @@ class TriggerManager:
             "code": trigger.code,
             "source_remote": source_device_fp,
             "timestamp": now_iso,
+            # Location-aware fields (v0.5.7). None for legacy captures or a
+            # receiver whose device has no HA area assignment.
+            "receiver_entity_id": receiver_entity_id,
+            "receiver_area_id": receiver_area_id,
+            "receiver_area_name": receiver_area_name,
         }
 
         # Fire the event entity.
@@ -160,33 +314,28 @@ class TriggerManager:
     ) -> dict[str, list[str]]:
         """Repoint triggers from an old signal fingerprint to a new one.
 
-        Used when an edit changes a signal/command's S/L fingerprint: any
+        Used when an edit changes a signal/command's S/L fingerprint: every
         trigger bound to the old fingerprint is updated to the new
         ``(signal_fingerprint, protocol, code)`` together so it keeps firing
         on the edited signal. A no-op when the fingerprint is unchanged (snap
         and byte-only edits preserve the S/L fingerprint).
 
-        Skip-and-report on collision: if a *different* trigger already owns
-        the new fingerprint (the one-trigger-per-fingerprint invariant), it is
-        left alone and named in ``skipped`` instead of creating a duplicate.
-        All matching triggers are mutated in memory, then a single
-        ``async_save`` persists -- never a per-trigger save.
+        v0.5.7: multiple triggers per fingerprint are legal (they may carry
+        different receiver scopes), so there is no collision rejection -- all
+        matching triggers are rewired. All matching triggers are mutated in
+        memory, then a single ``async_save`` persists.
 
-        Returns ``{"rewired": [names], "skipped": [names]}`` so the caller can
-        build a note that names the affected trigger(s).
+        Returns ``{"rewired": [names], "skipped": []}``; ``skipped`` is kept in
+        the shape for callers but is always empty now that collisions are legal.
         """
         rewired: list[str] = []
         skipped: list[str] = []
         if not new_fingerprint or old_fingerprint == new_fingerprint:
             return {"rewired": rewired, "skipped": skipped}
 
-        existing = self._store.get_trigger_by_fingerprint(new_fingerprint)
         changed = False
         for trigger in self._store.get_all_triggers():
             if trigger.signal_fingerprint != old_fingerprint:
-                continue
-            if existing is not None and existing.id != trigger.id:
-                skipped.append(trigger.name)
                 continue
             trigger.signal_fingerprint = new_fingerprint
             trigger.protocol = new_protocol

--- a/custom_components/hair/websocket_api.py
+++ b/custom_components/hair/websocket_api.py
@@ -22,6 +22,7 @@ from .command_templates import get_action_options, get_templates_for_device_type
 from .const import (
     DEFAULT_CAPTURE_TIMEOUT,
     DOMAIN,
+    EVENT_SIGNAL_UPDATED,
     MAX_DITTO_COUNT,
     MAX_SEND_COUNT,
     WS_PREFIX,
@@ -353,12 +354,27 @@ async def ws_delete_command(
         connection.send_error(msg["id"], "not_configured", "HAIR not configured")
         return
     manager: DeviceManager = data["device_manager"]
+    # Capture the removed command's signal fingerprint before deletion so we
+    # can notify other browser tabs that this signal's assignment set changed
+    # (v0.5.7 hair_signal_updated: refreshes the green Assign badge live).
+    from .event_parser import EventParser
+
+    sig_fp: str | None = None
+    device = manager.get_device(msg["device_id"])
+    if device is not None:
+        cmd = device.get_command(msg["command_id"])
+        if cmd is not None:
+            sig_fp = EventParser.signal_fingerprint(
+                cmd.protocol, cmd.code, cmd.raw_timings
+            )
     removed = await manager.async_remove_command(
         msg["device_id"], msg["command_id"]
     )
     if not removed:
         connection.send_error(msg["id"], "not_found", "Command not found")
         return
+    if sig_fp:
+        hass.bus.async_fire(EVENT_SIGNAL_UPDATED, {"signal_fingerprint": sig_fp})
     connection.send_result(msg["id"], {"removed": True})
 
 
@@ -692,6 +708,12 @@ async def ws_save_captured_command(
     command.decoded_fingerprint = d_fp
     command.byte_hash = EventParser.pronto_byte_hash(result.code)
     await manager.async_add_command(device.id, command)
+    # Notify other tabs this signal now has an assignment (v0.5.7).
+    save_fp = EventParser.signal_fingerprint(
+        command.protocol, command.code, command.raw_timings
+    )
+    if save_fp:
+        hass.bus.async_fire(EVENT_SIGNAL_UPDATED, {"signal_fingerprint": save_fp})
     connection.send_result(msg["id"], command.to_dict())
 
 
@@ -857,6 +879,45 @@ async def ws_codes_import_remote(
 # --- Signal Monitor (Unknown Devices) ---
 
 
+def _assignment_index(hair_devices: list[IRDevice]) -> dict[str, list[str]]:
+    """Map each signal fingerprint to the list of assigned HAIR commands.
+
+    A catalog signal is "assigned" when a HAIR device command re-encodes to the
+    same S/L fingerprint. ``IRCommand`` carries no stored fingerprint, so it is
+    computed here exactly as ``storage._rebuild_command_index`` does. Values are
+    ``"<device name>.<command name>"`` strings for the frontend tooltip. Keyed on
+    the S/L fingerprint only (dots plan Section 4.7); the byte-hash tiebreaker is
+    not applied here, so two distinct codes sharing an S/L fingerprint count
+    together -- acceptable for a soft row indicator.
+    """
+    from .event_parser import EventParser
+
+    index: dict[str, list[str]] = {}
+    for device in hair_devices:
+        for command in device.commands:
+            fp = EventParser.signal_fingerprint(
+                command.protocol, command.code, command.raw_timings
+            )
+            if not fp:
+                continue
+            index.setdefault(fp, []).append(f"{device.name}.{command.name}")
+    return index
+
+
+def _augment_signals_with_assignments(
+    device_dict: dict[str, Any], assignment_index: dict[str, list[str]]
+) -> None:
+    """Annotate each serialized signal with its assignment count + list.
+
+    Mutates ``device_dict['signals']`` in place, adding ``assignment_count`` and
+    ``assigned_to`` (dots polish, v0.5.7). Cheap; runs on the per-device fetch.
+    """
+    for sig in device_dict.get("signals", []):
+        assigned = assignment_index.get(sig.get("fingerprint"), [])
+        sig["assignment_count"] = len(assigned)
+        sig["assigned_to"] = assigned
+
+
 def _unknown_device_summary(device) -> dict[str, Any]:
     """Build a summary dict for an unknown device."""
     return {
@@ -924,7 +985,16 @@ async def ws_get_unknown_device(
     if device is None:
         connection.send_error(msg["id"], "not_found", "Unknown device not found")
         return
-    connection.send_result(msg["id"], device.to_dict())
+    result = device.to_dict()
+    # Annotate each signal with its HAIR-command assignment count for the green
+    # Assign dot (dots polish, v0.5.7). Non-critical enrichment: if the HAIR
+    # store is not wired, the signals simply carry no assignment info.
+    store = data.get("store")
+    if store is not None:
+        _augment_signals_with_assignments(
+            result, _assignment_index(store.get_all_devices())
+        )
+    connection.send_result(msg["id"], result)
 
 
 @websocket_api.require_admin
@@ -1862,6 +1932,7 @@ async def ws_get_triggers(
     vol.Optional("min_hits", default=1): int,
     vol.Optional("source_device_id"): vol.Any(str, None),
     vol.Optional("source_command_id"): vol.Any(str, None),
+    vol.Optional("receiver_entity_ids"): [str],
 })
 @websocket_api.async_response
 async def ws_create_trigger(
@@ -1910,15 +1981,11 @@ async def ws_create_trigger(
         )
         return
 
-    # Reject duplicate fingerprint.
-    existing = store.get_trigger_by_fingerprint(sig_fp)
-    if existing is not None:
-        connection.send_error(
-            msg["id"], "duplicate",
-            f"A trigger already exists for this signal: {existing.name}"
-        )
-        return
-
+    # v0.5.7: multiple triggers per fingerprint are legal -- users create
+    # per-receiver-scoped triggers on the same signal (different rooms). The
+    # frontend routes through the trigger popover's explicit "+ new trigger"
+    # action, so a second trigger on a known fingerprint is intentional. No
+    # duplicate rejection.
     trigger = IRTrigger(
         name=msg["name"],
         signal_fingerprint=sig_fp,
@@ -1927,6 +1994,7 @@ async def ws_create_trigger(
         min_hits=msg.get("min_hits", 1),
         source_device_id=msg.get("source_device_id"),
         source_command_id=msg.get("source_command_id"),
+        receiver_entity_ids=list(msg.get("receiver_entity_ids") or []),
     )
     store.add_trigger(trigger)
     await store.async_save()
@@ -1947,6 +2015,7 @@ async def ws_create_trigger(
     vol.Optional("name"): str,
     vol.Optional("min_hits"): int,
     vol.Optional("enabled"): bool,
+    vol.Optional("receiver_entity_ids"): [str],
 })
 @websocket_api.async_response
 async def ws_update_trigger(
@@ -1973,6 +2042,9 @@ async def ws_update_trigger(
         trigger.min_hits = max(1, msg["min_hits"])
     if "enabled" in msg:
         trigger.enabled = msg["enabled"]
+    if "receiver_entity_ids" in msg:
+        # Receiver scope (v0.5.7). Empty list = any receiver (backward compat).
+        trigger.receiver_entity_ids = list(msg["receiver_entity_ids"] or [])
     trigger.updated_at = datetime.now(UTC).isoformat()
 
     store.update_trigger(trigger)

--- a/llms.txt
+++ b/llms.txt
@@ -78,6 +78,16 @@ Key components:
   configurable min-hits threshold prevents accidental triggers from a single
   misfire. To the best of the project's knowledge, HAIR is the only HA integration
   turning received IR into automation triggers as of HA 2026.6.
+  Location-aware (v0.5.7): the fire payload also carries receiver_entity_id plus
+  receiver_area_id and receiver_area_name, resolved from the entity/device/area
+  registry chain at fire time (so area renames and device moves need no migration).
+  A trigger can carry a receiver_entity_ids scope list (empty = any receiver,
+  backward compatible); scoped triggers fire only when a listed receiver observes
+  the signal, and legacy ESPHome-bridge captures (receiver_entity_id=None) match
+  only unscoped triggers. Multiple triggers per signal fingerprint are legal (one
+  per room). A single press observed by several receivers within a 60ms window
+  fires each matching trigger once (per-(trigger, fingerprint) dedup) and counts as
+  one hit toward min_hits.
 
 Signal fingerprinting details:
 - Uses S/L (short/long) pulse-duration classification. Each pulse is classified as


### PR DESCRIPTION
## v0.5.7 -- Location Awareness + Dots

Two coordinated changes ship together in this release: location-aware triggers, and a unified corner-dot pattern across signal-row buttons.

Location-aware triggers means every trigger fire now tells your automation where the signal came from. The event data gains `receiver_entity_id`, `receiver_area_id`, and `receiver_area_name`, resolved live from Home Assistant's area registry. If you use the same physical remote in multiple rooms, you can route your automations by room name without any Jinja templating. Trigger definitions gain an optional Receiver scope: leave it on "Any receiver" (the default, unchanged behavior) or pick one or more receivers so the trigger fires only when one of them observes the signal. Multiple triggers on the same signal are now supported, so you can create one trigger per room, each with its own name and scope. A single physical press captured by several receivers fires each matching trigger once.

The dots polish pass unifies the "this signal has state worth knowing about" indicators on a single dot-in-corner-of-button pattern. The Assign button shows a green dot when a signal is assigned; a small count appears inside the dot when it maps to more than one device command. The Trigger button shows a yellow dot with the same treatment. The old solid-fill "trigger on" styling is gone. Clicking the Trigger button on a signal that already has triggers opens a small picker so you can edit an existing trigger or add another. Assign and Trigger indicators refresh live across browser tabs.

### Added
- Location-aware triggers with per-receiver scope. Reported by @blalor, with a workaround and independent endorsement from @Didgeridrew in the community forum thread (GH #34).
- Multiple triggers per signal fingerprint (each with its own receiver scope).
- Corner-dot indicators for Assign and Trigger across signal rows and device command rows.
- Trigger picker popover for signals that already have one or more triggers.
- Live refresh of Assign and Trigger indicators across browser tabs when a signal's assignments or triggers change.

### Changed
- The `.trigger-on` solid-fill styling on the Trigger button is replaced by the yellow corner-dot pattern.
- Signal Monitor tracks ditto attribution per-receiver, so simultaneous captures from different receivers no longer share state.

### Notes
- Existing triggers migrate silently: their receiver scope is empty by default, which matches today's "fires on any receiver" behavior. No configuration changes required.
- The new receiver, area, and area name fields on the event payload are additive; automations that ignore them keep working.
- Scoped triggers require a native `InfraredReceiverEntity` on the receiving side (HA 2026.6+ with ESPHome using the modern platform). Legacy ESPHome-bridge captures continue to fire unscoped triggers.

Closes #34. Thanks to @blalor and @Didgeridrew.