### PR TITLE
v0.6.0 (Shave and a Haircut): protocol decode registry + seven local decoders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to HAIR will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.0] - Unreleased -- Shave and a Haircut
+## [0.6.0] - 2026-07-17 -- Shave and a Haircut
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to HAIR will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - Unreleased -- Shave and a Haircut
+
+### Added
+
+- HAIR now decodes seven more protocols: Sony SIRC (12, 15, and 20-bit), Symphony (the ceiling-fan family), Philips RC-5 (including the RC5X extension), Samsung32, Sharp, Kaseikyo (the Panasonic family), and Marantz Extended. Until now only NEC signals got a decoded identity; every other remote leaned on the byte-level tiebreaker, which is exactly where the remaining rough edges lived. A decoded signal gets the strongest identity HAIR has: stable per-button matching that survives receiver jitter, clean re-encoded transmit instead of replaying captured timings, and the protocol name on the Sniffer row.
+- The decoders live inside HAIR and are written in the shared infrared-protocols library's own style, because that library is their long-term home. Each one is headed upstream as a pull request; whenever a Home Assistant release bundles a library version that can decode one of these protocols itself, HAIR automatically defers to the library for that protocol, no update required. Until then the built-in decoder covers the gap. The diagnostics download lists which source is serving each protocol.
+- RC-5 and Marantz remotes alternate a toggle bit between key presses so the receiver can tell "held" from "pressed twice". HAIR now tracks that state per command and flips it on every send, the way the original remotes do.
+
+### Fixed
+
+- One button is one row again, even on remotes without a decodable protocol in yesterday's HAIR. Day-one v0.5.8 reports showed the strict byte-level identity could split repeat presses of a single button into many Sniffer rows: the press length varies, so captures contain different numbers of repeated frames, and on some receivers the pulse widths wobble across a quantization edge between presses. The new decoders read the actual bits instead: a capture is split into its frames, each frame is decoded, and the majority decides, so a two-frame capture, a three-frame capture, and a jittery capture of the same button all produce the same identity. Reported by @loic.gouraud (twelve rows for twelve presses of one button) and @blalor (a duplicate row on an NEC remote) within a day of v0.5.8 -- thank you both for the fast, precise reports.
+- Sniffer catalogs that already fragmented heal at startup: the existing load-time merge now runs with decoded identity available, so the split rows collapse into the oldest row, keeping its alias and summing its hit counts.
+- The ceiling-fan class from GH #38 decodes now. Symphony remotes send a preamble frame or two and then repeat the button code for as long as the button is held, so every capture used to look different. The majority vote discards the preambles and the truncated tail, and all captures of a button collapse to one row. Thanks @mvdwetering for the ESPHome log that identified the protocol and the preamble detail; your captures are in the test suite.
+- Sony remotes transmit reliably from the catalog now: decoded Sony signals re-encode canonical timings on Test and device TX, the same first-class treatment NEC has had since v0.4.0.
+
+### Changed
+
+- Decode-capable protocols no longer market themselves as "NEC today" in the docs. The registry reports itself in diagnostics, including whether each protocol is served by the bundled library or by HAIR's built-in decoder, and whether its transmit path re-encodes or replays raw.
+- The infrared-protocols test dependency cap moved from <7.0 to <8.0; upstream's 7.x line keeps the same command contract (verified against source).
+
 ## [0.5.8] - 2026-07-14 -- Fine-Tooth Comb
 
 ### Fixed

--- a/custom_components/hair/code_library.py
+++ b/custom_components/hair/code_library.py
@@ -22,7 +22,6 @@ import os
 import re
 from typing import Any
 
-from .const import DECODED_FINGERPRINT_FORMAT
 from .ir_command import raw_to_pronto
 
 _LOGGER = logging.getLogger(__name__)
@@ -192,6 +191,20 @@ def _decoded_fields(command) -> dict[str, Any]:
     (``NECCommand`` -> ``NEC``). Address and command must both be ints to
     form the fingerprint; otherwise the entry stays Pronto-only.
     """
+    from .protocol_decode import format_fingerprint, identity_from_command
+
+    identity = identity_from_command(command)
+    if identity is not None:
+        return {
+            "decoded_protocol": identity.protocol,
+            "decoded_address": identity.address,
+            "decoded_command": identity.command,
+            "decoded_fingerprint": identity.fingerprint,
+            "decoded_extras": dict(identity.extras) if identity.extras else None,
+        }
+    # Fallback for classes outside the registry: the pre-v0.6.0 generic
+    # derivation, so a future library class with plain address/command
+    # fields still yields a usable identity.
     protocol = type(command).__name__.removesuffix("Command") or None
     address = getattr(command, "address", None)
     cmd = getattr(command, "command", None)
@@ -200,15 +213,17 @@ def _decoded_fields(command) -> dict[str, Any]:
             "decoded_protocol": protocol,
             "decoded_address": int(address),
             "decoded_command": int(cmd),
-            "decoded_fingerprint": DECODED_FINGERPRINT_FORMAT.format(
-                protocol=protocol, address=int(address), command=int(cmd)
+            "decoded_fingerprint": format_fingerprint(
+                protocol, int(address), int(cmd)
             ),
+            "decoded_extras": None,
         }
     return {
         "decoded_protocol": None,
         "decoded_address": None,
         "decoded_command": None,
         "decoded_fingerprint": None,
+        "decoded_extras": None,
     }
 
 

--- a/custom_components/hair/decoders/__init__.py
+++ b/custom_components/hair/decoders/__init__.py
@@ -1,0 +1,112 @@
+"""Local IR protocol decoders (the shave-and-a-haircut package).
+
+HAIR's local-first decoder strategy (multi-protocol decoder plan, Section
+6): each module in this package defines a Command class shaped exactly like
+an ``infrared_protocols`` module -- same base class, same keyword-only
+constructor, same ``get_raw_timings`` / ``from_raw_timings`` contract -- so
+the module can be donated upstream as a near-file-copy. The registry in
+``protocol_decode`` prefers the upstream class whenever the bundled library
+ships a decoder for the protocol (feature-detected via
+``from_raw_timings``); these local classes are the polyfill until then.
+
+Rules for this package (do not break them):
+
+- No code derived from GPL/LGPL implementations (IRremoteESP8266, ESPHome
+  C++, LIRC). Timing constants are protocol facts and are fine; code
+  structure is not. Everything here is written fresh from the protocol
+  specs and validated against captures. This keeps the upstream donation
+  (Apache-2.0) unencumbered.
+- Encoders must be behavior-identical to the upstream library's encoder
+  when upstream ships one (asserted by round-trip tests), so swapping the
+  registry to the upstream class can never change what is transmitted.
+- Decoders follow the upstream ``NECCommand.from_raw_timings`` conventions:
+  classmethod, ``list[int]`` signed microsecond timings in (positive=mark,
+  negative=space) form, return ``Self | None``, never raise on malformed
+  input by construction (bounds-checked indexing only).
+
+Shared helpers below implement the two ideas every decoder needs: tolerant
+timing classification and frame splitting. Real captures arrive with
+receiver jitter (marks stretched by AGC, spaces shortened) and often
+contain several complete frames per capture (a held button, or a remote
+that always re-sends). Decoders therefore split the capture into frames,
+decode each frame independently, and let the majority vote decide -- a
+trailing partial frame or a vendor preamble frame cannot poison the
+result.
+"""
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Callable, Sequence
+
+# Default fractional tolerance for matching a timing against its nominal
+# value. Matches the convention the upstream NEC decoder established (0.4).
+TOLERANCE = 0.4
+
+
+def is_close(actual: int, expected: int, tolerance: float = TOLERANCE) -> bool:
+    """Return True if ``actual`` is within ``tolerance`` of ``expected``.
+
+    Both values are treated as magnitudes; callers negate spaces before
+    passing them in, mirroring the upstream NEC decoder's convention.
+    """
+    if expected <= 0:
+        return False
+    margin = expected * tolerance
+    return expected - margin <= actual <= expected + margin
+
+
+def split_frames(timings: Sequence[int], min_gap_us: int) -> list[list[int]]:
+    """Split signed timings into frames at spaces of at least ``min_gap_us``.
+
+    The gap spaces themselves are dropped; each returned frame is a signed
+    timing list that starts on a mark. Frames that end the capture without
+    a trailing gap are returned as-is (captures routinely truncate the
+    final trailer space). Empty input returns no frames.
+    """
+    frames: list[list[int]] = []
+    current: list[int] = []
+    for value in timings:
+        if value < 0 and -value >= min_gap_us:
+            if current:
+                frames.append(current)
+                current = []
+            continue
+        if not current and value < 0:
+            # A frame never starts on a space; drop leading idle.
+            continue
+        current.append(value)
+    if current:
+        frames.append(current)
+    return frames
+
+
+def majority[T](values: Sequence[T]) -> tuple[T, int] | None:
+    """Return the most common value and its count, or None if empty.
+
+    Ties resolve to the value seen first, which for IR captures means the
+    earliest decoded frame of the tied set -- deterministic and stable.
+    """
+    if not values:
+        return None
+    counted = Counter(values).most_common()
+    return counted[0]
+
+
+def decode_frames_majority[T](
+    frames: Sequence[Sequence[int]],
+    decode_frame: Callable[[Sequence[int]], T | None],
+    *,
+    min_votes: int = 1,
+) -> tuple[T, int] | None:
+    """Decode every frame, majority-vote the results.
+
+    Returns ``(winner, vote_count)`` or None when no frame decodes or the
+    winner has fewer than ``min_votes`` votes. ``min_votes`` exists for
+    checksum-free protocols (Symphony) where a single decoded frame is not
+    enough evidence to accept the capture.
+    """
+    decoded = [d for d in (decode_frame(f) for f in frames) if d is not None]
+    top = majority(decoded)
+    if top is None or top[1] < min_votes:
+        return None
+    return top

--- a/custom_components/hair/decoders/_base.py
+++ b/custom_components/hair/decoders/_base.py
@@ -1,0 +1,31 @@
+"""Base-class import shim for the local decoder package.
+
+Every decoder module imports ``Command`` from here so the package works
+both with the real ``infrared_protocols`` library (normal runtime, Python
+3.13+) and without it (the Python 3.12 CI leg, where HAIR's test stubs
+stand in). When a module is donated upstream, this import collapses to
+``from . import Command`` -- the only line that changes.
+"""
+from __future__ import annotations
+
+try:
+    from infrared_protocols.commands import Command
+except ImportError:  # test environment without infrared_protocols
+    import abc
+
+    class Command(abc.ABC):  # type: ignore[no-redef]
+        """Minimal stand-in matching infrared_protocols.commands.Command."""
+
+        repeat_count: int
+        modulation: int
+
+        def __init__(self, *, modulation: int, repeat_count: int = 0) -> None:
+            self.modulation = modulation
+            self.repeat_count = repeat_count
+
+        @abc.abstractmethod
+        def get_raw_timings(self) -> list[int]:
+            """Get raw timings as signed microsecond integers."""
+
+
+__all__ = ["Command"]

--- a/custom_components/hair/decoders/kaseikyo.py
+++ b/custom_components/hair/decoders/kaseikyo.py
@@ -164,9 +164,22 @@ class KaseikyoCommand(Command):
         ):
             return None
 
+        # The frame's LAST mark is the end pulse; everything between the
+        # leader and it is bit pairs. Anchoring on the last mark (rather
+        # than greedily consuming pairs) keeps a trailing sub-gap space
+        # after the end pulse from being misread as a final bit's space.
+        end_index = None
+        for j in range(len(frame) - 1, 1, -1):
+            if frame[j] > 0:
+                end_index = j
+                break
+        if end_index is None or (end_index - 2) % 2 != 0:
+            return None
+        if not _MARK_MIN_US <= frame[end_index] <= _MARK_MAX_US:
+            return None
+
         bits: list[int] = []
-        i = 2
-        while i + 1 < len(frame):
+        for i in range(2, end_index, 2):
             mark = frame[i]
             space = -frame[i + 1]
             if not _MARK_MIN_US <= mark <= _MARK_MAX_US:
@@ -174,15 +187,9 @@ class KaseikyoCommand(Command):
             if not _SPACE_MIN_US <= space <= _SPACE_MAX_US:
                 return None
             bits.append(1 if space > _SPACE_MIDPOINT_US else 0)
-            i += 2
             if len(bits) > 8 * _MAX_PAYLOAD_BYTES:
                 return None
 
-        # End pulse, then nothing but (possibly) a truncated space.
-        if i >= len(frame) or not _MARK_MIN_US <= frame[i] <= _MARK_MAX_US:
-            return None
-        if any(value > 0 for value in frame[i + 1 :]):
-            return None
         if len(bits) % 8 != 0 or len(bits) < 8 * _MIN_PAYLOAD_BYTES:
             return None
 

--- a/custom_components/hair/decoders/kaseikyo.py
+++ b/custom_components/hair/decoders/kaseikyo.py
@@ -1,0 +1,204 @@
+"""Kaseikyo format IR command with decode support.
+
+Encode side mirrors ``infrared_protocols.commands.kaseikyo.KaseikyoCommand``
+byte-for-byte (asserted by round-trip tests). Decode side is new
+(upstream is encode-only as of 7.5.0).
+
+Kaseikyo is the 16-bit-vendor family (Panasonic, Denon, JVC-48, Sharp-48
+and friends). Timing in base units T = 1e6 * 16 / 38000 ~= 421us:
+
+- Leader: 8T mark, 4T space. Bit: 1T mark, then 1T space (0) or 3T
+  space (1). End pulse: 1T mark. Repeat code: 8T mark, 8T space, 1T end
+  pulse, NEC-style.
+- Payload LSB first per byte: vendor address (16 bits), then a byte
+  whose low nibble is the vendor parity (address_lo ^ address_hi,
+  nibble-folded) and whose high nibble is data, then the remaining data
+  bytes. Standard frames are 48 bits (6 bytes) total; the decoder
+  accepts any whole-byte payload of 4+ bytes and validates the parity
+  nibble, which is the family's integrity check.
+
+The decoded ``data`` reconstructs the constructor's argument: byte 0
+carries the genuine high nibble with a zero low nibble (the wire's low
+nibble is the parity, which the encoder re-derives), followed by the
+remaining payload bytes verbatim -- so encode(decode(x)) reproduces x.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import Self, override
+
+from . import decode_frames_majority, is_close, split_frames
+from ._base import Command
+
+# Base unit at the family-standard 16-pulse burst / 38kHz carrier.
+_UNIT_US = round(1_000_000 * 16 / 38000)  # 421
+_LEADER_MARK_US = 8 * _UNIT_US
+_LEADER_SPACE_US = 4 * _UNIT_US
+_REPEAT_SPACE_US = 8 * _UNIT_US
+# Midpoint between the 0-space (1T) and 1-space (3T).
+_SPACE_MIDPOINT_US = 2 * _UNIT_US
+_MARK_MIN_US = 150
+_MARK_MAX_US = 800
+_SPACE_MIN_US = 150
+_SPACE_MAX_US = 2200
+# Bit spaces top out at 3T (~1263us); leader space is ~1684us. The
+# inter-frame trailer is at least 8ms per the family convention.
+_FRAME_GAP_US = 6000
+
+_FRAME_TIME_US = 130000
+_TRAILER_MIN_US = 8000
+_MIN_PAYLOAD_BYTES = 4
+_MAX_PAYLOAD_BYTES = 12
+
+
+class KaseikyoCommand(Command):
+    """Kaseikyo format IR command with decode support."""
+
+    address: int
+    data: bytes
+    error_correction: Callable[[bytes], bytes] | None
+    base_unit: float
+
+    def __init__(
+        self,
+        *,
+        address: int,
+        data: bytes,
+        error_correction: Callable[[bytes], bytes] | None = None,
+        modulation: int = 38000,
+        burst_pulse: int = 16,
+        repeat_count: int = 0,
+    ) -> None:
+        """Initialize the Kaseikyo IR command."""
+        super().__init__(modulation=modulation, repeat_count=repeat_count)
+        self.address = address
+        self.data = data
+        self.error_correction = error_correction
+        self.base_unit = 1000000 * burst_pulse / modulation
+
+    @override
+    def get_raw_timings(self) -> list[int]:
+        """Get raw timings for the Kaseikyo command."""
+        leader_high = round(8 * self.base_unit)
+        leader_low = round(4 * self.base_unit)
+        repeat_low = round(8 * self.base_unit)
+        bit_high = round(1 * self.base_unit)
+        zero_low = round(1 * self.base_unit)
+        one_low = round(3 * self.base_unit)
+        repeat_frame_gap = max(
+            _FRAME_TIME_US - (leader_high + repeat_low + bit_high), _TRAILER_MIN_US
+        )
+
+        timings = [leader_high, -leader_low]
+
+        parity = self.address & 0xFFFF
+        parity ^= parity >> 8
+        parity ^= parity >> 4
+        parity &= 0x0F
+
+        data_bytes = [
+            self.address & 0xFF,
+            (self.address >> 8) & 0xFF,
+            (self.data[0] & 0xF0) | parity,
+            *self.data[1:],
+        ]
+        if self.error_correction:
+            data_bytes.extend(self.error_correction(bytes(data_bytes)))
+
+        for byte in data_bytes:
+            for _ in range(8):
+                bit = byte & 1
+                timings.append(bit_high)
+                timings.append(-one_low if bit else -zero_low)
+                byte >>= 1
+
+        timings.append(bit_high)
+
+        gap = max(_FRAME_TIME_US - sum(abs(t) for t in timings), _TRAILER_MIN_US)
+        for _ in range(self.repeat_count):
+            timings.extend([-gap, leader_high, -repeat_low, bit_high])
+            gap = repeat_frame_gap
+
+        return timings
+
+    @classmethod
+    def from_raw_timings(cls, timings: list[int]) -> Self | None:
+        """Decode raw IR timings into a KaseikyoCommand.
+
+        Majority-votes across full frames; NEC-style repeat markers after
+        the winning frame add to ``repeat_count``. Returns None when no
+        frame decodes with a valid vendor parity nibble.
+        """
+        frames = split_frames(timings, _FRAME_GAP_US)
+        repeat_markers = sum(1 for frame in frames if cls._is_repeat_marker(frame))
+        data_frames = [f for f in frames if not cls._is_repeat_marker(f)]
+        result = decode_frames_majority(data_frames, cls._decode_frame)
+        if result is None:
+            return None
+        (address, payload), votes = result
+        return cls(
+            address=address,
+            data=bytes(payload),
+            repeat_count=votes - 1 + repeat_markers,
+        )
+
+    @staticmethod
+    def _is_repeat_marker(frame: Sequence[int]) -> bool:
+        """Return True for the 8T/8T/1T NEC-style repeat frame."""
+        if len(frame) != 3:
+            return False
+        return (
+            is_close(frame[0], _LEADER_MARK_US)
+            and is_close(-frame[1], _REPEAT_SPACE_US)
+            and _MARK_MIN_US <= frame[2] <= _MARK_MAX_US
+        )
+
+    @staticmethod
+    def _decode_frame(frame: Sequence[int]) -> tuple[int, tuple[int, ...]] | None:
+        """Decode one Kaseikyo frame to ``(address, payload_bytes)``."""
+        # Leader pair + at least 4 byte-pairs + end pulse.
+        if len(frame) < 2 + 2 * 8 * _MIN_PAYLOAD_BYTES + 1:
+            return None
+        if not is_close(frame[0], _LEADER_MARK_US) or not is_close(
+            -frame[1], _LEADER_SPACE_US
+        ):
+            return None
+
+        bits: list[int] = []
+        i = 2
+        while i + 1 < len(frame):
+            mark = frame[i]
+            space = -frame[i + 1]
+            if not _MARK_MIN_US <= mark <= _MARK_MAX_US:
+                return None
+            if not _SPACE_MIN_US <= space <= _SPACE_MAX_US:
+                return None
+            bits.append(1 if space > _SPACE_MIDPOINT_US else 0)
+            i += 2
+            if len(bits) > 8 * _MAX_PAYLOAD_BYTES:
+                return None
+
+        # End pulse, then nothing but (possibly) a truncated space.
+        if i >= len(frame) or not _MARK_MIN_US <= frame[i] <= _MARK_MAX_US:
+            return None
+        if any(value > 0 for value in frame[i + 1 :]):
+            return None
+        if len(bits) % 8 != 0 or len(bits) < 8 * _MIN_PAYLOAD_BYTES:
+            return None
+
+        wire_bytes: list[int] = []
+        for byte_index in range(len(bits) // 8):
+            byte = 0
+            for bit_index in range(8):
+                byte |= bits[byte_index * 8 + bit_index] << bit_index
+            wire_bytes.append(byte)
+
+        address = wire_bytes[0] | (wire_bytes[1] << 8)
+        parity = address ^ (address >> 8)
+        parity ^= parity >> 4
+        parity &= 0x0F
+        if wire_bytes[2] & 0x0F != parity:
+            return None
+
+        payload = (wire_bytes[2] & 0xF0, *wire_bytes[3:])
+        return (address, payload)

--- a/custom_components/hair/decoders/marantz_extended.py
+++ b/custom_components/hair/decoders/marantz_extended.py
@@ -1,0 +1,198 @@
+"""Marantz extended IR command with decode support.
+
+Encode side mirrors
+``infrared_protocols.commands.marantz_extended.MarantzExtendedCommand``
+byte-for-byte (asserted by round-trip tests). Decode side is new
+(upstream is encode-only as of 7.5.0).
+
+Marantz extended is RC-5 with a fixed mid-frame pause and six extension
+bits: 8 leader bits (S1, S2/field, toggle, 5 address bits), a pause of
+exactly four RC-5 half-bit units of space, then 12 trailing bits (6
+command + 6 extension), all Manchester coded at the RC-5 rate. On the
+wire the pause merges with any adjacent space half-bits, so the decoder
+works on the reconstructed half-bit lattice: 16 leader halves, 4 pause
+halves (all space), 24 trailing halves -- 44 in total, with the same
+implicit leading/trailing space restoration RC-5 needs. The toggle bit
+is press state, not identity, exactly as in RC-5.
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Self, override
+
+from . import decode_frames_majority, split_frames
+from ._base import Command
+from .rc5 import (
+    _append_signed_us,
+    _manchester_encode_bit,
+    _strip_idle_edges,
+)
+
+_HALF_BIT_US = 889
+_MODULATION_HZ = 36000
+_REPEAT_PERIOD_US = 114000
+_PAUSE_US = 4 * _HALF_BIT_US
+# The longest legitimate run is the pause plus a space half-bit on each
+# side: six half-bit units (~5334us). Larger spaces separate frames.
+_FRAME_GAP_US = 8000
+_MAX_RUN_UNITS = 6
+_UNIT_TOLERANCE_US = 400
+
+_LEADER_HALVES = 16  # S1, S2, T, A4..A0
+_PAUSE_HALVES = 4
+_TRAILING_HALVES = 24  # C5..C0, E5..E0
+_FRAME_HALVES = _LEADER_HALVES + _PAUSE_HALVES + _TRAILING_HALVES
+
+
+class MarantzExtendedCommand(Command):
+    """Marantz extended IR command with decode support."""
+
+    address: int
+    command: int
+    extension: int
+    toggle: int
+
+    def __init__(
+        self,
+        *,
+        address: int,
+        command: int,
+        extension: int,
+        toggle: int = 0,
+        modulation: int = _MODULATION_HZ,
+        repeat_count: int = 0,
+    ) -> None:
+        """Initialize the Marantz extended IR command."""
+        if not 0 <= address <= 0x1F:
+            raise ValueError("Marantz address must be in range 0x00..0x1F")
+        if not 0 <= command <= 0x7F:
+            raise ValueError("Marantz command must be in range 0x00..0x7F")
+        if not 0 <= extension <= 0x3F:
+            raise ValueError("Marantz extension must be in range 0x00..0x3F")
+        super().__init__(modulation=modulation, repeat_count=repeat_count)
+        self.address = address
+        self.command = command
+        self.extension = extension
+        self.toggle = toggle
+
+    @override
+    def get_raw_timings(self) -> list[int]:
+        """Get raw timings for the Marantz extended command."""
+        start_bit_2 = 0 if self.command & 0x40 else 1
+        command_bits = self.command & 0x3F
+
+        leader_bits: list[int] = [1, start_bit_2, self.toggle & 1]
+        for i in range(4, -1, -1):
+            leader_bits.append((self.address >> i) & 1)
+
+        trailing_bits: list[int] = []
+        for i in range(5, -1, -1):
+            trailing_bits.append((command_bits >> i) & 1)
+        for i in range(5, -1, -1):
+            trailing_bits.append((self.extension >> i) & 1)
+
+        frame: list[int] = []
+        for bit in leader_bits:
+            _manchester_encode_bit(frame, bit, _HALF_BIT_US)
+        _append_signed_us(frame, -_PAUSE_US)
+        for bit in trailing_bits:
+            _manchester_encode_bit(frame, bit, _HALF_BIT_US)
+        _strip_idle_edges(frame)
+
+        timings = list(frame)
+        if self.repeat_count > 0:
+            frame_duration = sum(abs(t) for t in frame)
+            gap = _REPEAT_PERIOD_US - frame_duration
+            for _ in range(self.repeat_count):
+                timings.append(-gap)
+                timings.extend(frame)
+        return timings
+
+    @classmethod
+    def from_raw_timings(cls, timings: list[int]) -> Self | None:
+        """Decode raw IR timings into a MarantzExtendedCommand.
+
+        Returns the majority identity across the capture's frames, or
+        None when no frame decodes as Marantz extended.
+        """
+        frames = split_frames(timings, _FRAME_GAP_US)
+        result = decode_frames_majority(frames, cls._decode_frame)
+        if result is None:
+            return None
+        (address, command, extension, toggle), votes = result
+        return cls(
+            address=address,
+            command=command,
+            extension=extension,
+            toggle=toggle,
+            repeat_count=votes - 1,
+        )
+
+    @classmethod
+    def _decode_frame(
+        cls, frame: Sequence[int]
+    ) -> tuple[int, int, int, int] | None:
+        """Decode one frame to ``(address, command, extension, toggle)``."""
+        halves = cls._to_half_bits(frame)
+        if halves is None:
+            return None
+
+        # The pause occupies four space halves between the leader and
+        # trailing sections.
+        if any(h > 0 for h in halves[_LEADER_HALVES : _LEADER_HALVES + _PAUSE_HALVES]):
+            return None
+
+        def _read_bits(section: Sequence[int]) -> list[int] | None:
+            bits: list[int] = []
+            for i in range(len(section) // 2):
+                first, second = section[2 * i], section[2 * i + 1]
+                if first < 0 and second > 0:
+                    bits.append(1)
+                elif first > 0 and second < 0:
+                    bits.append(0)
+                else:
+                    return None
+            return bits
+
+        leader = _read_bits(halves[:_LEADER_HALVES])
+        trailing = _read_bits(halves[_LEADER_HALVES + _PAUSE_HALVES :])
+        if leader is None or trailing is None:
+            return None
+        if leader[0] != 1:  # S1 is always 1
+            return None
+
+        start_bit_2 = leader[1]
+        toggle = leader[2]
+        address = 0
+        for bit in leader[3:8]:
+            address = (address << 1) | bit
+        command = 0
+        for bit in trailing[0:6]:
+            command = (command << 1) | bit
+        extension = 0
+        for bit in trailing[6:12]:
+            extension = (extension << 1) | bit
+        if start_bit_2 == 0:  # field bit carries inverted command bit 6
+            command |= 0x40
+        return (address, command, extension, toggle)
+
+    @staticmethod
+    def _to_half_bits(frame: Sequence[int]) -> list[int] | None:
+        """Expand merged wire timings into the 44-entry half-bit lattice."""
+        halves: list[int] = [-1]  # implicit first half of S1
+        for value in frame:
+            magnitude = abs(value)
+            units = max(1, round(magnitude / _HALF_BIT_US))
+            if units > _MAX_RUN_UNITS:
+                return None
+            if abs(magnitude - units * _HALF_BIT_US) > _UNIT_TOLERANCE_US * units:
+                return None
+            sign = 1 if value > 0 else -1
+            halves.extend([sign] * units)
+            if len(halves) > _FRAME_HALVES:
+                return None
+        if len(halves) == _FRAME_HALVES - 1:
+            halves.append(-1)  # implicit stripped trailing space
+        if len(halves) != _FRAME_HALVES:
+            return None
+        return halves

--- a/custom_components/hair/decoders/rc5.py
+++ b/custom_components/hair/decoders/rc5.py
@@ -1,0 +1,196 @@
+"""RC-5 IR command (Philips) with decode support.
+
+Encode side mirrors ``infrared_protocols.commands.rc5.RC5Command``
+byte-for-byte (asserted by round-trip tests), including the RC5X
+extension where a command with bit 6 set re-purposes the second start
+bit. Decode side is new (upstream is encode-only as of 7.5.0).
+
+RC-5 is Manchester coded: 14 bits of 1778us each, split into two 889us
+half-bits. Logic '1' is space-then-mark, logic '0' is mark-then-space,
+and adjacent same-sign halves merge on the wire. Frame layout MSB first:
+S1 (always 1), S2 (or inverted command bit 6 for RC5X), toggle, 5
+address bits, 6 command bits. The toggle bit flips per key press and is
+therefore press state, not signal identity -- callers must exclude it
+from identity comparisons.
+
+Decoding reverses the Manchester merge: quantize every timing to one or
+two half-bit units, rebuild the half-bit lattice (restoring the leading
+idle space that S1's first half loses on the wire and the trailing space
+the encoder strips), and read bit i from lattice positions 2i/2i+1. A
+held key re-sends the frame every 114ms with the toggle constant, so
+multi-frame captures majority-vote like every decoder in this package.
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Self, override
+
+from . import decode_frames_majority, split_frames
+from ._base import Command
+
+_HALF_BIT_US = 889
+_MODULATION_HZ = 36000
+_REPEAT_PERIOD_US = 114000
+# Midpoint between one half-bit (889us) and two merged half-bits (1778us).
+_HALF_MIDPOINT_US = 1334
+_HALF_MIN_US = 400
+_HALF_MAX_US = 2500
+# Bit-internal spaces top out at 1778us; the inter-frame idle is ~89ms.
+_FRAME_GAP_US = 8000
+
+_FRAME_BITS = 14
+_FRAME_HALVES = 2 * _FRAME_BITS
+
+
+def _append_signed_us(timings: list[int], value: int) -> None:
+    """Append a microsecond duration, merging into the last entry if same sign."""
+    if timings and (timings[-1] > 0) == (value > 0):
+        timings[-1] += value
+    else:
+        timings.append(value)
+
+
+def _manchester_encode_bit(timings: list[int], bit: int, half_bit_us: int) -> None:
+    """Append the two Manchester half-bits for ``bit`` to ``timings``."""
+    if bit:
+        _append_signed_us(timings, -half_bit_us)
+        _append_signed_us(timings, half_bit_us)
+    else:
+        _append_signed_us(timings, half_bit_us)
+        _append_signed_us(timings, -half_bit_us)
+
+
+def _strip_idle_edges(timings: list[int]) -> None:
+    """Drop any leading and trailing space (negative) entries in place."""
+    if timings and timings[0] < 0:
+        timings.pop(0)
+    if timings and timings[-1] < 0:
+        timings.pop()
+
+
+class RC5Command(Command):
+    """RC-5 IR command (Philips and derivatives) with decode support."""
+
+    address: int
+    command: int
+    toggle: int
+
+    def __init__(
+        self,
+        *,
+        address: int,
+        command: int,
+        toggle: int = 0,
+        modulation: int = _MODULATION_HZ,
+        repeat_count: int = 0,
+    ) -> None:
+        """Initialize the RC-5 IR command."""
+        if not 0 <= address <= 0x1F:
+            raise ValueError("RC-5 address must be in range 0x00..0x1F")
+        if not 0 <= command <= 0x7F:
+            raise ValueError("RC-5 command must be in range 0x00..0x7F")
+        super().__init__(modulation=modulation, repeat_count=repeat_count)
+        self.address = address
+        self.command = command
+        self.toggle = toggle
+
+    @override
+    def get_raw_timings(self) -> list[int]:
+        """Get raw timings for the RC-5 command (14 bits, Manchester)."""
+        start_bit_2 = 0 if self.command & 0x40 else 1
+        command_bits = self.command & 0x3F
+
+        bits: list[int] = [1, start_bit_2, self.toggle & 1]
+        for i in range(4, -1, -1):
+            bits.append((self.address >> i) & 1)
+        for i in range(5, -1, -1):
+            bits.append((command_bits >> i) & 1)
+
+        frame: list[int] = []
+        for bit in bits:
+            _manchester_encode_bit(frame, bit, _HALF_BIT_US)
+        _strip_idle_edges(frame)
+
+        timings = list(frame)
+        if self.repeat_count > 0:
+            frame_duration = sum(abs(t) for t in frame)
+            gap = _REPEAT_PERIOD_US - frame_duration
+            for _ in range(self.repeat_count):
+                timings.append(-gap)
+                timings.extend(frame)
+        return timings
+
+    @classmethod
+    def from_raw_timings(cls, timings: list[int]) -> Self | None:
+        """Decode raw IR timings into an RC5Command.
+
+        Returns the majority identity across the frames in the capture,
+        with ``repeat_count`` set to the number of extra agreeing frames,
+        or None when no frame decodes as RC-5.
+        """
+        frames = split_frames(timings, _FRAME_GAP_US)
+        result = decode_frames_majority(frames, cls._decode_frame)
+        if result is None:
+            return None
+        (address, command, toggle), votes = result
+        return cls(
+            address=address,
+            command=command,
+            toggle=toggle,
+            repeat_count=votes - 1,
+        )
+
+    @classmethod
+    def _decode_frame(cls, frame: Sequence[int]) -> tuple[int, int, int] | None:
+        """Decode one RC-5 frame to ``(address, command, toggle)``."""
+        halves = cls._to_half_bits(frame, expected_halves=_FRAME_HALVES)
+        if halves is None or len(halves) != _FRAME_HALVES:
+            return None
+
+        bits: list[int] = []
+        for i in range(_FRAME_BITS):
+            first, second = halves[2 * i], halves[2 * i + 1]
+            if first < 0 and second > 0:
+                bits.append(1)
+            elif first > 0 and second < 0:
+                bits.append(0)
+            else:
+                return None
+
+        if bits[0] != 1:  # S1 is always 1
+            return None
+        start_bit_2 = bits[1]
+        toggle = bits[2]
+        address = 0
+        for bit in bits[3:8]:
+            address = (address << 1) | bit
+        command = 0
+        for bit in bits[8:14]:
+            command = (command << 1) | bit
+        if start_bit_2 == 0:  # RC5X: S2 carries inverted command bit 6
+            command |= 0x40
+        return (address, command, toggle)
+
+    @staticmethod
+    def _to_half_bits(
+        frame: Sequence[int], *, expected_halves: int
+    ) -> list[int] | None:
+        """Expand merged wire timings into a +/-1 half-bit lattice.
+
+        Restores the implicit leading space (S1 transmits space-then-mark
+        and the wire strips the leading idle) and, when the frame's last
+        bit ends on a stripped space, the implicit trailing space.
+        """
+        halves: list[int] = [-1]  # implicit first half of S1
+        for value in frame:
+            magnitude = abs(value)
+            if not _HALF_MIN_US <= magnitude <= _HALF_MAX_US:
+                return None
+            units = 1 if magnitude < _HALF_MIDPOINT_US else 2
+            sign = 1 if value > 0 else -1
+            halves.extend([sign] * units)
+            if len(halves) > expected_halves:
+                return None
+        if len(halves) == expected_halves - 1:
+            halves.append(-1)  # implicit stripped trailing space
+        return halves

--- a/custom_components/hair/decoders/samsung.py
+++ b/custom_components/hair/decoders/samsung.py
@@ -1,0 +1,162 @@
+"""Samsung32 IR command with decode support.
+
+Encode side mirrors ``infrared_protocols.commands.samsung.Samsung32Command``
+byte-for-byte (asserted by round-trip tests). Decode side is new
+(upstream is encode-only as of 7.5.0).
+
+Samsung32 is NEC-shaped with a different leader (4500/4500 instead of
+9000/4500) and full-frame repeats instead of dedicated repeat codes:
+
+- Leader: 4500us mark, 4500us space. Bit: 560us mark, then 560us space
+  (0) or 1690us space (1). End pulse: 560us mark. 32 data bits LSB
+  first: address low, address high, command, inverted command. Standard
+  addresses send the same byte twice; extended addresses split 16 bits.
+- Held buttons re-send the whole frame, padded to a 108ms period.
+
+The inverted-command checksum makes single frames trustworthy; repeats
+still majority-vote so a capture holding three re-sends decodes to one
+identity with the repeat count preserved.
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Self, override
+
+from . import decode_frames_majority, is_close, split_frames
+from ._base import Command
+
+_LEADER_MARK_US = 4500
+_LEADER_SPACE_US = 4500
+_BIT_MARK_US = 560
+_ZERO_SPACE_US = 560
+_ONE_SPACE_US = 1690
+# Midpoint between the 0-space (560us) and 1-space (1690us).
+_SPACE_MIDPOINT_US = 1125
+_MARK_MIN_US = 220
+_MARK_MAX_US = 1000
+_SPACE_MIN_US = 220
+_SPACE_MAX_US = 2400
+_FRAME_PERIOD_US = 108000
+# Bit spaces top out at 1690us; the pad to 108ms separates frames.
+_FRAME_GAP_US = 8000
+
+
+class Samsung32Command(Command):
+    """Samsung32 IR command with decode support."""
+
+    address: int
+    command: int
+
+    def __init__(
+        self,
+        *,
+        address: int,
+        command: int,
+        modulation: int = 38000,
+        repeat_count: int = 0,
+    ) -> None:
+        """Initialize the Samsung32 IR command."""
+        if not 0 <= address <= 0xFFFF:
+            raise ValueError("Samsung32 address must be in range 0x00..0xFFFF")
+        if not 0 <= command <= 0xFF:
+            raise ValueError("Samsung32 command must be in range 0x00..0xFF")
+        super().__init__(modulation=modulation, repeat_count=repeat_count)
+        self.address = address
+        self.command = command
+
+    @override
+    def get_raw_timings(self) -> list[int]:
+        """Get raw timings for the Samsung32 command."""
+        timings: list[int] = [_LEADER_MARK_US, -_LEADER_SPACE_US]
+
+        if self.address <= 0xFF:
+            address_low = self.address & 0xFF
+            address_high = self.address & 0xFF
+        else:
+            address_low = self.address & 0xFF
+            address_high = (self.address >> 8) & 0xFF
+
+        command_byte = self.command & 0xFF
+        command_inverted = (~self.command) & 0xFF
+
+        data = (
+            address_low
+            | (address_high << 8)
+            | (command_byte << 16)
+            | (command_inverted << 24)
+        )
+
+        for _ in range(32):
+            bit = data & 1
+            timings.append(_BIT_MARK_US)
+            timings.append(-_ONE_SPACE_US if bit else -_ZERO_SPACE_US)
+            data >>= 1
+
+        timings.append(_BIT_MARK_US)
+
+        if self.repeat_count > 0:
+            frame_duration = sum(abs(t) for t in timings)
+            gap = _FRAME_PERIOD_US - frame_duration
+            base_frame = timings.copy()
+            for _ in range(self.repeat_count):
+                timings.append(-gap)
+                timings.extend(base_frame)
+
+        return timings
+
+    @classmethod
+    def from_raw_timings(cls, timings: list[int]) -> Self | None:
+        """Decode raw IR timings into a Samsung32Command.
+
+        Returns the majority identity across the capture's frames with
+        ``repeat_count`` preserved, or None when nothing decodes.
+        """
+        frames = split_frames(timings, _FRAME_GAP_US)
+        result = decode_frames_majority(frames, cls._decode_frame)
+        if result is None:
+            return None
+        (address, command), votes = result
+        return cls(address=address, command=command, repeat_count=votes - 1)
+
+    @staticmethod
+    def _decode_frame(frame: Sequence[int]) -> tuple[int, int] | None:
+        """Decode one Samsung32 frame to ``(address, command)``."""
+        # Leader pair + 32 bit pairs + end pulse.
+        if len(frame) < 2 + 64 + 1:
+            return None
+        if not is_close(frame[0], _LEADER_MARK_US) or not is_close(
+            -frame[1], _LEADER_SPACE_US
+        ):
+            return None
+
+        data = 0
+        for i in range(32):
+            mark = frame[2 + 2 * i]
+            space = -frame[3 + 2 * i]
+            if not _MARK_MIN_US <= mark <= _MARK_MAX_US:
+                return None
+            if not _SPACE_MIN_US <= space <= _SPACE_MAX_US:
+                return None
+            if space > _SPACE_MIDPOINT_US:
+                data |= 1 << i
+
+        if not _MARK_MIN_US <= frame[66] <= _MARK_MAX_US:
+            return None
+        if any(value > 0 for value in frame[67:]):
+            return None
+
+        address_low = data & 0xFF
+        address_high = (data >> 8) & 0xFF
+        command_byte = (data >> 16) & 0xFF
+        command_inverted = (data >> 24) & 0xFF
+        if command_byte ^ command_inverted != 0xFF:
+            return None
+
+        # Standard Samsung32 duplicates the address byte; collapse it so
+        # the decoded address round-trips through the encoder unchanged.
+        address = (
+            address_low
+            if address_high == address_low
+            else address_low | (address_high << 8)
+        )
+        return (address, command_byte)

--- a/custom_components/hair/decoders/sharp.py
+++ b/custom_components/hair/decoders/sharp.py
@@ -15,9 +15,18 @@ frame -- as its integrity check:
 - Second frame repeats the address bits and inverts command, extension,
   and check (XOR 0x7FE0).
 
-The decoder requires the frame pair: a lone 15-bit frame's single check
-bit is far too weak to accept, and real Sharp hardware always sends the
-pair. Captures holding multiple pairs majority-vote as usual.
+The 40ms trailer between the two frames exceeds typical capture-window
+gap limits, so on real receivers the halves routinely arrive as SEPARATE
+captures (observed on Sharp hardware in the field) -- a decoder that
+demands the pair inside one capture never fires. Each frame therefore
+decodes alone: the check bit says which half it is (0 = data, 1 =
+inverted), and an inverted half is XOR-folded back to the data form, so
+both halves of one press produce the identical identity and merge. With
+the check bit spent on half-detection, the integrity gate is Sharp's
+other signature: all sixteen marks in a frame are nominally identical
+(320us), so the decoder rejects any frame whose marks are not mutually
+consistent. Captures holding several frames majority-vote as usual, and
+a (data, inverted) pair in one capture simply casts two agreeing votes.
 """
 from __future__ import annotations
 
@@ -35,6 +44,10 @@ _TRAILER_SPACE_US = 40000
 _SPACE_MIDPOINT_US = 1180
 _MARK_MIN_US = 120
 _MARK_MAX_US = 700
+# All marks in a Sharp frame are nominally identical; any mark deviating
+# more than this fraction from the frame's own mean is a structure reject
+# (the integrity check that replaces the pair requirement for lone halves).
+_MARK_SPREAD_TOLERANCE = 0.25
 _SPACE_MIN_US = 300
 _SPACE_MAX_US = 2400
 # Bit spaces top out at 1680us; the 40ms trailer separates frames.
@@ -105,48 +118,39 @@ class SharpCommand(Command):
     def from_raw_timings(cls, timings: list[int]) -> Self | None:
         """Decode raw IR timings into a SharpCommand.
 
-        Frames pair up as (data, inverted); the decoder validates each
-        pair and majority-votes across pairs. Returns None when no valid
-        pair exists in the capture.
+        Each 15-bit frame decodes independently; inverted halves fold
+        back to the data form via the check bit, so a press whose two
+        halves were split across the capture boundary still yields the
+        identity, and a pair inside one capture casts two agreeing
+        votes. Returns None when no structurally valid frame exists.
         """
         frames = split_frames(timings, _FRAME_GAP_US)
-        words = [cls._decode_frame(frame) for frame in frames]
-
-        pairs: list[tuple[int, int, int]] = []
-        i = 0
-        while i + 1 < len(words):
-            first, second = words[i], words[i + 1]
-            if first is None or second is None:
-                i += 1
-                continue
-            decoded = cls._validate_pair(first, second)
-            if decoded is None:
-                i += 1
-                continue
-            pairs.append(decoded)
-            i += 2
-
-        result = decode_frames_majority(pairs, lambda pair: pair)
+        result = decode_frames_majority(frames, cls._decode_normalized)
         if result is None:
             return None
         (address, command, extension), votes = result
+        # Two frames (one pair) per press: votes count halves.
+        presses = (votes + 1) // 2
         return cls(
             address=address,
             command=command,
             extension=extension,
-            repeat_count=votes - 1,
+            repeat_count=presses - 1,
         )
 
-    @staticmethod
-    def _validate_pair(data: int, idata: int) -> tuple[int, int, int] | None:
-        """Validate a (data, inverted) frame pair; extract the fields."""
-        if data ^ idata != _INVERT_MASK:
+    @classmethod
+    def _decode_normalized(
+        cls, frame: Sequence[int]
+    ) -> tuple[int, int, int] | None:
+        """Decode one frame and fold an inverted half to the data form."""
+        word = cls._decode_frame(frame)
+        if word is None:
             return None
-        if (data >> 14) & 1 != 0:  # check bit: 0 in the data frame
-            return None
-        address = data & 0x1F
-        command = (data >> 5) & 0xFF
-        extension = (data >> 13) & 1
+        if (word >> 14) & 1:  # check bit set: this is the inverted half
+            word ^= _INVERT_MASK
+        address = word & 0x1F
+        command = (word >> 5) & 0xFF
+        extension = (word >> 13) & 1
         return (address, command, extension)
 
     @staticmethod
@@ -156,6 +160,7 @@ class SharpCommand(Command):
         if len(frame) < 2 * _FRAME_BITS + 1:
             return None
 
+        marks: list[int] = []
         data = 0
         for i in range(_FRAME_BITS):
             mark = frame[2 * i]
@@ -164,11 +169,22 @@ class SharpCommand(Command):
                 return None
             if not _SPACE_MIN_US <= space <= _SPACE_MAX_US:
                 return None
+            marks.append(mark)
             if space > _SPACE_MIDPOINT_US:
                 data |= 1 << i
 
-        if not _MARK_MIN_US <= frame[2 * _FRAME_BITS] <= _MARK_MAX_US:
+        trailer_mark = frame[2 * _FRAME_BITS]
+        if not _MARK_MIN_US <= trailer_mark <= _MARK_MAX_US:
             return None
+        marks.append(trailer_mark)
         if any(value > 0 for value in frame[2 * _FRAME_BITS + 1 :]):
+            return None
+
+        # Structural integrity: every mark in a Sharp frame is the same
+        # nominal 320us pulse. A frame mixing genuinely different mark
+        # widths is another protocol, whatever its spaces look like.
+        mean_mark = sum(marks) / len(marks)
+        spread = mean_mark * _MARK_SPREAD_TOLERANCE
+        if any(abs(mark - mean_mark) > spread for mark in marks):
             return None
         return data

--- a/custom_components/hair/decoders/sharp.py
+++ b/custom_components/hair/decoders/sharp.py
@@ -1,0 +1,174 @@
+"""Sharp IR command with decode support.
+
+Encode side mirrors ``infrared_protocols.commands.sharp.SharpCommand``
+byte-for-byte (asserted by round-trip tests) and adds ``repeat_count``
+support (Sharp has no repeat code; held buttons re-send the full
+double-frame transmission). Decode side is new (upstream is encode-only
+as of 7.5.0).
+
+Sharp transmits every command twice -- a data frame and a bit-inverted
+frame -- as its integrity check:
+
+- No leader. Bit: 320us mark, then 680us space (0) or 1680us space (1).
+  15 bits LSB first: 5 address bits, 8 command bits, 1 extension bit,
+  1 check bit (0 in the data frame). Trailer: 320us mark + 40ms space.
+- Second frame repeats the address bits and inverts command, extension,
+  and check (XOR 0x7FE0).
+
+The decoder requires the frame pair: a lone 15-bit frame's single check
+bit is far too weak to accept, and real Sharp hardware always sends the
+pair. Captures holding multiple pairs majority-vote as usual.
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Self, override
+
+from . import decode_frames_majority, split_frames
+from ._base import Command
+
+_BIT_MARK_US = 320
+_ZERO_SPACE_US = 680
+_ONE_SPACE_US = 1680
+_TRAILER_SPACE_US = 40000
+# Midpoint between the 0-space (680us) and 1-space (1680us).
+_SPACE_MIDPOINT_US = 1180
+_MARK_MIN_US = 120
+_MARK_MAX_US = 700
+_SPACE_MIN_US = 300
+_SPACE_MAX_US = 2400
+# Bit spaces top out at 1680us; the 40ms trailer separates frames.
+_FRAME_GAP_US = 8000
+
+_FRAME_BITS = 15
+_INVERT_MASK = 0x7FE0
+
+
+class SharpCommand(Command):
+    """Sharp IR command with decode support."""
+
+    address: int
+    command: int
+    extension: int
+
+    def __init__(
+        self,
+        *,
+        address: int,
+        command: int,
+        extension: int = 0,
+        modulation: int = 38000,
+        repeat_count: int = 0,
+    ) -> None:
+        """Initialize the Sharp IR command.
+
+        :param address: The IR address for the Sharp command. (5 bits)
+        :param command: The IR command for the Sharp command. (8 bits)
+        :param extension: The extension bit for the Sharp command. (1 bit)
+        """
+        if not 0 <= address <= 0x1F:
+            raise ValueError(f"address must be in range 0-31, got {address}")
+        if not 0 <= command <= 0xFF:
+            raise ValueError(f"command must be in range 0-255, got {command}")
+        if extension not in (0, 1):
+            raise ValueError(f"extension must be 0 or 1, got {extension}")
+        super().__init__(modulation=modulation, repeat_count=repeat_count)
+        self.address = address
+        self.command = command
+        self.extension = extension
+
+    @override
+    def get_raw_timings(self) -> list[int]:
+        """Get raw timings for the Sharp command (data + inverted frame)."""
+        data = self.address | (self.command << 5) | (self.extension << 13)
+        idata = data ^ _INVERT_MASK
+
+        pair: list[int] = []
+
+        def _encode_bits(value: int) -> None:
+            for _ in range(_FRAME_BITS):
+                bit = value & 1
+                pair.append(_BIT_MARK_US)
+                pair.append(-(_ONE_SPACE_US if bit else _ZERO_SPACE_US))
+                value >>= 1
+            pair.extend([_BIT_MARK_US, -_TRAILER_SPACE_US])
+
+        _encode_bits(data)
+        _encode_bits(idata)
+
+        timings = list(pair)
+        for _ in range(self.repeat_count):
+            timings.extend(pair)
+        return timings
+
+    @classmethod
+    def from_raw_timings(cls, timings: list[int]) -> Self | None:
+        """Decode raw IR timings into a SharpCommand.
+
+        Frames pair up as (data, inverted); the decoder validates each
+        pair and majority-votes across pairs. Returns None when no valid
+        pair exists in the capture.
+        """
+        frames = split_frames(timings, _FRAME_GAP_US)
+        words = [cls._decode_frame(frame) for frame in frames]
+
+        pairs: list[tuple[int, int, int]] = []
+        i = 0
+        while i + 1 < len(words):
+            first, second = words[i], words[i + 1]
+            if first is None or second is None:
+                i += 1
+                continue
+            decoded = cls._validate_pair(first, second)
+            if decoded is None:
+                i += 1
+                continue
+            pairs.append(decoded)
+            i += 2
+
+        result = decode_frames_majority(pairs, lambda pair: pair)
+        if result is None:
+            return None
+        (address, command, extension), votes = result
+        return cls(
+            address=address,
+            command=command,
+            extension=extension,
+            repeat_count=votes - 1,
+        )
+
+    @staticmethod
+    def _validate_pair(data: int, idata: int) -> tuple[int, int, int] | None:
+        """Validate a (data, inverted) frame pair; extract the fields."""
+        if data ^ idata != _INVERT_MASK:
+            return None
+        if (data >> 14) & 1 != 0:  # check bit: 0 in the data frame
+            return None
+        address = data & 0x1F
+        command = (data >> 5) & 0xFF
+        extension = (data >> 13) & 1
+        return (address, command, extension)
+
+    @staticmethod
+    def _decode_frame(frame: Sequence[int]) -> int | None:
+        """Decode one 15-bit Sharp frame to its raw data word."""
+        # 15 bit pairs + trailer mark; the trailer space is the frame gap.
+        if len(frame) < 2 * _FRAME_BITS + 1:
+            return None
+
+        data = 0
+        for i in range(_FRAME_BITS):
+            mark = frame[2 * i]
+            space = -frame[2 * i + 1]
+            if not _MARK_MIN_US <= mark <= _MARK_MAX_US:
+                return None
+            if not _SPACE_MIN_US <= space <= _SPACE_MAX_US:
+                return None
+            if space > _SPACE_MIDPOINT_US:
+                data |= 1 << i
+
+        if not _MARK_MIN_US <= frame[2 * _FRAME_BITS] <= _MARK_MAX_US:
+            return None
+        if any(value > 0 for value in frame[2 * _FRAME_BITS + 1 :]):
+            return None
+        return data

--- a/custom_components/hair/decoders/sony.py
+++ b/custom_components/hair/decoders/sony.py
@@ -1,0 +1,161 @@
+"""SONY SIRC IR command with decode support.
+
+Encode side mirrors ``infrared_protocols.commands.sony.SonyCommand``
+byte-for-byte (asserted by round-trip tests) and adds ``repeat_count``
+support: SIRC has no dedicated repeat code, a held button re-sends the
+full frame every 45ms, so repeats append whole frames.
+
+Decode side is new (upstream is encode-only as of 7.5.0). SIRC timing:
+
+- Unit T = 600us. Leader: 4T mark. Bit: 1T space, then 1T mark (0) or
+  2T mark (1). Data LSB first: 7-bit command, then 5/8/13-bit address
+  (SIRC-12/15/20). Trailer: space padding the frame to 45ms.
+
+Real receivers wobble mark widths across the 1T/2T midpoint's
+neighborhood (the exact failure that motivated this decoder: HAIR's
+generic quantizers fragmented one button into many identities). The
+decoder therefore classifies marks by midpoint (900us) inside generous
+absolute bounds rather than by narrow per-nominal windows, splits the
+capture into frames at the trailer gaps, decodes every frame, and lets
+the majority vote decide -- a capture holding two frames and a truncated
+third still decodes cleanly, and its identity is byte-identical to a
+single-frame capture of the same button.
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Self, override
+
+from . import decode_frames_majority, is_close, split_frames
+from ._base import Command
+
+_UNIT_US = 600
+_LEADER_US = 4 * _UNIT_US
+# Midpoint between the 1T (600us) and 2T (1200us) mark widths.
+_MARK_MIDPOINT_US = 900
+# Sanity bounds for any data mark / space; outside these the frame is
+# rejected rather than classified.
+_MARK_MIN_US = 240
+_MARK_MAX_US = 2100
+_SPACE_MIN_US = 240
+_SPACE_MAX_US = 1200
+# A space at least this long separates SIRC frames (bit spaces are 1T).
+_FRAME_GAP_US = 4000
+_FRAME_PERIOD_US = 45000
+
+_TOTAL_BITS_TO_ADDRESS_BITS = {12: 5, 15: 8, 20: 13}
+
+
+class SonyCommand(Command):
+    """SONY SIRC IR command (12/15/20-bit) with decode support."""
+
+    address: int
+    address_bits: int
+    command: int
+
+    def __init__(
+        self,
+        *,
+        address: int,
+        address_bits: int,
+        command: int,
+        modulation: int = 40000,
+        repeat_count: int = 0,
+    ) -> None:
+        """Initialize the SONY SIRC IR command."""
+        if address_bits not in (5, 8, 13):
+            raise ValueError("SONY SIRC address_bits must be one of 5, 8, or 13")
+        if not 0 <= address < (1 << address_bits):
+            raise ValueError("SONY SIRC address is out of range for address_bits")
+        if not 0 <= command <= 0x7F:
+            raise ValueError("SONY SIRC command must be in range 0x00..0x7F")
+        super().__init__(modulation=modulation, repeat_count=repeat_count)
+        self.address = address
+        self.address_bits = address_bits
+        self.command = command
+
+    @override
+    def get_raw_timings(self) -> list[int]:
+        """Get raw timings for the SONY SIRC command.
+
+        SIRC has no repeat code; ``repeat_count`` re-sends the same frame,
+        each frame occupying the full 45ms period (trailer space pads).
+        """
+        total_bits = 7 + self.address_bits
+        data = self.command | (self.address << 7)
+
+        frame: list[int] = [_LEADER_US]
+        bits = data
+        for _ in range(total_bits):
+            bit = bits & 1
+            frame.append(-_UNIT_US)
+            frame.append(2 * _UNIT_US if bit else _UNIT_US)
+            bits >>= 1
+
+        # Trailer pads each frame to the 45ms period. With repeat_count == 0
+        # this matches the upstream encoder byte-for-byte (asserted in
+        # tests); repeats re-send the identical frame, per the SIRC spec.
+        trailer_low = _FRAME_PERIOD_US - sum(abs(t) for t in frame)
+        timings: list[int] = []
+        for _ in range(self.repeat_count + 1):
+            timings.extend(frame)
+            timings.append(-trailer_low)
+        return timings
+
+    @classmethod
+    def from_raw_timings(cls, timings: list[int]) -> Self | None:
+        """Decode raw IR timings into a SonyCommand.
+
+        Splits the capture into frames at trailer gaps, decodes each frame
+        independently, and returns the majority identity with
+        ``repeat_count`` set to the number of extra agreeing frames.
+        Returns None if no frame decodes as SIRC.
+        """
+        frames = split_frames(timings, _FRAME_GAP_US)
+        result = decode_frames_majority(frames, cls._decode_frame)
+        if result is None:
+            return None
+        (address, address_bits, command), votes = result
+        return cls(
+            address=address,
+            address_bits=address_bits,
+            command=command,
+            repeat_count=votes - 1,
+        )
+
+    @staticmethod
+    def _decode_frame(frame: Sequence[int]) -> tuple[int, int, int] | None:
+        """Decode one SIRC frame to ``(address, address_bits, command)``."""
+        # Leader mark, then (space, mark) per bit.
+        if len(frame) < 1 + 2 * 12:
+            return None
+        if not is_close(frame[0], _LEADER_US):
+            return None
+
+        bits: list[int] = []
+        i = 1
+        while i + 1 < len(frame) and len(bits) < 20:
+            space = -frame[i]
+            mark = frame[i + 1]
+            if not _SPACE_MIN_US <= space <= _SPACE_MAX_US:
+                return None
+            if not _MARK_MIN_US <= mark <= _MARK_MAX_US:
+                return None
+            bits.append(1 if mark > _MARK_MIDPOINT_US else 0)
+            i += 2
+
+        total_bits = len(bits)
+        address_bits = _TOTAL_BITS_TO_ADDRESS_BITS.get(total_bits)
+        if address_bits is None:
+            return None
+        # Any mark left inside the frame means it held more pairs than a
+        # valid SIRC bit count; reject rather than truncate.
+        if any(value > 0 for value in frame[i:]):
+            return None
+
+        data = 0
+        for index, bit in enumerate(bits):
+            data |= bit << index
+        command = data & 0x7F
+        address = data >> 7
+        return (address, address_bits, command)

--- a/custom_components/hair/decoders/symphony.py
+++ b/custom_components/hair/decoders/symphony.py
@@ -1,0 +1,136 @@
+"""Symphony IR command (encode + decode).
+
+Symphony is the rc_switch-family protocol used by ceiling fans, coolers,
+and similar RF-heritage remotes (GH #38, mvdwetering's fan). Not present
+in ``infrared_protocols`` as of 7.5.0 -- this module is fresh territory
+and the upstream donation candidate is the whole file.
+
+Protocol (timing constants per the ESPHome receiver that decodes these
+devices in the field; the code below is written fresh from the spec):
+
+- No header. Bit: 1260us mark + 460us space (1), 460us mark + 1260us
+  space (0). MSB first. Valid frame lengths: 8, 12, or 16 bits.
+- A transmission is the frame re-sent many times while the button is
+  held; frames are separated by a footer gap (~6.9ms) or longer idle.
+- No checksum of any kind.
+
+The missing checksum drives two decode rules. First, a capture must
+contain at least two agreeing frames before it is accepted -- a single
+1260/460-shaped frame is not enough evidence that this is Symphony
+rather than line noise. Second, the majority vote across frames decides
+the identity: several Symphony remotes transmit vendor preamble frames
+(all-zeros, then all-ones) before the button code repeats, and majority
+naturally discards them along with truncated tail frames.
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Self, override
+
+from . import decode_frames_majority, split_frames
+from ._base import Command
+
+_SHORT_US = 460
+_LONG_US = 1260
+# Midpoint between the short (460us) and long (1260us) pulse widths.
+_PULSE_MIDPOINT_US = 860
+_PULSE_MIN_US = 180
+_PULSE_MAX_US = 2200
+# Footer gap between repeated frames: 4 * (460 + 1260).
+_FOOTER_GAP_US = 4 * (_SHORT_US + _LONG_US)
+# Bit spaces top out at 1260us; anything past this separates frames.
+_FRAME_GAP_US = 4000
+
+_VALID_NBITS = (8, 12, 16)
+
+
+class SymphonyCommand(Command):
+    """Symphony IR command (8/12/16-bit, rc_switch family)."""
+
+    data: int
+    nbits: int
+
+    def __init__(
+        self,
+        *,
+        data: int,
+        nbits: int = 12,
+        modulation: int = 38000,
+        repeat_count: int = 0,
+    ) -> None:
+        """Initialize the Symphony IR command."""
+        if nbits not in _VALID_NBITS:
+            raise ValueError("Symphony nbits must be one of 8, 12, or 16")
+        if not 0 <= data < (1 << nbits):
+            raise ValueError("Symphony data is out of range for nbits")
+        super().__init__(modulation=modulation, repeat_count=repeat_count)
+        self.data = data
+        self.nbits = nbits
+
+    @override
+    def get_raw_timings(self) -> list[int]:
+        """Get raw timings for the Symphony command.
+
+        Symphony receivers lock onto a single frame; ``repeat_count``
+        re-sends the frame with the footer gap between repeats, matching
+        how the hardware remotes pad for reliability.
+        """
+        frame: list[int] = []
+        for i in range(self.nbits - 1, -1, -1):
+            bit = (self.data >> i) & 1
+            if bit:
+                frame.extend([_LONG_US, -_SHORT_US])
+            else:
+                frame.extend([_SHORT_US, -_LONG_US])
+
+        timings: list[int] = []
+        for _ in range(self.repeat_count + 1):
+            timings.extend(frame)
+            timings.append(-_FOOTER_GAP_US)
+        return timings
+
+    @classmethod
+    def from_raw_timings(cls, timings: list[int]) -> Self | None:
+        """Decode raw IR timings into a SymphonyCommand.
+
+        Requires at least two agreeing frames (the protocol has no
+        checksum; repetition is the only integrity evidence). Preamble
+        frames and truncated tails lose the majority vote and are
+        discarded. Returns None otherwise.
+        """
+        frames = split_frames(timings, _FRAME_GAP_US)
+        result = decode_frames_majority(frames, cls._decode_frame, min_votes=2)
+        if result is None:
+            return None
+        (data, nbits), votes = result
+        return cls(data=data, nbits=nbits, repeat_count=votes - 1)
+
+    @staticmethod
+    def _decode_frame(frame: Sequence[int]) -> tuple[int, int] | None:
+        """Decode one Symphony frame to ``(data, nbits)``."""
+        # Each bit is a (mark, space) pair; the final space may be the
+        # (stripped) footer gap, so a frame ending on a mark is valid.
+        marks = frame[0::2]
+        spaces = frame[1::2]
+        if len(marks) not in _VALID_NBITS:
+            return None
+
+        bits: list[int] = []
+        for index, mark in enumerate(marks):
+            if mark <= 0 or not _PULSE_MIN_US <= mark <= _PULSE_MAX_US:
+                return None
+            long_mark = mark > _PULSE_MIDPOINT_US
+            if index < len(spaces):
+                space = -spaces[index]
+                if not _PULSE_MIN_US <= space <= _PULSE_MAX_US:
+                    return None
+                # Mark and space widths must disagree (one long, one
+                # short); equal-width pairs are not Symphony bits.
+                if (space > _PULSE_MIDPOINT_US) == long_mark:
+                    return None
+            bits.append(1 if long_mark else 0)
+
+        data = 0
+        for bit in bits:
+            data = (data << 1) | bit
+        return (data, len(bits))

--- a/custom_components/hair/device_manager.py
+++ b/custom_components/hair/device_manager.py
@@ -140,7 +140,7 @@ class DeviceManager:
         from .event_parser import EventParser
         from .ir_command import ProntoCommand
         from .pronto_validator import validate_pronto
-        from .protocol_decode import decode_to_fields
+        from .protocol_decode import try_decode_identity
 
         device = self._store.get_device(device_id)
         if device is None:
@@ -201,12 +201,11 @@ class DeviceManager:
                 raw = ProntoCommand(new_code).get_raw_timings()
             except Exception:  # bad code falls back to no decoded timings
                 raw = None
-            (
-                decoded_protocol,
-                decoded_address,
-                decoded_command,
-                decoded_fingerprint,
-            ) = decode_to_fields(raw)
+            identity = try_decode_identity(raw)
+            decoded_protocol = identity.protocol if identity else None
+            decoded_address = identity.address if identity else None
+            decoded_command = identity.command if identity else None
+            decoded_fingerprint = identity.fingerprint if identity else None
             command.protocol = "PRONTO"
             command.code = new_code
             command.raw_timings = list(raw) if raw else None
@@ -220,6 +219,9 @@ class DeviceManager:
             command.decoded_address = decoded_address
             command.decoded_command = decoded_command
             command.decoded_fingerprint = decoded_fingerprint
+            command.decoded_extras = (
+                dict(identity.extras) if identity and identity.extras else None
+            )
             # Rewire on ANY identity component changing (v0.5.8): a
             # sub-threshold edit shifts only the byte_hash, never the S/L
             # fingerprint, and would otherwise orphan a scoped trigger.
@@ -394,7 +396,9 @@ class DeviceManager:
                 command.decoded_address,
                 command.decoded_command,
                 repeat_count=command.repeat_count or 0,
+                decoded_extras=command.decoded_extras,
             )
+        decoded_tx = ir_cmd is not None
         if ir_cmd is None:
             ir_cmd = build_command(
                 protocol=command.protocol,
@@ -413,6 +417,22 @@ class DeviceManager:
                 await asyncio.sleep(SEND_REPEAT_GAP)
             for emitter_id in device.emitter_entity_ids:
                 await ir_send(self._hass, emitter_id, ir_cmd)
+
+        # RC-5-family toggle state (v0.6.0): one send-command call is one
+        # logical press, so flip once after the full emitter loop completes
+        # without raising -- send_count > 1 deliberately re-sends the same
+        # toggle. The decoded fingerprint excludes toggle, so the reverse
+        # index is unaffected and a bare save is safe.
+        if (
+            decoded_tx
+            and command.decoded_extras
+            and "toggle" in command.decoded_extras
+        ):
+            command.decoded_extras["toggle"] = (
+                int(command.decoded_extras["toggle"]) ^ 1
+            )
+            self._store.update_device(device)
+            await self._store.async_save()
 
     async def async_set_command_tx_force_raw(
         self, device_id: str, command_id: str, tx_force_raw: bool

--- a/custom_components/hair/diagnostics.py
+++ b/custom_components/hair/diagnostics.py
@@ -10,6 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
+from .protocol_decode import registered_protocols
 
 REDACT_KEYS = {"raw_timings", "code"}
 
@@ -53,6 +54,7 @@ async def async_get_config_entry_diagnostics(
         "devices": devices,
         "is_capturing": getattr(orchestrator, "is_capturing", False),
         "infrared_protocols_version": version,
+        "protocol_registry": registered_protocols(),
         "decoded_commands": {
             "total": decoded_total,
             "by_protocol": dict(decoded_by_protocol),

--- a/custom_components/hair/frontend/dist/ha-panel-ir-devices.js
+++ b/custom_components/hair/frontend/dist/ha-panel-ir-devices.js
@@ -6598,7 +6598,7 @@ function e(e,t,i,s){var o,a=arguments.length,r=a<3?t:null===s?s=Object.getOwnPro
                       ></ir-add-device-dialog>
                   `:""}
 
-            <div class="version-footer">v${"0.5.8"}</div>
+            <div class="version-footer">v${"0.6.0"}</div>
             </ha-top-app-bar-fixed>
         `:B`<div class="loading">Loading…</div>`}};fs.styles=r`
         :host {

--- a/custom_components/hair/frontend/src/ha-panel-ir-devices.ts
+++ b/custom_components/hair/frontend/src/ha-panel-ir-devices.ts
@@ -18,7 +18,7 @@ import type { DeviceSummary, IRDevice } from "./types.js";
 // Bump alongside manifest.json on every release. Surfaced as a quiet
 // footer line at the bottom of the panel so users (and bug reporters)
 // can identify the installed HAIR version without opening Settings.
-const HAIR_VERSION = "0.5.8";
+const HAIR_VERSION = "0.6.0";
 
 type PanelTab = "devices" | "sniffer" | "clips" | "plucker";
 

--- a/custom_components/hair/frontend/src/types.ts
+++ b/custom_components/hair/frontend/src/types.ts
@@ -56,6 +56,9 @@ export interface IRCommand {
     // its button (e.g. NEC).
     decoded_protocol?: string | null;
     decoded_fingerprint?: string | null;
+    // Protocol state beyond the identity (v0.6.0): RC-5/Marantz toggle,
+    // Sharp extension. Server-managed; surfaced for display only.
+    decoded_extras?: Record<string, number> | null;
     // Byte-level identity (v0.3.4 tiebreaker; identity since v0.5.8).
     // Was missing from this interface -- the device-detail trigger dialog
     // reads it -- which surfaced as a TS2339 build warning.
@@ -197,6 +200,7 @@ export interface UnknownSignal {
     decoded_address?: number | null;
     decoded_command?: number | null;
     decoded_fingerprint?: string | null;
+    decoded_extras?: Record<string, number> | null;
     // User-tunable TX knobs (mirror IRCommand) plus the capture-side ditto
     // observation surfaced as an editor hint.
     repeat_count?: number;
@@ -271,6 +275,7 @@ export interface PluckedSignalPreview {
     decoded_address?: number | null;
     decoded_command?: number | null;
     decoded_fingerprint?: string | null;
+    decoded_extras?: Record<string, number> | null;
     plucked_command_name: string;
     suggested_alias: string;
 }

--- a/custom_components/hair/ir_command.py
+++ b/custom_components/hair/ir_command.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 
 import logging
 
-from .const import DECODED_PROTOCOL_NEC
-
 try:
     from infrared_protocols import Command
 except ImportError:  # test environment without infrared_protocols
@@ -188,29 +186,29 @@ def build_decoded_command(
     decoded_command: int | None,
     *,
     repeat_count: int = 0,
+    decoded_extras: dict[str, int] | None = None,
 ) -> Command | None:
     """Build a protocol-native Command from decoded fields, or ``None``.
 
-    Returns a canonical-timing Command (NEC today) when the decoded fields
-    are present and the library is available, so transmit re-encodes clean
-    timings instead of replaying captured (receiver-distorted) ones -- the
-    frafall (GH #14) fix. Returns ``None`` when the protocol is
-    unsupported, a field is missing, or the library is unavailable, so the
-    caller falls back to Pronto/raw replay.
+    Returns a canonical-timing Command when the decoded protocol is
+    registered on the rebuild tier, so transmit re-encodes clean timings
+    instead of replaying captured (receiver-distorted) ones -- the
+    frafall (GH #14) fix, generalized to every registered protocol in
+    v0.6.0. ``decoded_extras`` carries protocol state the re-encode
+    needs (RC-5/Marantz toggle, Sharp extension). Returns ``None`` when
+    the protocol is unregistered, identity-only, a field is missing, or
+    the library is unavailable, so the caller falls back to Pronto/raw
+    replay.
     """
-    if (
-        decoded_protocol != DECODED_PROTOCOL_NEC
-        or decoded_address is None
-        or decoded_command is None
-    ):
-        return None
-    try:
-        from infrared_protocols.commands.nec import NECCommand
-    except ImportError:
-        return None
-    try:
-        cmd = NECCommand(address=decoded_address, command=decoded_command)
-    except (TypeError, ValueError):
+    from .protocol_decode import build_protocol_command
+
+    cmd = build_protocol_command(
+        decoded_protocol,
+        decoded_address,
+        decoded_command,
+        extras=decoded_extras,
+    )
+    if cmd is None:
         return None
     if repeat_count:
         cmd.repeat_count = repeat_count

--- a/custom_components/hair/manifest.json
+++ b/custom_components/hair/manifest.json
@@ -1,7 +1,7 @@
 {
     "domain": "hair",
     "name": "HAIR",
-    "version": "0.5.8",
+    "version": "0.6.0",
     "documentation": "https://github.com/DAB-LABS/HAIR",
     "issue_tracker": "https://github.com/DAB-LABS/HAIR/issues",
     "dependencies": ["infrared"],

--- a/custom_components/hair/models.py
+++ b/custom_components/hair/models.py
@@ -56,6 +56,11 @@ class IRCommand:
     decoded_address: int | None = None
     decoded_command: int | None = None
     decoded_fingerprint: str | None = None
+    # Protocol state the decoded re-encode needs beyond the identity
+    # triple (v0.6.0): RC-5/Marantz toggle, Sharp extension. Plain dict,
+    # no schema; None for protocols without extras and for commands
+    # stored before v0.6.0.
+    decoded_extras: dict[str, int] | None = None
     # Per-command opt-out: when True, TX replays the captured Pronto rather
     # than re-encoding from the decoded value. Default False, so a command
     # with decoded fields transmits canonical timings unless the user
@@ -84,6 +89,9 @@ class IRCommand:
             "decoded_address": self.decoded_address,
             "decoded_command": self.decoded_command,
             "decoded_fingerprint": self.decoded_fingerprint,
+            "decoded_extras": dict(self.decoded_extras)
+            if self.decoded_extras
+            else None,
             "tx_force_raw": self.tx_force_raw,
             "plucked_command_name": self.plucked_command_name,
             "created_at": self.created_at,
@@ -107,6 +115,7 @@ class IRCommand:
             decoded_address=data.get("decoded_address"),
             decoded_command=data.get("decoded_command"),
             decoded_fingerprint=data.get("decoded_fingerprint"),
+            decoded_extras=data.get("decoded_extras") or None,
             tx_force_raw=bool(data.get("tx_force_raw", False)),
             plucked_command_name=data.get("plucked_command_name"),
             created_at=data.get("created_at") or _now_iso(),
@@ -254,6 +263,9 @@ class IRDevice:
                 # (decoded_*) on the clone.
                 byte_hash=cmd.byte_hash,
                 decoded_protocol=cmd.decoded_protocol,
+                decoded_extras=(
+                    dict(cmd.decoded_extras) if cmd.decoded_extras else None
+                ),
                 decoded_address=cmd.decoded_address,
                 decoded_command=cmd.decoded_command,
                 decoded_fingerprint=cmd.decoded_fingerprint,
@@ -624,6 +636,10 @@ class UnknownSignal:
     decoded_address: int | None = None
     decoded_command: int | None = None
     decoded_fingerprint: str | None = None
+    # Protocol state beyond the identity triple (v0.6.0): RC-5/Marantz
+    # toggle, Sharp extension. Carried onto the IRCommand at assign time
+    # via _apply_signal_provenance so decoded TX can re-encode it.
+    decoded_extras: dict[str, int] | None = None
     protocol: str | None = None
     code: str | None = None
     raw_timings: list[int] = field(default_factory=list)
@@ -658,6 +674,9 @@ class UnknownSignal:
             "decoded_address": self.decoded_address,
             "decoded_command": self.decoded_command,
             "decoded_fingerprint": self.decoded_fingerprint,
+            "decoded_extras": dict(self.decoded_extras)
+            if self.decoded_extras
+            else None,
             "protocol": self.protocol,
             "code": self.code,
             "raw_timings": list(self.raw_timings),
@@ -690,6 +709,7 @@ class UnknownSignal:
             decoded_address=data.get("decoded_address"),
             decoded_command=data.get("decoded_command"),
             decoded_fingerprint=data.get("decoded_fingerprint"),
+            decoded_extras=data.get("decoded_extras") or None,
             protocol=data.get("protocol"),
             code=data.get("code"),
             raw_timings=data.get("raw_timings") or [],

--- a/custom_components/hair/pluck.py
+++ b/custom_components/hair/pluck.py
@@ -58,6 +58,7 @@ def _normalized_to_dict(
         "decoded_address": n.decoded_address,
         "decoded_command": n.decoded_command,
         "decoded_fingerprint": n.decoded_fingerprint,
+        "decoded_extras": dict(n.decoded_extras) if n.decoded_extras else None,
         "plucked_command_name": command_name,
         "suggested_alias": suggested_alias,
     }

--- a/custom_components/hair/protocol_decode.py
+++ b/custom_components/hair/protocol_decode.py
@@ -1,69 +1,470 @@
-"""NEC protocol decoding via Home Assistant's bundled infrared-protocols.
+"""Protocol decode registry: decoded identity for captured IR signals.
 
-Phase A of the protocols integration (v0.4.0): HAIR decodes captured
-signals as NEC when the library can read them and stores the decoded
-identity alongside the raw Pronto, so later releases can match by decoded
-fingerprint and transmit canonical timings instead of replaying captured
-(receiver-distorted) timings.
+v0.4.0 decoded NEC through Home Assistant's bundled ``infrared-protocols``
+library. v0.6.0 generalizes that into a registry (multi-protocol decoder
+plan, Section 4.1) fed from two sources, probed in this order per
+protocol:
 
-The library is consumed via HA core's ``infrared`` dependency -- there is
-no ``manifest.json`` pin. All access is guarded so a missing or
-restructured library degrades cleanly to "no decode" rather than breaking
-the capture path. Adding a protocol is a one-line addition to
-``try_decode`` once the library ships that protocol's ``from_raw_timings``
-classmethod.
+1. **Upstream**: the bundled ``infrared_protocols`` class, used whenever
+   it ships a ``from_raw_timings`` decoder (feature-detected, never
+   version-pinned). What upstream can decode, upstream decodes.
+2. **Local**: HAIR's own decoder in ``custom_components/hair/decoders/``,
+   the polyfill used until the upstream library gains that protocol's
+   decoder (local-first strategy, plan Section 6). Local classes are
+   upstream-shaped, and their encoders are asserted byte-identical to
+   upstream's, so which source serves a protocol is invisible to stored
+   identity and to transmit.
+
+A protocol whose class cannot be imported from either source is skipped
+with a DEBUG log -- silent-skip is correct for "user's HA ships an older
+library", wrong for a typo'd class name, and the log plus the
+``registered_protocols()`` diagnostics listing tell the two apart.
+
+The decoded fingerprint is formatted in exactly one place
+(:func:`format_fingerprint`); nothing outside this module may assemble
+one by hand. The NEC format is byte-identical to every release since
+v0.4.0, so existing stored identities keep matching with zero migration.
+Toggle bits (RC-5, Marantz) are press state, not identity, and are
+excluded from the fingerprint; Sharp's extension bit and Marantz's
+extension field are identity and are folded in via a per-protocol
+suffix. Protocol variants that change the frame's bit count (SIRC-12/15/20,
+Kaseikyo/Symphony widths) are folded into the protocol label itself, so
+the ``(protocol, address, command)`` triple plus the label is always a
+complete identity.
 """
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
 
 from .const import DECODED_FINGERPRINT_FORMAT, DECODED_PROTOCOL_NEC
 
 _LOGGER = logging.getLogger(__name__)
 
-try:
-    from infrared_protocols.commands.nec import NECCommand
+# ---------------------------------------------------------------------------
+# Identity container
+# ---------------------------------------------------------------------------
 
-    _HAS_NEC = hasattr(NECCommand, "from_raw_timings")
-except ImportError:
-    NECCommand = None  # type: ignore[assignment,misc]
-    _HAS_NEC = False
+
+@dataclass(frozen=True)
+class DecodedIdentity:
+    """Rich decode result: the four decoded_* fields plus state extras."""
+
+    protocol: str
+    address: int
+    command: int
+    fingerprint: str
+    extras: dict[str, int] | None
+    source: str  # "upstream" | "local"
+
+
+# ---------------------------------------------------------------------------
+# Protocol specs
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProtocolSpec:
+    """One registered protocol: its class, its adapters, its tier."""
+
+    key: str  # stable registry key, e.g. "sony"
+    command_cls: type
+    source: str  # "upstream" | "local"
+    tx_rebuild: bool
+    # Adapters bridging the class's fields and HAIR's identity triple.
+    extract: Any  # Callable[[command], (label, address, command, extras|None)]
+    construct: Any  # Callable[[label, address, command, extras|None], command|None]
+    labels: tuple[str, ...] = field(default=())  # labels this spec serves
+
+
+def _import_class(module_name: str, class_name: str) -> type | None:
+    """Import a command class, returning None when unavailable."""
+    try:
+        module = __import__(module_name, fromlist=[class_name])
+    except ImportError:
+        return None
+    return getattr(module, class_name, None)
+
+
+def _resolve_class(
+    protocol_key: str, upstream_module: str | None, class_name: str,
+    local_module: str | None,
+) -> tuple[type, str] | None:
+    """Feature-detect the decoding class for a protocol.
+
+    Upstream wins when it can decode; the local polyfill covers the gap;
+    None (with a DEBUG log) when neither source provides the class.
+    """
+    if upstream_module is not None:
+        cls = _import_class(upstream_module, class_name)
+        if cls is not None and hasattr(cls, "from_raw_timings"):
+            return (cls, "upstream")
+    if local_module is not None:
+        cls = _import_class(local_module, class_name)
+        if cls is not None and hasattr(cls, "from_raw_timings"):
+            return (cls, "local")
+    _LOGGER.debug(
+        "protocol %s not registered: no decoding class %s available "
+        "(upstream=%s, local=%s)",
+        protocol_key, class_name, upstream_module, local_module,
+    )
+    return None
+
+
+# --- per-protocol adapters --------------------------------------------------
+
+_SONY_ADDRESS_BITS_TO_TOTAL = {5: 12, 8: 15, 13: 20}
+_SONY_TOTAL_TO_ADDRESS_BITS = {12: 5, 15: 8, 20: 13}
+
+
+def _extract_nec(cmd: Any) -> tuple[str, int, int, dict[str, int] | None]:
+    return (DECODED_PROTOCOL_NEC, int(cmd.address), int(cmd.command), None)
+
+
+def _construct_nec(cls: type, label: str, address: int, command: int,
+                   extras: Any) -> Any:
+    return cls(address=address, command=command)
+
+
+def _extract_sony(cmd: Any) -> tuple[str, int, int, dict[str, int] | None]:
+    total = _SONY_ADDRESS_BITS_TO_TOTAL[int(cmd.address_bits)]
+    return (f"SONY{total}", int(cmd.address), int(cmd.command), None)
+
+
+def _construct_sony(cls: type, label: str, address: int, command: int,
+                    extras: Any) -> Any:
+    try:
+        total_bits = int(label[4:])
+    except ValueError:
+        return None
+    address_bits = _SONY_TOTAL_TO_ADDRESS_BITS.get(total_bits)
+    if address_bits is None:
+        return None
+    return cls(address=address, address_bits=address_bits, command=command)
+
+
+def _extract_samsung(cmd: Any) -> tuple[str, int, int, dict[str, int] | None]:
+    return ("SAMSUNG32", int(cmd.address), int(cmd.command), None)
+
+
+def _construct_samsung(cls: type, label: str, address: int, command: int,
+                       extras: Any) -> Any:
+    return cls(address=address, command=command)
+
+
+def _extract_rc5(cmd: Any) -> tuple[str, int, int, dict[str, int] | None]:
+    return ("RC5", int(cmd.address), int(cmd.command), {"toggle": int(cmd.toggle)})
+
+
+def _construct_rc5(cls: type, label: str, address: int, command: int,
+                   extras: Any) -> Any:
+    toggle = int((extras or {}).get("toggle", 0))
+    return cls(address=address, command=command, toggle=toggle & 1)
+
+
+def _extract_sharp(cmd: Any) -> tuple[str, int, int, dict[str, int] | None]:
+    extension = int(cmd.extension)
+    return ("SHARP", int(cmd.address), int(cmd.command),
+            {"extension": extension} if extension else None)
+
+
+def _construct_sharp(cls: type, label: str, address: int, command: int,
+                     extras: Any) -> Any:
+    extension = int((extras or {}).get("extension", 0))
+    return cls(address=address, command=command, extension=extension & 1)
+
+
+def _extract_marantz(cmd: Any) -> tuple[str, int, int, dict[str, int] | None]:
+    return ("MARANTZ", int(cmd.address), int(cmd.command),
+            {"extension": int(cmd.extension), "toggle": int(cmd.toggle)})
+
+
+def _construct_marantz(cls: type, label: str, address: int, command: int,
+                       extras: Any) -> Any:
+    bag = extras or {}
+    return cls(
+        address=address,
+        command=command,
+        extension=int(bag.get("extension", 0)),
+        toggle=int(bag.get("toggle", 0)) & 1,
+    )
+
+
+def _extract_kaseikyo(cmd: Any) -> tuple[str, int, int, dict[str, int] | None]:
+    payload = bytes(cmd.data)
+    total_bits = 8 * (2 + len(payload))
+    return (
+        f"KASEIKYO{total_bits}",
+        int(cmd.address),
+        int.from_bytes(payload, "big"),
+        None,
+    )
+
+
+def _construct_kaseikyo(cls: type, label: str, address: int, command: int,
+                        extras: Any) -> Any:
+    try:
+        total_bits = int(label[8:])
+    except ValueError:
+        return None
+    payload_len = total_bits // 8 - 2
+    if payload_len < 1:
+        return None
+    return cls(address=address, data=command.to_bytes(payload_len, "big"))
+
+
+def _extract_symphony(cmd: Any) -> tuple[str, int, int, dict[str, int] | None]:
+    return (f"SYMPHONY{int(cmd.nbits)}", 0, int(cmd.data), None)
+
+
+def _construct_symphony(cls: type, label: str, address: int, command: int,
+                        extras: Any) -> Any:
+    try:
+        nbits = int(label[8:])
+    except ValueError:
+        return None
+    return cls(data=command, nbits=nbits)
+
+
+def _extract_geac(cmd: Any) -> tuple[str, int, int, dict[str, int] | None]:
+    return ("GEAC", int(cmd.address), int(cmd.command), None)
+
+
+def _construct_geac(cls: type, label: str, address: int, command: int,
+                    extras: Any) -> Any:
+    # Identity-only tier: GE-AC transmit always replays the captured raw
+    # (plan finding B6) -- decoded identity is for matching only.
+    return None
+
+
+# --- fingerprint suffixes (identity-bearing extras) --------------------------
+
+# Per-protocol identity suffix appended to the base fingerprint. Toggle
+# never appears here: it flips per press and would split one button into
+# two identities.
+def _identity_suffix(protocol: str, extras: Mapping[str, int] | None) -> str:
+    if not extras:
+        return ""
+    if protocol == "SHARP" and extras.get("extension"):
+        return ":x1"
+    if protocol == "MARANTZ":
+        return f":x{int(extras.get('extension', 0)):02x}"
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+# (key, upstream module, class name, local module, tx_rebuild, extract,
+#  construct, label prefix) -- probe order is registration order: strict
+# checksum-validated protocols first, checksum-free last, and specific
+# formats ahead of their generic parents (plan finding B6).
+_REGISTRATIONS: tuple[tuple, ...] = (
+    ("nec", "infrared_protocols.commands.nec", "NECCommand",
+     None, True, _extract_nec, _construct_nec, (DECODED_PROTOCOL_NEC,)),
+    ("samsung32", "infrared_protocols.commands.samsung", "Samsung32Command",
+     "custom_components.hair.decoders.samsung", True,
+     _extract_samsung, _construct_samsung, ("SAMSUNG32",)),
+    ("sony", "infrared_protocols.commands.sony", "SonyCommand",
+     "custom_components.hair.decoders.sony", True,
+     _extract_sony, _construct_sony, ("SONY12", "SONY15", "SONY20")),
+    ("sharp", "infrared_protocols.commands.sharp", "SharpCommand",
+     "custom_components.hair.decoders.sharp", True,
+     _extract_sharp, _construct_sharp, ("SHARP",)),
+    ("marantz", "infrared_protocols.commands.marantz_extended",
+     "MarantzExtendedCommand",
+     "custom_components.hair.decoders.marantz_extended", True,
+     _extract_marantz, _construct_marantz, ("MARANTZ",)),
+    ("rc5", "infrared_protocols.commands.rc5", "RC5Command",
+     "custom_components.hair.decoders.rc5", True,
+     _extract_rc5, _construct_rc5, ("RC5",)),
+    ("kaseikyo", "infrared_protocols.commands.kaseikyo", "KaseikyoCommand",
+     "custom_components.hair.decoders.kaseikyo", True,
+     _extract_kaseikyo, _construct_kaseikyo, ("KASEIKYO",)),
+    ("geac", "infrared_protocols.commands.general_electric", "GEACCommand",
+     None, False, _extract_geac, _construct_geac, ("GEAC",)),
+    ("symphony", None, "SymphonyCommand",
+     "custom_components.hair.decoders.symphony", True,
+     _extract_symphony, _construct_symphony, ("SYMPHONY",)),
+)
+
+_registry: list[ProtocolSpec] | None = None
+
+
+def _build_registry() -> list[ProtocolSpec]:
+    """Build the ordered spec list by feature-detecting each protocol."""
+    specs: list[ProtocolSpec] = []
+    for (key, upstream_module, class_name, local_module, tx_rebuild,
+         extract, construct, labels) in _REGISTRATIONS:
+        resolved = _resolve_class(key, upstream_module, class_name, local_module)
+        if resolved is None:
+            continue
+        cls, source = resolved
+        specs.append(
+            ProtocolSpec(
+                key=key,
+                command_cls=cls,
+                source=source,
+                tx_rebuild=tx_rebuild,
+                extract=extract,
+                construct=construct,
+                labels=labels,
+            )
+        )
+    return specs
+
+
+def _ensure_registry() -> list[ProtocolSpec]:
+    """Lazily build the registry (import-time builds hurt the test matrix)."""
+    global _registry
+    if _registry is None:
+        _registry = _build_registry()
+    return _registry
+
+
+def _reset_registry_for_tests() -> None:
+    """Drop the cached registry so tests can rebuild under monkeypatching."""
+    global _registry
+    _registry = None
+
+
+def get_spec(protocol: str | None) -> ProtocolSpec | None:
+    """Resolve a decoded-protocol label to its registered spec, or None.
+
+    Labels either match a spec exactly ("NEC", "RC5", "SHARP") or start
+    with the spec's registered prefix carrying a bit-count variant
+    ("SONY15", "KASEIKYO48", "SYMPHONY12").
+    """
+    if not protocol:
+        return None
+    for spec in _ensure_registry():
+        for label in spec.labels:
+            if protocol == label or (
+                protocol.startswith(label) and protocol[len(label):].isdigit()
+            ):
+                return spec
+    return None
+
+
+def registered_protocols() -> list[dict[str, Any]]:
+    """Describe the live registry for diagnostics: key, source, tier."""
+    return [
+        {
+            "protocol": spec.key,
+            "source": spec.source,
+            "tx_rebuild": spec.tx_rebuild,
+        }
+        for spec in _ensure_registry()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Public decode / format API
+# ---------------------------------------------------------------------------
 
 
 def library_available() -> bool:
-    """Return True if the NEC decoder is importable and usable."""
-    return _HAS_NEC
+    """Return True if the upstream NEC decoder is importable and usable."""
+    cls = _import_class("infrared_protocols.commands.nec", "NECCommand")
+    return cls is not None and hasattr(cls, "from_raw_timings")
+
+
+def format_fingerprint(
+    protocol: str,
+    address: int,
+    command: int,
+    extras: Mapping[str, int] | None = None,
+) -> str:
+    """Format the decoded fingerprint -- the single place that does.
+
+    The base template is byte-identical to the v0.4.0 NEC format;
+    identity-bearing extras (Sharp extension, Marantz extension) append a
+    per-protocol suffix. Toggle state never participates.
+    """
+    base = DECODED_FINGERPRINT_FORMAT.format(
+        protocol=protocol, address=address, command=command
+    )
+    return base + _identity_suffix(protocol, extras)
+
+
+def try_decode_identity(raw_timings: list[int] | None) -> DecodedIdentity | None:
+    """Decode raw timings into a :class:`DecodedIdentity`, or ``None``.
+
+    Probes the registry in order; the first protocol whose decoder
+    accepts the capture wins. Decoders validate their protocols'
+    checksums and structure, so a match is a real identification, not a
+    guess. Never raises into the capture hot path.
+    """
+    if not raw_timings:
+        return None
+    for spec in _ensure_registry():
+        try:
+            cmd = spec.command_cls.from_raw_timings(list(raw_timings))
+        except Exception:  # never break capture on a malformed-input error
+            continue
+        if cmd is None:
+            continue
+        try:
+            protocol, address, command, extras = spec.extract(cmd)
+        except (AttributeError, TypeError, ValueError):
+            continue
+        return DecodedIdentity(
+            protocol=protocol,
+            address=address,
+            command=command,
+            fingerprint=format_fingerprint(protocol, address, command, extras),
+            extras=extras,
+            source=spec.source,
+        )
+    return None
+
+
+def identity_from_command(command: Any) -> DecodedIdentity | None:
+    """Derive decoded identity from an existing Command instance.
+
+    Used by the code library / Plucker surfaces that already hold a
+    library (or local) Command object rather than raw timings. Specs are
+    matched by class name so an upstream encode-only instance (e.g. a
+    pluckable built from the upstream SonyCommand) still resolves to the
+    protocol's registered spec and gets the same label and fingerprint a
+    captured signal would.
+    """
+    if command is None:
+        return None
+    name = type(command).__name__
+    for spec in _ensure_registry():
+        if name != spec.command_cls.__name__ and not isinstance(
+            command, spec.command_cls
+        ):
+            continue
+        try:
+            protocol, address, cmd_val, extras = spec.extract(command)
+        except (AttributeError, TypeError, ValueError, KeyError):
+            return None
+        return DecodedIdentity(
+            protocol=protocol,
+            address=address,
+            command=cmd_val,
+            fingerprint=format_fingerprint(protocol, address, cmd_val, extras),
+            extras=extras,
+            source=spec.source,
+        )
+    return None
 
 
 def try_decode(raw_timings: list[int] | None) -> tuple[str, int, int] | None:
     """Decode raw IR timings to ``(protocol, address, command)`` or ``None``.
 
-    Probes NEC today. Returns the protocol-family label, the 16-bit
-    address, and the 8-bit command data byte (NOT the wire-packed
-    ``(command << 8) | ~command`` form ESPHome's ``transmit_nec`` accepts),
-    so a stored ``decoded_command`` of ``0x08`` reads the way the user
-    expects when correlating with the protocol layer.
-
-    Returns ``None`` when the timings are absent, the library is
-    unavailable, or no probed protocol matches. The library validates
-    NEC's command-inverse checksum, so a non-match is a real reject, not a
-    guess. Never raises into the capture hot path.
+    Kept for callers (and tests) that predate the richer
+    :func:`try_decode_identity`; identical probe behavior.
     """
-    if not raw_timings or not _HAS_NEC:
+    identity = try_decode_identity(raw_timings)
+    if identity is None:
         return None
-
-    try:
-        nec = NECCommand.from_raw_timings(list(raw_timings))
-    except Exception:  # never break capture on a malformed-input decode error
-        return None
-
-    if nec is None:
-        return None
-
-    try:
-        return (DECODED_PROTOCOL_NEC, int(nec.address), int(nec.command))
-    except (AttributeError, TypeError, ValueError):
-        return None
+    return (identity.protocol, identity.address, identity.command)
 
 
 def decode_to_fields(
@@ -71,17 +472,40 @@ def decode_to_fields(
 ) -> tuple[str | None, int | None, int | None, str | None]:
     """Decode raw timings into the four ``decoded_*`` fields, or all-None.
 
-    Wraps ``try_decode`` and formats the decoded fingerprint, so capture,
-    paste, edit, and backfill all derive the decoded identity through one
-    path and cannot drift. Returns ``(protocol, address, command,
-    fingerprint)``; all ``None`` when the timings are absent, the library is
-    unavailable, or nothing decodes. Never raises.
+    Wraps :func:`try_decode_identity` and keeps the original 4-tuple
+    contract (plan finding B3: callers that need extras migrate to
+    ``try_decode_identity`` deliberately, one at a time). Never raises.
     """
-    decoded = try_decode(raw_timings)
-    if decoded is None:
+    identity = try_decode_identity(raw_timings)
+    if identity is None:
         return (None, None, None, None)
-    protocol, address, command = decoded
-    fingerprint = DECODED_FINGERPRINT_FORMAT.format(
-        protocol=protocol, address=address, command=command
+    return (
+        identity.protocol,
+        identity.address,
+        identity.command,
+        identity.fingerprint,
     )
-    return (protocol, address, command, fingerprint)
+
+
+def build_protocol_command(
+    protocol: str | None,
+    address: int | None,
+    command: int | None,
+    *,
+    extras: Mapping[str, int] | None = None,
+) -> Any | None:
+    """Build a protocol-native Command from decoded fields, or ``None``.
+
+    Returns None when the protocol is unregistered, the spec is
+    identity-only (``tx_rebuild=False``), a field is missing, or the
+    class rejects the values -- callers fall back to Pronto/raw replay.
+    """
+    if protocol is None or address is None or command is None:
+        return None
+    spec = get_spec(protocol)
+    if spec is None or not spec.tx_rebuild:
+        return None
+    try:
+        return spec.construct(spec.command_cls, protocol, address, command, extras)
+    except (TypeError, ValueError, OverflowError):
+        return None

--- a/custom_components/hair/signal_monitor.py
+++ b/custom_components/hair/signal_monitor.py
@@ -60,7 +60,7 @@ from .event_parser import EventParser
 from .ir_command import raw_to_pronto
 from .models import CaptureResult, UnknownDevice, UnknownSignal
 from .pronto_validator import validate_pronto
-from .protocol_decode import decode_to_fields
+from .protocol_decode import try_decode_identity
 from .signal_store import SignalStore
 from .storage import HAIRStore
 
@@ -89,6 +89,7 @@ class NormalizedSignal:
     decoded_address: int | None
     decoded_command: int | None
     decoded_fingerprint: str | None
+    decoded_extras: dict[str, int] | None
 
 
 def normalize(parsed: Any) -> NormalizedSignal:
@@ -118,12 +119,7 @@ def normalize(parsed: Any) -> NormalizedSignal:
     # matcher can key on the decoded fingerprint and the TX path can
     # re-encode canonical timings. None for undecodable signals or when the
     # library is unavailable.
-    (
-        decoded_protocol,
-        decoded_address,
-        decoded_command,
-        decoded_fingerprint,
-    ) = decode_to_fields(parsed.raw_timings)
+    identity = try_decode_identity(parsed.raw_timings)
     return NormalizedSignal(
         protocol=parsed.protocol,
         code=parsed.code,
@@ -133,10 +129,13 @@ def normalize(parsed: Any) -> NormalizedSignal:
         device_address=device_address,
         dev_fp=dev_fp,
         byte_hash=byte_hash,
-        decoded_protocol=decoded_protocol,
-        decoded_address=decoded_address,
-        decoded_command=decoded_command,
-        decoded_fingerprint=decoded_fingerprint,
+        decoded_protocol=identity.protocol if identity else None,
+        decoded_address=identity.address if identity else None,
+        decoded_command=identity.command if identity else None,
+        decoded_fingerprint=identity.fingerprint if identity else None,
+        decoded_extras=(
+            dict(identity.extras) if identity and identity.extras else None
+        ),
     )
 
 
@@ -194,6 +193,9 @@ def _apply_signal_provenance(
     command.decoded_address = signal.decoded_address
     command.decoded_command = signal.decoded_command
     command.decoded_fingerprint = signal.decoded_fingerprint
+    command.decoded_extras = (
+        dict(signal.decoded_extras) if signal.decoded_extras else None
+    )
     if repeat_count is not None:
         command.repeat_count = max(0, min(int(repeat_count), MAX_DITTO_COUNT))
     else:
@@ -737,6 +739,7 @@ class SignalMonitor:
         decoded_address = n.decoded_address
         decoded_command = n.decoded_command
         decoded_fingerprint = n.decoded_fingerprint
+        decoded_extras = n.decoded_extras
 
         # Step 2: Check triggers (before known-command skip so triggers
         # work for both assigned commands and unknown signals). Threads the
@@ -819,6 +822,9 @@ class SignalMonitor:
                     decoded_address=decoded_address,
                     decoded_command=decoded_command,
                     decoded_fingerprint=decoded_fingerprint,
+                    decoded_extras=(
+                        dict(decoded_extras) if decoded_extras else None
+                    ),
                     protocol=parsed.protocol,
                     code=parsed.code,
                     raw_timings=list(parsed.raw_timings) if parsed.raw_timings else [],
@@ -1419,7 +1425,9 @@ class SignalMonitor:
                 signal.decoded_address,
                 signal.decoded_command,
                 repeat_count=signal.repeat_count or 0,
+                decoded_extras=signal.decoded_extras,
             )
+        decoded_tx = ir_cmd is not None
         if ir_cmd is None:
             try:
                 ir_cmd = build_command(
@@ -1452,6 +1460,20 @@ class SignalMonitor:
         except Exception as exc:
             return {"success": False, "code": "send_failed",
                     "error": f"Emitter did not respond: {exc}"}
+
+        # RC-5-family toggle state (v0.6.0): mirror
+        # device_manager.async_send_command -- one Test is one logical
+        # press, flipped once after a fully successful send. Fingerprint
+        # excludes toggle, so the catalog row's identity is unchanged.
+        if (
+            decoded_tx
+            and signal.decoded_extras
+            and "toggle" in signal.decoded_extras
+        ):
+            signal.decoded_extras["toggle"] = (
+                int(signal.decoded_extras["toggle"]) ^ 1
+            )
+            await self._signal_store.async_save()
 
         return {"success": True}
 
@@ -1540,12 +1562,14 @@ class SignalMonitor:
                 decode_raw = ProntoCommand(code).get_raw_timings()
             except Exception:
                 decode_raw = None
-            (
-                decoded_protocol,
-                decoded_address,
-                decoded_command,
-                decoded_fingerprint,
-            ) = decode_to_fields(decode_raw)
+            identity = try_decode_identity(decode_raw)
+            decoded_protocol = identity.protocol if identity else None
+            decoded_address = identity.address if identity else None
+            decoded_command = identity.command if identity else None
+            decoded_fingerprint = identity.fingerprint if identity else None
+            decoded_extras = (
+                dict(identity.extras) if identity and identity.extras else None
+            )
 
             # Reject a paste of a signal already on this remote. The match
             # is the tiered identity rule (decoded > byte_hash > S/L
@@ -1573,6 +1597,9 @@ class SignalMonitor:
                 decoded_address=decoded_address,
                 decoded_command=decoded_command,
                 decoded_fingerprint=decoded_fingerprint,
+                decoded_extras=(
+                    dict(decoded_extras) if decoded_extras else None
+                ),
                 protocol="PRONTO",
                 code=code,
                 raw_timings=[],
@@ -1672,12 +1699,14 @@ class SignalMonitor:
                 decode_raw = ProntoCommand(code).get_raw_timings()
             except Exception:
                 decode_raw = None
-            (
-                decoded_protocol,
-                decoded_address,
-                decoded_command,
-                decoded_fingerprint,
-            ) = decode_to_fields(decode_raw)
+            identity = try_decode_identity(decode_raw)
+            decoded_protocol = identity.protocol if identity else None
+            decoded_address = identity.address if identity else None
+            decoded_command = identity.command if identity else None
+            decoded_fingerprint = identity.fingerprint if identity else None
+            decoded_extras = (
+                dict(identity.extras) if identity and identity.extras else None
+            )
 
             # Tiered duplicate guard (matches the paste/edit/capture paths):
             # a re-encoding of an already-plucked command is refused even
@@ -1701,6 +1730,9 @@ class SignalMonitor:
                 decoded_address=decoded_address,
                 decoded_command=decoded_command,
                 decoded_fingerprint=decoded_fingerprint,
+                decoded_extras=(
+                    dict(decoded_extras) if decoded_extras else None
+                ),
                 protocol="PRONTO",
                 code=code,
                 raw_timings=[],
@@ -1774,12 +1806,14 @@ class SignalMonitor:
                 raw = ProntoCommand(code).get_raw_timings()
             except Exception:
                 raw = None
-            (
-                decoded_protocol,
-                decoded_address,
-                decoded_command,
-                decoded_fingerprint,
-            ) = decode_to_fields(raw)
+            identity = try_decode_identity(raw)
+            decoded_protocol = identity.protocol if identity else None
+            decoded_address = identity.address if identity else None
+            decoded_command = identity.command if identity else None
+            decoded_fingerprint = identity.fingerprint if identity else None
+            decoded_extras = (
+                dict(identity.extras) if identity and identity.extras else None
+            )
 
             # Refuse a code a *different* signal on this remote already holds
             # (tiered identity, so a jittered re-paste of an existing button
@@ -1822,6 +1856,7 @@ class SignalMonitor:
             signal.decoded_address = decoded_address
             signal.decoded_command = decoded_command
             signal.decoded_fingerprint = decoded_fingerprint
+            signal.decoded_extras = decoded_extras
             if alias is not None:
                 signal.alias = alias.strip()
             if repeat_count is not None:
@@ -1904,6 +1939,7 @@ class SignalMonitor:
                     decoded_address=entry.get("decoded_address"),
                     decoded_command=entry.get("decoded_command"),
                     decoded_fingerprint=entry.get("decoded_fingerprint"),
+                    decoded_extras=entry.get("decoded_extras") or None,
                     protocol="PRONTO",
                     code=code,
                     raw_timings=[],

--- a/custom_components/hair/signal_store.py
+++ b/custom_components/hair/signal_store.py
@@ -152,9 +152,8 @@ class SignalStore:
         # decode the stored raw timings (or timings derived from the
         # Pronto code) and populate the identity. Non-decodable signals are
         # left untouched. Idempotent across restarts.
-        from .const import DECODED_FINGERPRINT_FORMAT
         from .ir_command import ProntoCommand
-        from .protocol_decode import try_decode
+        from .protocol_decode import try_decode_identity
 
         decoded_backfilled = 0
         for device in self._devices.values():
@@ -167,15 +166,15 @@ class SignalStore:
                         raw = ProntoCommand(sig.code).get_raw_timings()
                     except (ValueError, IndexError):
                         raw = None
-                decoded = try_decode(raw)
-                if decoded is None:
+                identity = try_decode_identity(raw)
+                if identity is None:
                     continue
-                protocol, address, command = decoded
-                sig.decoded_protocol = protocol
-                sig.decoded_address = address
-                sig.decoded_command = command
-                sig.decoded_fingerprint = DECODED_FINGERPRINT_FORMAT.format(
-                    protocol=protocol, address=address, command=command
+                sig.decoded_protocol = identity.protocol
+                sig.decoded_address = identity.address
+                sig.decoded_command = identity.command
+                sig.decoded_fingerprint = identity.fingerprint
+                sig.decoded_extras = (
+                    dict(identity.extras) if identity.extras else None
                 )
                 decoded_backfilled += 1
         if decoded_backfilled:

--- a/custom_components/hair/storage.py
+++ b/custom_components/hair/storage.py
@@ -334,7 +334,7 @@ class HAIRStore:
         carries a ``decoded_fingerprint`` is skipped.
         """
         from .ir_command import ProntoCommand
-        from .protocol_decode import decode_to_fields
+        from .protocol_decode import try_decode_identity
 
         changed = 0
         for device in self._data.values():
@@ -347,13 +347,16 @@ class HAIRStore:
                         raw = ProntoCommand(cmd.code).get_raw_timings()
                     except (ValueError, IndexError):
                         raw = None
-                protocol, address, command, fingerprint = decode_to_fields(raw)
-                if fingerprint is None:
+                identity = try_decode_identity(raw)
+                if identity is None:
                     continue
-                cmd.decoded_protocol = protocol
-                cmd.decoded_address = address
-                cmd.decoded_command = command
-                cmd.decoded_fingerprint = fingerprint
+                cmd.decoded_protocol = identity.protocol
+                cmd.decoded_address = identity.address
+                cmd.decoded_command = identity.command
+                cmd.decoded_fingerprint = identity.fingerprint
+                cmd.decoded_extras = (
+                    dict(identity.extras) if identity.extras else None
+                )
                 changed += 1
         if changed:
             _LOGGER.info(

--- a/custom_components/hair/tests/test_capture_dittos.py
+++ b/custom_components/hair/tests/test_capture_dittos.py
@@ -228,7 +228,9 @@ async def test_test_signal_honors_repeat_count(fake_hass):
     ):
         res = await monitor.test_signal("s1", "infrared.e")
     assert res["success"]
-    bdc.assert_called_once_with("NEC", 0x1000, 0x18, repeat_count=3)
+    bdc.assert_called_once_with(
+        "NEC", 0x1000, 0x18, repeat_count=3, decoded_extras=None
+    )
 
 
 @pytest.mark.asyncio
@@ -267,7 +269,9 @@ async def test_test_signal_composes_repeat_and_send(fake_hass):
     ):
         res = await monitor.test_signal("s1", "infrared.e")
     assert res["success"]
-    bdc.assert_called_once_with("NEC", 0x1000, 0x18, repeat_count=5)
+    bdc.assert_called_once_with(
+        "NEC", 0x1000, 0x18, repeat_count=5, decoded_extras=None
+    )
     assert ir_send.await_count == 3
 
 

--- a/custom_components/hair/tests/test_decoded_tx_consistency.py
+++ b/custom_components/hair/tests/test_decoded_tx_consistency.py
@@ -30,6 +30,7 @@ from custom_components.hair.models import (
     UnknownDevice,
     UnknownSignal,
 )
+from custom_components.hair.protocol_decode import DecodedIdentity
 from custom_components.hair.signal_monitor import (
     SignalMonitor,
     _apply_signal_provenance,
@@ -255,7 +256,9 @@ async def test_catalog_test_uses_decoded_when_available(fake_hass):
     assert result["success"] is True
     # test_signal now forwards the signal's repeat_count (default 1) to the
     # decoded build (v0.5.5 ditto-honoring Test path).
-    bdc.assert_called_once_with("NEC", 0x1000, 0x18, repeat_count=1)
+    bdc.assert_called_once_with(
+        "NEC", 0x1000, 0x18, repeat_count=1, decoded_extras=None
+    )
     bc.assert_not_called()
     ir_send.assert_awaited_once()
     assert ir_send.call_args[0][2] is sentinel
@@ -342,8 +345,11 @@ async def test_save_captured_command_decodes_at_save(fake_hass):
     conn = _make_connection()
 
     with patch(
-        "custom_components.hair.protocol_decode.decode_to_fields",
-        return_value=("NEC", 0x1000, 0x18, "NEC:0x1000:0x18"),
+        "custom_components.hair.protocol_decode.try_decode_identity",
+        return_value=DecodedIdentity(
+            protocol="NEC", address=0x1000, command=0x18,
+            fingerprint="NEC:0x1000:0x18", extras=None, source="upstream",
+        ),
     ):
         await ws_save_captured_command(
             fake_hass,
@@ -381,8 +387,8 @@ async def test_save_captured_command_non_nec_leaves_fields_none(fake_hass):
     conn = _make_connection()
 
     with patch(
-        "custom_components.hair.protocol_decode.decode_to_fields",
-        return_value=(None, None, None, None),
+        "custom_components.hair.protocol_decode.try_decode_identity",
+        return_value=None,
     ):
         await ws_save_captured_command(
             fake_hass,

--- a/custom_components/hair/tests/test_decoders.py
+++ b/custom_components/hair/tests/test_decoders.py
@@ -213,6 +213,69 @@ class TestRoundTrips:
             extension,
         )
 
+    def test_sharp_lone_halves_decode_to_same_identity(self):
+        """The 40ms mid-pair trailer splits real captures, so each half
+        must decode alone -- and both halves of one press must agree
+        (field finding: Sharp hardware via the Athom receiver delivers
+        one half per capture)."""
+        full = SharpCommand(
+            address=0x01, command=0x68, extension=0
+        ).get_raw_timings()
+        # The pair is two 32-entry frames; split them apart.
+        data_half, inverted_half = full[:32], full[32:]
+        a = SharpCommand.from_raw_timings(data_half)
+        b = SharpCommand.from_raw_timings(inverted_half)
+        assert a is not None and b is not None
+        assert (a.address, a.command, a.extension) == (0x01, 0x68, 0)
+        assert (b.address, b.command, b.extension) == (0x01, 0x68, 0)
+
+    def test_sharp_real_capture_fixtures(self):
+        """Real Sharp-remote captures (test-bench Athom receiver,
+        2026-07-17): lone inverted halves with receiver-shifted mark
+        widths (342us and 263us against the nominal 320us)."""
+        real = {
+            # (address, command, extension) -> Pronto capture
+            (0x01, 0x14, 1): (
+                "0000 006D 0010 0000 000D 0042 000D 001A 000D 001A 000D "
+                "001A 000D 001A 000D 0042 000D 0042 000D 001A 000D 0042 "
+                "000D 001A 000D 0042 000D 0042 000D 0042 000D 001A 000D "
+                "0042 000D 017C"
+            ),
+            (0x11, 0x4B, 1): (
+                "0000 006D 0010 0000 000A 0046 000A 001E 000A 001E 000A "
+                "001E 000A 0046 000A 001E 000A 001E 000A 0046 000A 001E "
+                "000A 0046 000A 0046 000A 001E 000A 0046 000A 001E 000A "
+                "0046 000A 017C"
+            ),
+        }
+        for (address, command, extension), code in real.items():
+            words = [int(w, 16) for w in code.split()]
+            period = words[1] * 0.241246
+            raw: list[int] = []
+            for i in range(words[2]):
+                mark, space = words[4 + 2 * i], words[5 + 2 * i]
+                raw.append(round(mark * period))
+                if space:
+                    raw.append(-round(space * period))
+            decoded = SharpCommand.from_raw_timings(raw)
+            assert decoded is not None, f"real capture {address:#x} refused"
+            assert (decoded.address, decoded.command, decoded.extension) == (
+                address,
+                command,
+                extension,
+            )
+
+    def test_sharp_mark_constancy_rejects_mixed_marks(self):
+        """With the check bit spent on half-detection, mark constancy is
+        the structural gate: a 15-pair frame whose marks vary wildly is
+        not Sharp."""
+        frame: list[int] = []
+        for i in range(15):
+            frame.append(320 if i % 2 else 640)  # alternating mark widths
+            frame.append(-680)
+        frame.append(320)
+        assert SharpCommand.from_raw_timings(frame) is None
+
     def test_sharp_repeats(self):
         encoded = SharpCommand(
             address=0x01, command=0x68, extension=1, repeat_count=1

--- a/custom_components/hair/tests/test_decoders.py
+++ b/custom_components/hair/tests/test_decoders.py
@@ -1,0 +1,466 @@
+"""Tests for the local decoder package (shave-and-a-haircut).
+
+Three layers per protocol:
+
+1. Encoder parity -- the local encoder's output is byte-identical to the
+   upstream ``infrared_protocols`` encoder (where upstream ships one), so
+   the registry swapping between the classes can never change what is
+   transmitted. Skipped on Python legs without the library.
+2. Round-trips -- encode with either encoder, decode with the local
+   decoder, recover the identical fields, including repeat counts from
+   multi-frame captures.
+3. Rejection -- clean frames of every other protocol, and NEC frames,
+   must decode to None. Cross-protocol acceptance is how wrong-decoder
+   bugs corrupt stored identities, so the full matrix is asserted.
+
+Dirty-capture cases (receiver jitter, truncated tails, vendor preamble
+frames) are built from the field reports that motivated each decoder.
+"""
+from __future__ import annotations
+
+import importlib.util
+import itertools
+
+import pytest
+
+from custom_components.hair.decoders.kaseikyo import KaseikyoCommand
+from custom_components.hair.decoders.marantz_extended import MarantzExtendedCommand
+from custom_components.hair.decoders.rc5 import RC5Command
+from custom_components.hair.decoders.samsung import Samsung32Command
+from custom_components.hair.decoders.sharp import SharpCommand
+from custom_components.hair.decoders.sony import SonyCommand
+from custom_components.hair.decoders.symphony import SymphonyCommand
+
+_HAS_LIBRARY = importlib.util.find_spec("infrared_protocols") is not None
+
+_needs_library = pytest.mark.skipif(
+    not _HAS_LIBRARY,
+    reason="infrared-protocols unavailable (requires Python 3.13+)",
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Encoder parity with upstream
+# ---------------------------------------------------------------------------
+
+
+@_needs_library
+class TestEncoderParity:
+    """Local encoders are byte-identical to upstream encoders."""
+
+    def test_sony(self):
+        from infrared_protocols.commands.sony import SonyCommand as Upstream
+
+        for address_bits, address, command in (
+            (5, 0x01, 0x15),
+            (8, 0xA5, 0x69),
+            (13, 0x1A5A, 0x2E),
+        ):
+            local = SonyCommand(
+                address=address, address_bits=address_bits, command=command
+            )
+            upstream = Upstream(
+                address=address, address_bits=address_bits, command=command
+            )
+            assert local.get_raw_timings() == upstream.get_raw_timings()
+            assert local.modulation == upstream.modulation
+
+    def test_rc5_standard_and_rc5x(self):
+        from infrared_protocols.commands.rc5 import RC5Command as Upstream
+
+        for address, command, toggle, repeats in (
+            (5, 0x35, 1, 0),
+            (0x1F, 0x75, 0, 2),  # bit 6 set: RC5X encoding
+            (0, 0, 0, 1),
+        ):
+            local = RC5Command(
+                address=address, command=command, toggle=toggle, repeat_count=repeats
+            )
+            upstream = Upstream(
+                address=address, command=command, toggle=toggle, repeat_count=repeats
+            )
+            assert local.get_raw_timings() == upstream.get_raw_timings()
+            assert local.modulation == upstream.modulation
+
+    def test_samsung(self):
+        from infrared_protocols.commands.samsung import Samsung32Command as Upstream
+
+        for address, command, repeats in ((0x07, 0x02, 0), (0x1234, 0xAB, 2)):
+            local = Samsung32Command(
+                address=address, command=command, repeat_count=repeats
+            )
+            upstream = Upstream(address=address, command=command, repeat_count=repeats)
+            assert local.get_raw_timings() == upstream.get_raw_timings()
+
+    def test_sharp(self):
+        from infrared_protocols.commands.sharp import SharpCommand as Upstream
+
+        local = SharpCommand(address=0x01, command=0x68, extension=1)
+        upstream = Upstream(address=0x01, command=0x68, extension=1)
+        assert local.get_raw_timings() == upstream.get_raw_timings()
+
+    def test_kaseikyo(self):
+        from infrared_protocols.commands.kaseikyo import KaseikyoCommand as Upstream
+
+        payload = bytes([0x40, 0x04, 0x01, 0x00])
+        local = KaseikyoCommand(address=0x2002, data=payload, repeat_count=1)
+        upstream = Upstream(address=0x2002, data=payload, repeat_count=1)
+        assert local.get_raw_timings() == upstream.get_raw_timings()
+
+    def test_marantz(self):
+        from infrared_protocols.commands.marantz_extended import (
+            MarantzExtendedCommand as Upstream,
+        )
+
+        local = MarantzExtendedCommand(
+            address=0x10, command=0x0C, extension=0x20, toggle=1, repeat_count=2
+        )
+        upstream = Upstream(
+            address=0x10, command=0x0C, extension=0x20, toggle=1, repeat_count=2
+        )
+        assert local.get_raw_timings() == upstream.get_raw_timings()
+
+
+# ---------------------------------------------------------------------------
+# 2. Round-trips
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrips:
+    """encode -> decode recovers identical fields."""
+
+    @pytest.mark.parametrize(
+        ("address_bits", "address", "command"),
+        [(5, 0x01, 0x15), (8, 0xA5, 0x69), (13, 0x1A5A, 0x2E), (5, 0, 0)],
+    )
+    def test_sony(self, address_bits, address, command):
+        encoded = SonyCommand(
+            address=address, address_bits=address_bits, command=command
+        ).get_raw_timings()
+        decoded = SonyCommand.from_raw_timings(encoded)
+        assert decoded is not None
+        assert (decoded.address, decoded.address_bits, decoded.command) == (
+            address,
+            address_bits,
+            command,
+        )
+        assert decoded.repeat_count == 0
+
+    def test_sony_multi_frame_repeats(self):
+        encoded = SonyCommand(
+            address=0xA5, address_bits=8, command=0x69, repeat_count=3
+        ).get_raw_timings()
+        decoded = SonyCommand.from_raw_timings(encoded)
+        assert decoded is not None
+        assert decoded.repeat_count == 3
+        assert (decoded.address, decoded.command) == (0xA5, 0x69)
+
+    @pytest.mark.parametrize(
+        ("address", "command", "toggle"),
+        [(5, 0x35, 1), (0x1F, 0x75, 0), (0, 0, 0), (0x0A, 0x40, 1)],
+    )
+    def test_rc5(self, address, command, toggle):
+        encoded = RC5Command(
+            address=address, command=command, toggle=toggle
+        ).get_raw_timings()
+        decoded = RC5Command.from_raw_timings(encoded)
+        assert decoded is not None
+        assert (decoded.address, decoded.command, decoded.toggle) == (
+            address,
+            command,
+            toggle,
+        )
+
+    def test_rc5_repeats(self):
+        encoded = RC5Command(
+            address=5, command=0x35, toggle=1, repeat_count=2
+        ).get_raw_timings()
+        decoded = RC5Command.from_raw_timings(encoded)
+        assert decoded is not None
+        assert decoded.repeat_count == 2
+
+    @pytest.mark.parametrize(
+        ("address", "command"),
+        [(0x07, 0x02), (0x1234, 0xAB), (0, 0), (0xFF, 0xFF)],
+    )
+    def test_samsung(self, address, command):
+        encoded = Samsung32Command(address=address, command=command).get_raw_timings()
+        decoded = Samsung32Command.from_raw_timings(encoded)
+        assert decoded is not None
+        assert (decoded.address, decoded.command) == (address, command)
+
+    def test_samsung_repeats(self):
+        encoded = Samsung32Command(
+            address=0x07, command=0x02, repeat_count=2
+        ).get_raw_timings()
+        decoded = Samsung32Command.from_raw_timings(encoded)
+        assert decoded is not None
+        assert decoded.repeat_count == 2
+
+    @pytest.mark.parametrize(
+        ("address", "command", "extension"),
+        [(0x01, 0x68, 1), (0x1F, 0x00, 0), (0, 0xFF, 0)],
+    )
+    def test_sharp(self, address, command, extension):
+        encoded = SharpCommand(
+            address=address, command=command, extension=extension
+        ).get_raw_timings()
+        decoded = SharpCommand.from_raw_timings(encoded)
+        assert decoded is not None
+        assert (decoded.address, decoded.command, decoded.extension) == (
+            address,
+            command,
+            extension,
+        )
+
+    def test_sharp_repeats(self):
+        encoded = SharpCommand(
+            address=0x01, command=0x68, extension=1, repeat_count=1
+        ).get_raw_timings()
+        decoded = SharpCommand.from_raw_timings(encoded)
+        assert decoded is not None
+        assert decoded.repeat_count == 1
+
+    @pytest.mark.parametrize(
+        ("address", "payload"),
+        [
+            (0x2002, bytes([0x40, 0x04, 0x01, 0x00])),  # Panasonic-shaped, 48-bit
+            (0x0301, bytes([0xF0, 0xAA])),
+        ],
+    )
+    def test_kaseikyo(self, address, payload):
+        encoded = KaseikyoCommand(address=address, data=payload).get_raw_timings()
+        decoded = KaseikyoCommand.from_raw_timings(encoded)
+        assert decoded is not None
+        assert decoded.address == address
+        assert bytes(decoded.data) == payload
+
+    def test_kaseikyo_data_low_nibble_is_parity_domain(self):
+        """The constructor discards data[0]'s low nibble; decode returns 0 there."""
+        encoded = KaseikyoCommand(
+            address=0x2002, data=bytes([0x4F, 0x04])
+        ).get_raw_timings()
+        decoded = KaseikyoCommand.from_raw_timings(encoded)
+        assert decoded is not None
+        assert bytes(decoded.data) == bytes([0x40, 0x04])
+        # Re-encoding reproduces the identical wire frame.
+        assert (
+            KaseikyoCommand(
+                address=0x2002, data=bytes(decoded.data)
+            ).get_raw_timings()
+            == encoded
+        )
+
+    def test_kaseikyo_nec_style_repeats(self):
+        encoded = KaseikyoCommand(
+            address=0x2002, data=bytes([0x40, 0x04, 0x01, 0x00]), repeat_count=2
+        ).get_raw_timings()
+        decoded = KaseikyoCommand.from_raw_timings(encoded)
+        assert decoded is not None
+        assert decoded.repeat_count == 2
+
+    @pytest.mark.parametrize(
+        ("address", "command", "extension", "toggle"),
+        [(0x10, 0x0C, 0x20, 1), (0x10, 0x4C, 0x20, 1), (0, 0, 0, 0)],
+    )
+    def test_marantz(self, address, command, extension, toggle):
+        encoded = MarantzExtendedCommand(
+            address=address, command=command, extension=extension, toggle=toggle
+        ).get_raw_timings()
+        decoded = MarantzExtendedCommand.from_raw_timings(encoded)
+        assert decoded is not None
+        assert (
+            decoded.address,
+            decoded.command,
+            decoded.extension,
+            decoded.toggle,
+        ) == (address, command, extension, toggle)
+
+    def test_symphony(self):
+        encoded = SymphonyCommand(data=0xC00, nbits=12, repeat_count=3).get_raw_timings()
+        decoded = SymphonyCommand.from_raw_timings(encoded)
+        assert decoded is not None
+        assert (decoded.data, decoded.nbits, decoded.repeat_count) == (0xC00, 12, 3)
+
+    def test_symphony_rejects_single_frame(self):
+        """No checksum, so one frame is not enough evidence."""
+        encoded = SymphonyCommand(data=0xC00, nbits=12).get_raw_timings()
+        assert SymphonyCommand.from_raw_timings(encoded) is None
+
+    def test_symphony_majority_discards_vendor_preambles(self):
+        """Real remotes send 0x000 / 0xFFF preamble frames first (GH #38)."""
+        preamble_a = SymphonyCommand(data=0x000, nbits=12).get_raw_timings()
+        preamble_b = SymphonyCommand(data=0xFFF, nbits=12).get_raw_timings()
+        button = SymphonyCommand(data=0xC00, nbits=12, repeat_count=4).get_raw_timings()
+        decoded = SymphonyCommand.from_raw_timings(preamble_a + preamble_b + button)
+        assert decoded is not None
+        assert (decoded.data, decoded.nbits) == (0xC00, 12)
+        assert decoded.repeat_count == 4
+
+
+# ---------------------------------------------------------------------------
+# 3. Dirty captures: jitter, truncation, mixed frames
+# ---------------------------------------------------------------------------
+
+
+def _jitter(timings: list[int], stretch_marks_us: int, shrink_spaces_us: int) -> list[int]:
+    """Simulate receiver AGC: marks stretch, spaces shrink."""
+    out: list[int] = []
+    for value in timings:
+        if value > 0:
+            out.append(value + stretch_marks_us)
+        else:
+            out.append(min(-1, value + shrink_spaces_us))
+    return out
+
+
+class TestDirtyCaptures:
+    """Receiver-shaped distortions must not change decoded identity."""
+
+    @pytest.mark.parametrize("stretch", [-120, -60, 60, 120, 180])
+    def test_sony_jitter(self, stretch):
+        clean = SonyCommand(
+            address=0xA5, address_bits=8, command=0x69, repeat_count=2
+        ).get_raw_timings()
+        dirty = _jitter(clean, stretch, -stretch)
+        decoded = SonyCommand.from_raw_timings(dirty)
+        assert decoded is not None
+        assert (decoded.address, decoded.command) == (0xA5, 0x69)
+
+    def test_sony_truncated_tail_frame(self):
+        """A capture window that cuts the last frame mid-bit still decodes."""
+        clean = SonyCommand(
+            address=0xA5, address_bits=8, command=0x69, repeat_count=2
+        ).get_raw_timings()
+        truncated = clean[:-7]  # chop into the final frame
+        decoded = SonyCommand.from_raw_timings(truncated)
+        assert decoded is not None
+        assert (decoded.address, decoded.command) == (0xA5, 0x69)
+
+    def test_sony_variable_frame_count_same_identity(self):
+        """Hypothesis A from the field reports: 2-frame and 3-frame captures
+        of one button must decode to the same identity."""
+        two = SonyCommand.from_raw_timings(
+            SonyCommand(
+                address=0xA5, address_bits=8, command=0x69, repeat_count=1
+            ).get_raw_timings()
+        )
+        three = SonyCommand.from_raw_timings(
+            SonyCommand(
+                address=0xA5, address_bits=8, command=0x69, repeat_count=2
+            ).get_raw_timings()
+        )
+        assert two is not None and three is not None
+        assert (two.address, two.address_bits, two.command) == (
+            three.address,
+            three.address_bits,
+            three.command,
+        )
+
+    @pytest.mark.parametrize("stretch", [-100, 100, 200])
+    def test_samsung_jitter(self, stretch):
+        clean = Samsung32Command(address=0x07, command=0x02).get_raw_timings()
+        decoded = Samsung32Command.from_raw_timings(_jitter(clean, stretch, -stretch))
+        assert decoded is not None
+        assert (decoded.address, decoded.command) == (0x07, 0x02)
+
+    @pytest.mark.parametrize("stretch", [-100, 100, 200])
+    def test_rc5_jitter(self, stretch):
+        clean = RC5Command(address=5, command=0x35, toggle=1).get_raw_timings()
+        decoded = RC5Command.from_raw_timings(_jitter(clean, stretch, -stretch))
+        assert decoded is not None
+        assert (decoded.address, decoded.command) == (5, 0x35)
+
+    @pytest.mark.parametrize("stretch", [-60, 60, 120])
+    def test_sharp_jitter(self, stretch):
+        clean = SharpCommand(address=0x01, command=0x68).get_raw_timings()
+        decoded = SharpCommand.from_raw_timings(_jitter(clean, stretch, -stretch))
+        assert decoded is not None
+        assert (decoded.address, decoded.command) == (0x01, 0x68)
+
+    @pytest.mark.parametrize("stretch", [-80, 80, 140])
+    def test_kaseikyo_jitter(self, stretch):
+        clean = KaseikyoCommand(
+            address=0x2002, data=bytes([0x40, 0x04, 0x01, 0x00])
+        ).get_raw_timings()
+        decoded = KaseikyoCommand.from_raw_timings(_jitter(clean, stretch, -stretch))
+        assert decoded is not None
+        assert decoded.address == 0x2002
+
+    @pytest.mark.parametrize("stretch", [-100, 100, 200])
+    def test_symphony_jitter(self, stretch):
+        clean = SymphonyCommand(data=0xC00, nbits=12, repeat_count=3).get_raw_timings()
+        decoded = SymphonyCommand.from_raw_timings(_jitter(clean, stretch, -stretch))
+        assert decoded is not None
+        assert (decoded.data, decoded.nbits) == (0xC00, 12)
+
+
+# ---------------------------------------------------------------------------
+# 4. Rejection matrix
+# ---------------------------------------------------------------------------
+
+_DECODERS = {
+    "sony": SonyCommand,
+    "rc5": RC5Command,
+    "samsung": Samsung32Command,
+    "sharp": SharpCommand,
+    "kaseikyo": KaseikyoCommand,
+    "marantz": MarantzExtendedCommand,
+    "symphony": SymphonyCommand,
+}
+
+
+def _samples() -> dict[str, list[int]]:
+    return {
+        "sony": SonyCommand(
+            address=0xA5, address_bits=8, command=0x69, repeat_count=2
+        ).get_raw_timings(),
+        "rc5": RC5Command(address=5, command=0x35, repeat_count=2).get_raw_timings(),
+        "samsung": Samsung32Command(
+            address=0x07, command=0x02, repeat_count=2
+        ).get_raw_timings(),
+        "sharp": SharpCommand(
+            address=0x01, command=0x68, repeat_count=1
+        ).get_raw_timings(),
+        "kaseikyo": KaseikyoCommand(
+            address=0x2002, data=bytes([0x40, 0x04, 0x01, 0x00]), repeat_count=1
+        ).get_raw_timings(),
+        "marantz": MarantzExtendedCommand(
+            address=0x10, command=0x0C, extension=0x20, repeat_count=2
+        ).get_raw_timings(),
+        "symphony": SymphonyCommand(
+            data=0xC00, nbits=12, repeat_count=3
+        ).get_raw_timings(),
+    }
+
+
+class TestRejectionMatrix:
+    """No decoder may accept another protocol's clean transmission."""
+
+    @pytest.mark.parametrize(
+        ("sample_name", "decoder_name"),
+        [
+            (s, d)
+            for s, d in itertools.product(_DECODERS, _DECODERS)
+            if s != d
+        ],
+    )
+    def test_cross_rejection(self, sample_name, decoder_name):
+        sample = _samples()[sample_name]
+        assert _DECODERS[decoder_name].from_raw_timings(sample) is None
+
+    @_needs_library
+    @pytest.mark.parametrize("decoder_name", sorted(_DECODERS))
+    def test_nec_rejected_by_all(self, decoder_name):
+        from infrared_protocols.commands.nec import NECCommand
+
+        nec = NECCommand(address=0x04, command=0x08, repeat_count=2).get_raw_timings()
+        assert _DECODERS[decoder_name].from_raw_timings(nec) is None
+
+    @pytest.mark.parametrize("decoder_name", sorted(_DECODERS))
+    def test_garbage_rejected(self, decoder_name):
+        assert _DECODERS[decoder_name].from_raw_timings([]) is None
+        assert _DECODERS[decoder_name].from_raw_timings([100]) is None
+        assert (
+            _DECODERS[decoder_name].from_raw_timings([1000, -1000] * 200) is None
+        )

--- a/custom_components/hair/tests/test_decoders.py
+++ b/custom_components/hair/tests/test_decoders.py
@@ -314,6 +314,21 @@ class TestRoundTrips:
             == encoded
         )
 
+    def test_kaseikyo_trailing_subgap_space_tolerated(self):
+        """A small trailing space after the end pulse (below the frame-gap
+        threshold, so it stays glued to the frame) must not be misread as
+        a 49th bit's space -- field finding from bench loopback codes."""
+        clean = KaseikyoCommand(
+            address=0x2002, data=bytes([0x80, 0x00, 0x3D, 0xBD])
+        ).get_raw_timings()
+        # Replace the 10ms trailer-adjacent tail with a 368us stray space.
+        assert clean[-1] > 0  # ends on the end pulse mark
+        dirty = [*clean, -368]
+        decoded = KaseikyoCommand.from_raw_timings(dirty)
+        assert decoded is not None
+        assert decoded.address == 0x2002
+        assert bytes(decoded.data) == bytes([0x80, 0x00, 0x3D, 0xBD])
+
     def test_kaseikyo_nec_style_repeats(self):
         encoded = KaseikyoCommand(
             address=0x2002, data=bytes([0x40, 0x04, 0x01, 0x00]), repeat_count=2

--- a/custom_components/hair/tests/test_device_manager.py
+++ b/custom_components/hair/tests/test_device_manager.py
@@ -328,8 +328,8 @@ class TestUpdateCommand:
         assert manager._store.match_command(None, old_fp, None) == (dev.id, "c1")
 
         with patch(
-            "custom_components.hair.protocol_decode.decode_to_fields",
-            return_value=(None, None, None, None),
+            "custom_components.hair.protocol_decode.try_decode_identity",
+            return_value=None,
         ):
             result = await manager.async_update_command(
                 dev.id, "c1", pronto=_CODE_LONG
@@ -428,8 +428,8 @@ class TestUpdateCommand:
         tm = TriggerManager(manager._hass, manager._store)
 
         with patch(
-            "custom_components.hair.protocol_decode.decode_to_fields",
-            return_value=(None, None, None, None),
+            "custom_components.hair.protocol_decode.try_decode_identity",
+            return_value=None,
         ):
             result = await manager.async_update_command(
                 dev.id, "c1", pronto=_CODE_LONG, trigger_manager=tm

--- a/custom_components/hair/tests/test_protocol_registry.py
+++ b/custom_components/hair/tests/test_protocol_registry.py
@@ -1,0 +1,328 @@
+"""Tests for the v0.6.0 protocol decode registry.
+
+Covers the multi-protocol decoder plan's acceptance set: registry
+contents against the CI library version (finding B2), single-formatter
+fingerprints with per-protocol suffix rules (N2/N3), end-to-end decode
+through ``try_decode_identity``, TX rebuild dispatch including the
+identity-only tier (B6), decoded_extras flow, and the field regression
+that motivated the release: repeat presses of one Sony button must
+produce ONE decoded identity regardless of frame count (hypothesis A)
+or mark-width jitter (hypothesis B).
+"""
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from custom_components.hair.decoders.rc5 import RC5Command
+from custom_components.hair.decoders.sharp import SharpCommand
+from custom_components.hair.decoders.sony import SonyCommand
+from custom_components.hair.decoders.symphony import SymphonyCommand
+from custom_components.hair.ir_command import ProntoCommand, build_decoded_command
+from custom_components.hair.protocol_decode import (
+    build_protocol_command,
+    format_fingerprint,
+    get_spec,
+    identity_from_command,
+    registered_protocols,
+    try_decode_identity,
+)
+
+_HAS_LIBRARY = importlib.util.find_spec("infrared_protocols") is not None
+_HAS_GEAC = (
+    importlib.util.find_spec("infrared_protocols.commands.general_electric")
+    is not None
+    if _HAS_LIBRARY
+    else False
+)
+
+_needs_library = pytest.mark.skipif(
+    not _HAS_LIBRARY,
+    reason="infrared-protocols unavailable (requires Python 3.13+)",
+)
+
+# Real SIRC-15 capture fixtures (loic.gouraud's remote family; see
+# test_unified_identity for provenance). PASTED is the clean editor
+# paste; RECEIVED is the live capture whose long marks crossed the S/L
+# threshold (0x2E/0x2F -> 0x30/0x31) -- the byte_hash flip pair.
+PASTED_YELLOW = (
+    "0000 006D 0010 0000 005D 0016 002E 0017 002E 0017 002F 0016 0017 "
+    "0017 0017 0017 002E 0017 0018 0016 002E 0017 002E 0017 002F 0016 "
+    "0017 0017 002E 0017 0017 0017 0018 0016 002E 0181"
+)
+RECEIVED_YELLOW = PASTED_YELLOW.replace("002E", "0030").replace("002F", "0031")
+
+
+# ---------------------------------------------------------------------------
+# Registry contents (finding B2: a typo'd class name must show up here)
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryContents:
+    def test_expected_protocols_registered(self):
+        listing = {row["protocol"]: row for row in registered_protocols()}
+
+        # The seven decoder protocols are always present: upstream when
+        # the bundled library decodes them (none as of 7.5.0), local
+        # polyfill otherwise -- including on the no-library CI leg.
+        for key in ("samsung32", "sony", "sharp", "marantz", "rc5",
+                    "kaseikyo", "symphony"):
+            assert key in listing, f"{key} missing from registry"
+            assert listing[key]["source"] == "local"
+            assert listing[key]["tx_rebuild"] is True
+
+        # NEC is upstream-only (no local polyfill; the library has
+        # decoded it since v0.4.0) so it registers only with the library.
+        assert ("nec" in listing) == _HAS_LIBRARY
+        if _HAS_LIBRARY:
+            assert listing["nec"]["source"] == "upstream"
+            assert listing["nec"]["tx_rebuild"] is True
+
+        # GE-AC feature-detects the upstream decoder and registers on
+        # the identity-only tier (finding B6).
+        assert ("geac" in listing) == _HAS_GEAC
+        if _HAS_GEAC:
+            assert listing["geac"]["tx_rebuild"] is False
+
+    def test_probe_order_strict_before_checksum_free(self):
+        keys = [row["protocol"] for row in registered_protocols()]
+        # Symphony has no checksum; it must probe last.
+        assert keys[-1] == "symphony"
+        # Marantz (specific) probes before RC-5 (its generic parent).
+        assert keys.index("marantz") < keys.index("rc5")
+
+    def test_get_spec_resolves_variant_labels(self):
+        assert get_spec("SONY15") is not None
+        assert get_spec("SONY15").key == "sony"
+        assert get_spec("KASEIKYO48").key == "kaseikyo"
+        assert get_spec("SYMPHONY12").key == "symphony"
+        assert get_spec("RC5").key == "rc5"
+        assert get_spec("UNKNOWN99") is None
+        assert get_spec(None) is None
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint formatting (N2: one formatter; N3: per-protocol formats)
+# ---------------------------------------------------------------------------
+
+
+class TestFingerprints:
+    def test_nec_format_byte_identical_to_v040(self):
+        assert format_fingerprint("NEC", 0xFB04, 0x08) == "NEC:0xfb04:0x08"
+
+    def test_sony_variant_in_label(self):
+        identity = try_decode_identity(
+            SonyCommand(address=0xA5, address_bits=8, command=0x69).get_raw_timings()
+        )
+        assert identity is not None
+        assert identity.protocol == "SONY15"
+        assert identity.fingerprint == "SONY15:0x00a5:0x69"
+
+    def test_toggle_excluded_from_identity(self):
+        """The same RC-5 button with flipped toggle is ONE identity."""
+        a = try_decode_identity(
+            RC5Command(address=5, command=0x35, toggle=0).get_raw_timings()
+        )
+        b = try_decode_identity(
+            RC5Command(address=5, command=0x35, toggle=1).get_raw_timings()
+        )
+        assert a is not None and b is not None
+        assert a.fingerprint == b.fingerprint
+        assert a.extras == {"toggle": 0}
+        assert b.extras == {"toggle": 1}
+
+    def test_sharp_extension_is_identity(self):
+        plain = try_decode_identity(
+            SharpCommand(address=1, command=0x68, extension=0).get_raw_timings()
+        )
+        extended = try_decode_identity(
+            SharpCommand(address=1, command=0x68, extension=1).get_raw_timings()
+        )
+        assert plain is not None and extended is not None
+        assert plain.fingerprint != extended.fingerprint
+        assert extended.fingerprint.endswith(":x1")
+        assert not plain.fingerprint.endswith(":x1")
+
+
+# ---------------------------------------------------------------------------
+# The field regression: one button, one identity (GH forum reports)
+# ---------------------------------------------------------------------------
+
+
+class TestSonyFragmentationCured:
+    def test_real_capture_pair_unifies_at_tier_1(self):
+        """The v0.5.8 byte_hash flip pair now shares a decoded identity."""
+        pasted = try_decode_identity(ProntoCommand(PASTED_YELLOW).get_raw_timings())
+        received = try_decode_identity(
+            ProntoCommand(RECEIVED_YELLOW).get_raw_timings()
+        )
+        assert pasted is not None, "clean Sony capture must decode"
+        assert received is not None, "jittered Sony capture must decode"
+        assert pasted.fingerprint == received.fingerprint
+        assert pasted.protocol == "SONY15"
+
+    def test_twelve_presses_one_identity(self):
+        """loic's 12-rows regression: repeat presses with varying frame
+        counts (hypothesis A) and mark jitter (hypothesis B) must all
+        decode to a single identity."""
+        fingerprints = set()
+        for press in range(12):
+            frames = press % 3  # 1-3 frames per capture
+            jitter = (press % 5 - 2) * 60  # -120..+120us mark wobble
+            clean = SonyCommand(
+                address=0xA5, address_bits=8, command=0x69, repeat_count=frames
+            ).get_raw_timings()
+            dirty = [
+                v + jitter if v > 0 else min(-1, v - jitter) for v in clean
+            ]
+            identity = try_decode_identity(dirty)
+            assert identity is not None, f"press {press} failed to decode"
+            fingerprints.add(identity.fingerprint)
+        assert len(fingerprints) == 1, (
+            f"one button fragmented into {len(fingerprints)} identities: "
+            f"{sorted(fingerprints)}"
+        )
+
+    def test_four_colored_buttons_stay_distinct(self):
+        """The v0.5.8 win is preserved: different buttons never merge."""
+        codes = (0x52E9, 0x32E9, 0x72E9, 0x12E9)  # ESPHome bit order
+        fingerprints = set()
+        for wire in codes:
+            # ESPHome logs MSB-first transmission order; rebuild the
+            # (address, command) pair the way the decoder sees the wire.
+            bits = [(wire >> i) & 1 for i in range(14, -1, -1)]
+            command = 0
+            for index, bit in enumerate(bits[:7]):
+                command |= bit << index
+            address = 0
+            for index, bit in enumerate(bits[7:]):
+                address |= bit << index
+            identity = try_decode_identity(
+                SonyCommand(
+                    address=address, address_bits=8, command=command
+                ).get_raw_timings()
+            )
+            assert identity is not None
+            fingerprints.add(identity.fingerprint)
+        assert len(fingerprints) == 4
+
+
+# ---------------------------------------------------------------------------
+# TX rebuild dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestTxRebuild:
+    @pytest.mark.parametrize(
+        ("protocol", "address", "command", "extras"),
+        [
+            ("SONY15", 0xA5, 0x69, None),
+            ("SONY12", 0x01, 0x15, None),
+            ("SAMSUNG32", 0x07, 0x02, None),
+            ("RC5", 5, 0x35, {"toggle": 1}),
+            ("SHARP", 1, 0x68, {"extension": 1}),
+            ("MARANTZ", 0x10, 0x0C, {"extension": 0x20, "toggle": 0}),
+            ("KASEIKYO48", 0x2002, 0x40040100, None),
+            ("SYMPHONY12", 0, 0xC00, None),
+        ],
+    )
+    def test_rebuild_round_trips_identity(self, protocol, address, command, extras):
+        cmd = build_protocol_command(protocol, address, command, extras=extras)
+        assert cmd is not None, f"{protocol} must rebuild"
+        rebuilt = try_decode_identity(cmd.get_raw_timings())
+        # Symphony's single rebuilt frame is (correctly) below the
+        # decoder's two-frame evidence bar; re-send once to decode.
+        if rebuilt is None and protocol.startswith("SYMPHONY"):
+            doubled = cmd.get_raw_timings() * 2
+            rebuilt = try_decode_identity(doubled)
+        assert rebuilt is not None
+        assert rebuilt.protocol == protocol
+        assert rebuilt.address == address
+        assert rebuilt.command == command
+
+    def test_unregistered_and_missing_fields_return_none(self):
+        assert build_protocol_command("UNKNOWN", 1, 2) is None
+        assert build_protocol_command(None, 1, 2) is None
+        assert build_protocol_command("RC5", None, 2) is None
+        assert build_protocol_command("SONY99", 1, 2) is None
+
+    @pytest.mark.skipif(not _HAS_GEAC, reason="GE-AC needs upstream 6.x+")
+    def test_geac_is_identity_only(self):
+        assert build_protocol_command("GEAC", 0x01, 0x02) is None
+
+    def test_build_decoded_command_threads_repeats_and_extras(self):
+        cmd = build_decoded_command(
+            "RC5", 5, 0x35, repeat_count=2, decoded_extras={"toggle": 1}
+        )
+        assert cmd is not None
+        assert cmd.repeat_count == 2
+        assert cmd.toggle == 1
+
+    def test_kaseikyo_payload_survives_int_packing(self):
+        """Leading-zero payload bytes round-trip through the packed int."""
+        source = try_decode_identity(
+            build_protocol_command(
+                "KASEIKYO48", 0x2002, 0x00040100
+            ).get_raw_timings()
+        )
+        assert source is not None
+        assert source.protocol == "KASEIKYO48"
+        assert source.command == 0x00040100
+
+
+# ---------------------------------------------------------------------------
+# identity_from_command (code library / pluckable surface)
+# ---------------------------------------------------------------------------
+
+
+class TestIdentityFromCommand:
+    def test_local_instance_resolves(self):
+        identity = identity_from_command(
+            SonyCommand(address=0xA5, address_bits=8, command=0x69)
+        )
+        assert identity is not None
+        assert identity.fingerprint == "SONY15:0x00a5:0x69"
+
+    @_needs_library
+    def test_upstream_encode_only_instance_resolves_by_class_name(self):
+        """A pluckable built from the upstream (encode-only) SonyCommand
+        still resolves to the sony spec and the same fingerprint."""
+        from infrared_protocols.commands.sony import SonyCommand as Upstream
+
+        identity = identity_from_command(
+            Upstream(address=0xA5, address_bits=8, command=0x69)
+        )
+        assert identity is not None
+        assert identity.fingerprint == "SONY15:0x00a5:0x69"
+
+    def test_unknown_instance_returns_none(self):
+        assert identity_from_command(object()) is None
+        assert identity_from_command(None) is None
+
+
+# ---------------------------------------------------------------------------
+# Symphony end-to-end (GH #38 shape)
+# ---------------------------------------------------------------------------
+
+
+class TestSymphonyEndToEnd:
+    def test_mvdwetering_shape_decodes_to_one_identity(self):
+        """Preamble frames + variable button-frame counts, three captures
+        of different lengths -> one identity (the 108/120/132-pair
+        splitting reported in GH #38)."""
+        fingerprints = set()
+        for repeats in (7, 8, 9):
+            capture = (
+                SymphonyCommand(data=0x000, nbits=12).get_raw_timings()
+                + SymphonyCommand(data=0xFFF, nbits=12).get_raw_timings()
+                + SymphonyCommand(
+                    data=0xC00, nbits=12, repeat_count=repeats
+                ).get_raw_timings()
+            )
+            identity = try_decode_identity(capture)
+            assert identity is not None
+            assert identity.protocol == "SYMPHONY12"
+            assert identity.command == 0xC00
+            fingerprints.add(identity.fingerprint)
+        assert len(fingerprints) == 1

--- a/custom_components/hair/tests/test_signal_monitor.py
+++ b/custom_components/hair/tests/test_signal_monitor.py
@@ -23,6 +23,7 @@ from custom_components.hair.models import (
     UnknownDevice,
     UnknownSignal,
 )
+from custom_components.hair.protocol_decode import DecodedIdentity
 from custom_components.hair.signal_monitor import SignalMonitor
 from custom_components.hair.signal_store import SignalStore
 
@@ -112,8 +113,11 @@ class TestDecodeAtCaptureAndForgeGuard:
         monitor = SignalMonitor(hass, store, _make_hair_store())
         await monitor.async_start()
         with patch(
-            "custom_components.hair.signal_monitor.decode_to_fields",
-            return_value=("NEC", 0xFB04, 0x08, "NEC:0xfb04:0x08"),
+            "custom_components.hair.signal_monitor.try_decode_identity",
+            return_value=DecodedIdentity(
+                protocol="NEC", address=0xFB04, command=0x08,
+                fingerprint="NEC:0xfb04:0x08", extras=None, source="upstream",
+            ),
         ):
             await monitor._on_ir_event(_make_event(_nec_event("0x1234")))
         devices = store.get_all_devices()
@@ -131,8 +135,8 @@ class TestDecodeAtCaptureAndForgeGuard:
         monitor = SignalMonitor(hass, store, _make_hair_store())
         await monitor.async_start()
         with patch(
-            "custom_components.hair.signal_monitor.decode_to_fields",
-            return_value=(None, None, None, None),
+            "custom_components.hair.signal_monitor.try_decode_identity",
+            return_value=None,
         ):
             await monitor._on_ir_event(_make_event(_nec_event("0x1234")))
         sig = store.get_all_devices()[0].signals[0]
@@ -766,8 +770,11 @@ class TestPublicAPI:
         store = _make_signal_store(hass)
         monitor = SignalMonitor(hass, store, _make_hair_store())
         with patch.object(store, "async_save", AsyncMock()), patch(
-            "custom_components.hair.signal_monitor.decode_to_fields",
-            return_value=("NEC", 0xFB04, 0x08, "NEC:0xfb04:0x08"),
+            "custom_components.hair.signal_monitor.try_decode_identity",
+            return_value=DecodedIdentity(
+                protocol="NEC", address=0xFB04, command=0x08,
+                fingerprint="NEC:0xfb04:0x08", extras=None, source="upstream",
+            ),
         ):
             device = await monitor.create_manual_remote("R")
             res = await monitor.create_manual_signal(
@@ -787,8 +794,8 @@ class TestPublicAPI:
         store = _make_signal_store(hass)
         monitor = SignalMonitor(hass, store, _make_hair_store())
         with patch.object(store, "async_save", AsyncMock()), patch(
-            "custom_components.hair.signal_monitor.decode_to_fields",
-            return_value=(None, None, None, None),
+            "custom_components.hair.signal_monitor.try_decode_identity",
+            return_value=None,
         ):
             device = await monitor.create_manual_remote("R")
             res = await monitor.create_manual_signal(

--- a/custom_components/hair/tests/test_signal_store.py
+++ b/custom_components/hair/tests/test_signal_store.py
@@ -13,6 +13,7 @@ from custom_components.hair.const import (
     SIGNAL_STORAGE_VERSION,
 )
 from custom_components.hair.models import UnknownDevice, UnknownSignal
+from custom_components.hair.protocol_decode import DecodedIdentity
 from custom_components.hair.signal_store import SignalStore, _SignalCatalogStore
 
 
@@ -60,8 +61,11 @@ async def test_async_load_backfills_catalog_decoded_fields():
         "dismissed": [],
     }
     with patch(
-        "custom_components.hair.protocol_decode.try_decode",
-        return_value=("NEC", 0xFB04, 0x49),
+        "custom_components.hair.protocol_decode.try_decode_identity",
+        return_value=DecodedIdentity(
+            protocol="NEC", address=0xFB04, command=0x49,
+            fingerprint="NEC:0xfb04:0x49", extras=None, source="upstream",
+        ),
     ), patch.object(store, "_store") as mock_store:
         mock_store.async_load = AsyncMock(return_value=raw)
         await store.async_load()

--- a/custom_components/hair/tests/test_storage.py
+++ b/custom_components/hair/tests/test_storage.py
@@ -13,6 +13,7 @@ from custom_components.hair.const import (
 )
 from custom_components.hair.event_parser import EventParser
 from custom_components.hair.models import IRCommand, IRDevice
+from custom_components.hair.protocol_decode import DecodedIdentity
 from custom_components.hair.storage import HAIRStore, _HAIRDeviceStore
 
 
@@ -129,8 +130,11 @@ async def test_async_load_backfills_decoded_fields(fake_hass):
         "custom_components.hair.storage._HAIRDeviceStore",
         lambda *a, **k: backing,
     ), patch(
-        "custom_components.hair.protocol_decode.try_decode",
-        return_value=("NEC", 0xFB04, 0x08),
+        "custom_components.hair.protocol_decode.try_decode_identity",
+        return_value=DecodedIdentity(
+            protocol="NEC", address=0xFB04, command=0x08,
+            fingerprint="NEC:0xfb04:0x08", extras=None, source="upstream",
+        ),
     ):
         store = HAIRStore(fake_hass)
         await store.async_load()

--- a/custom_components/hair/tests/test_toggle_flip.py
+++ b/custom_components/hair/tests/test_toggle_flip.py
@@ -1,0 +1,239 @@
+"""Tests for RC-5-family toggle handling and decoded_extras flow (v0.6.0).
+
+The toggle bit alternates between distinct key presses on RC-5 and
+Marantz remotes. HAIR models it as press STATE in ``decoded_extras``:
+excluded from identity (test_protocol_registry covers that), threaded
+into the decoded TX rebuild, and flipped exactly once per successful
+send-command / Test call -- after the full emitter loop, never
+per-emitter and never per send_count frame (plan finding N1).
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import homeassistant.components.infrared as _infrared_mod
+import pytest
+
+from custom_components.hair.device_manager import DeviceManager
+from custom_components.hair.entity_factory import EntityFactory
+from custom_components.hair.models import (
+    IRCommand,
+    IRDevice,
+    UnknownDevice,
+    UnknownSignal,
+)
+from custom_components.hair.signal_monitor import (
+    SignalMonitor,
+    _apply_signal_provenance,
+)
+from custom_components.hair.signal_store import SignalStore
+from custom_components.hair.storage import HAIRStore
+
+_PRONTO = "0000 006D 0002 0000 0020 0040 0020 0040"
+
+
+class _FakeStore:
+    def __init__(self, *args, **kwargs):
+        self._data = None
+
+    async def async_load(self):
+        return self._data
+
+    async def async_save(self, data):
+        self._data = data
+
+
+def _make_device_manager(hass) -> DeviceManager:
+    with patch("custom_components.hair.storage._HAIRDeviceStore", _FakeStore):
+        store = HAIRStore(hass)
+        store._loaded = True
+        factory = EntityFactory(hass)
+        factory.async_update_entities = AsyncMock()
+        with patch(
+            "custom_components.hair.device_manager.dr.async_get",
+            return_value=MagicMock(
+                async_get_or_create=MagicMock(return_value=MagicMock(id="ha-dev-1")),
+                async_get_device=MagicMock(return_value=None),
+                async_remove_device=MagicMock(),
+            ),
+        ):
+            return DeviceManager(hass, store, factory, "entry-1")
+
+
+def _rc5_command(toggle: int = 0) -> IRCommand:
+    return IRCommand(
+        id="c1",
+        name="Volume Up",
+        protocol="PRONTO",
+        code=_PRONTO,
+        frequency=36000,
+        decoded_protocol="RC5",
+        decoded_address=5,
+        decoded_command=0x10,
+        decoded_fingerprint="RC5:0x0005:0x10",
+        decoded_extras={"toggle": toggle},
+    )
+
+
+def _rc5_device(command: IRCommand) -> IRDevice:
+    return IRDevice(
+        id="d1",
+        name="Amp",
+        commands=[command],
+        emitter_entity_ids=["infrared.e1", "infrared.e2"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_flips_toggle_once_after_full_emitter_loop(fake_hass):
+    manager = _make_device_manager(fake_hass)
+    command = _rc5_command(toggle=0)
+    manager._store.add_device(_rc5_device(command))
+    manager._store.async_save = AsyncMock()
+
+    with patch.object(_infrared_mod, "async_send_command", AsyncMock()) as ir_send:
+        await manager.async_send_command("d1", "c1")
+
+    # Two emitters, one send: toggle flipped exactly once.
+    assert ir_send.await_count == 2
+    assert command.decoded_extras["toggle"] == 1
+    manager._store.async_save.assert_awaited_once()
+    # The transmitted command carried the PRE-flip toggle.
+    sent = ir_send.call_args[0][2]
+    assert getattr(sent, "toggle", None) == 0
+
+    # A second send flips back -- alternation, not latching.
+    with patch.object(_infrared_mod, "async_send_command", AsyncMock()):
+        await manager.async_send_command("d1", "c1")
+    assert command.decoded_extras["toggle"] == 0
+
+
+@pytest.mark.asyncio
+async def test_send_count_repeats_same_toggle(fake_hass):
+    """send_count > 1 is one logical press: same toggle N times, one flip."""
+    manager = _make_device_manager(fake_hass)
+    command = _rc5_command(toggle=1)
+    command.send_count = 3
+    manager._store.add_device(_rc5_device(command))
+    manager._store.async_save = AsyncMock()
+
+    sent_toggles = []
+
+    async def _capture(hass, emitter, cmd):
+        sent_toggles.append(getattr(cmd, "toggle", None))
+
+    with (
+        patch.object(_infrared_mod, "async_send_command", AsyncMock(side_effect=_capture)),
+        patch("custom_components.hair.device_manager.asyncio.sleep", AsyncMock()),
+    ):
+        await manager.async_send_command("d1", "c1")
+
+    assert sent_toggles == [1] * 6  # 3 frames x 2 emitters, all pre-flip
+    assert command.decoded_extras["toggle"] == 0
+
+
+@pytest.mark.asyncio
+async def test_failed_send_does_not_flip(fake_hass):
+    manager = _make_device_manager(fake_hass)
+    command = _rc5_command(toggle=0)
+    manager._store.add_device(_rc5_device(command))
+    manager._store.async_save = AsyncMock()
+
+    with (
+        patch.object(
+            _infrared_mod,
+            "async_send_command",
+            AsyncMock(side_effect=RuntimeError("emitter offline")),
+        ),
+        pytest.raises(RuntimeError),
+    ):
+        await manager.async_send_command("d1", "c1")
+
+    assert command.decoded_extras["toggle"] == 0
+    manager._store.async_save.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_non_toggle_protocol_never_saves(fake_hass):
+    """A decoded NEC send has no toggle state and must not touch storage."""
+    manager = _make_device_manager(fake_hass)
+    command = IRCommand(
+        id="c1",
+        name="Power",
+        protocol="PRONTO",
+        code=_PRONTO,
+        decoded_protocol="NEC",
+        decoded_address=0x04,
+        decoded_command=0x08,
+        decoded_fingerprint="NEC:0x0004:0x08",
+    )
+    manager._store.add_device(_rc5_device(command))
+    manager._store.async_save = AsyncMock()
+
+    with patch.object(_infrared_mod, "async_send_command", AsyncMock()):
+        await manager.async_send_command("d1", "c1")
+
+    manager._store.async_save.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_catalog_test_flips_signal_toggle(fake_hass):
+    store = SignalStore(fake_hass)
+    store._loaded = True
+    store.async_save = AsyncMock()
+    monitor = SignalMonitor(fake_hass, store, MagicMock())
+    signal = UnknownSignal(
+        id="s1",
+        fingerprint="s1",
+        protocol="PRONTO",
+        code=_PRONTO,
+        frequency=36000,
+        decoded_protocol="RC5",
+        decoded_address=5,
+        decoded_command=0x10,
+        decoded_fingerprint="RC5:0x0005:0x10",
+        decoded_extras={"toggle": 0},
+    )
+    store.add_device(UnknownDevice(id="ud1", fingerprint="d", signals=[signal]))
+
+    with patch.object(_infrared_mod, "async_send_command", AsyncMock()):
+        result = await monitor.test_signal("s1", "infrared.e")
+
+    assert result["success"] is True
+    assert signal.decoded_extras["toggle"] == 1
+    store.async_save.assert_awaited_once()
+
+
+def test_provenance_copies_decoded_extras():
+    """Assign carries extras onto the command as an independent copy."""
+    signal = UnknownSignal(
+        id="s1",
+        fingerprint="s1",
+        decoded_protocol="RC5",
+        decoded_fingerprint="RC5:0x0005:0x10",
+        decoded_extras={"toggle": 1},
+    )
+    command = IRCommand(name="Volume Up")
+    _apply_signal_provenance(command, signal)
+    assert command.decoded_extras == {"toggle": 1}
+    command.decoded_extras["toggle"] = 0
+    assert signal.decoded_extras["toggle"] == 1  # no shared dict
+
+    bare = UnknownSignal(id="s2", fingerprint="s2")
+    command2 = IRCommand(name="Mute")
+    _apply_signal_provenance(command2, bare)
+    assert command2.decoded_extras is None
+
+
+def test_models_serialize_decoded_extras_round_trip():
+    command = _rc5_command(toggle=1)
+    assert IRCommand.from_dict(command.to_dict()).decoded_extras == {"toggle": 1}
+    signal = UnknownSignal(
+        id="s1", fingerprint="s1", decoded_extras={"extension": 1}
+    )
+    assert (
+        UnknownSignal.from_dict(signal.to_dict()).decoded_extras
+        == {"extension": 1}
+    )
+    plain = UnknownSignal(id="s2", fingerprint="s2")
+    assert UnknownSignal.from_dict(plain.to_dict()).decoded_extras is None

--- a/custom_components/hair/tests/test_unified_identity.py
+++ b/custom_components/hair/tests/test_unified_identity.py
@@ -500,8 +500,11 @@ async def test_trigger_backfill_decoded_only(mock_hass):
 
     t_nec = store.get_trigger("t_nec")
     assert t_nec.decoded_fingerprint == "NEC:0xff00:0xaa"
+    # v0.6.0: the local SIRC decoder reads the real captured Sony fixture,
+    # so the legacy Sony trigger now gains tier-1 identity at load too
+    # (through v0.5.8 this asserted None -- "no Sony decoder yet").
     t_sony = store.get_trigger("t_sony")
-    assert t_sony.decoded_fingerprint is None  # no Sony decoder yet
+    assert t_sony.decoded_fingerprint == "SONY15:0x0097:0x27"
     t_codeless = store.get_trigger("t_codeless")
     assert t_codeless.decoded_fingerprint is None
     # The explicit negative assertion: the backfill must not have given

--- a/custom_components/hair/websocket_api.py
+++ b/custom_components/hair/websocket_api.py
@@ -701,13 +701,16 @@ async def ws_save_captured_command(
     # but a freshly captured command should not need it.) Both fields default
     # to None on undecodable / non-Pronto captures.
     from .event_parser import EventParser
-    from .protocol_decode import decode_to_fields
+    from .protocol_decode import try_decode_identity
 
-    d_proto, d_addr, d_cmd, d_fp = decode_to_fields(result.raw_timings)
-    command.decoded_protocol = d_proto
-    command.decoded_address = d_addr
-    command.decoded_command = d_cmd
-    command.decoded_fingerprint = d_fp
+    identity = try_decode_identity(result.raw_timings)
+    command.decoded_protocol = identity.protocol if identity else None
+    command.decoded_address = identity.address if identity else None
+    command.decoded_command = identity.command if identity else None
+    command.decoded_fingerprint = identity.fingerprint if identity else None
+    command.decoded_extras = (
+        dict(identity.extras) if identity and identity.extras else None
+    )
     command.byte_hash = EventParser.pronto_byte_hash(result.code)
     await manager.async_add_command(device.id, command)
     # Notify other tabs this signal now has an assignment (v0.5.7).

--- a/llms.txt
+++ b/llms.txt
@@ -106,9 +106,25 @@ Key components:
   precondition the trigger then randomly misses its own button. The dedup window
   slides and is keyed per trigger, so protocols that transmit several full frames
   per press (Sony sends 4-5) count as one press even when frames flip fingerprints.
-  When an upstream decoder lands for a protocol (e.g. Sony SIRC in
-  infrared-protocols), the decoded tier takes over automatically with no further
-  HAIR changes.
+  Local-first decoders (v0.6.0): HAIR ships its own decoders for seven
+  protocols -- Sony SIRC 12/15/20, Symphony (8/12/16-bit rc_switch family),
+  Philips RC-5 (incl. RC5X), Samsung32, Sharp, Kaseikyo (Panasonic family),
+  and Marantz Extended -- in custom_components/hair/decoders/, each shaped
+  exactly like an infrared_protocols module so it can be donated upstream as
+  a near-file-copy. A registry in protocol_decode.py feature-detects per
+  protocol: when the user's bundled infrared-protocols ships a decoder
+  (from_raw_timings present), upstream wins; otherwise the local polyfill
+  registers. Decoders split a capture into frames and majority-vote, so
+  variable frame counts and receiver jitter cannot fragment one button into
+  many identities (the v0.5.8 day-one field regression). The decoded
+  fingerprint is formatted in exactly one place (format_fingerprint);
+  bit-count variants fold into the protocol label (SONY15, KASEIKYO48,
+  SYMPHONY12), Sharp/Marantz extension bits fold into a fingerprint suffix,
+  and the RC-5/Marantz toggle bit is press STATE, stored in decoded_extras,
+  excluded from identity, threaded into decoded TX, and flipped once per
+  successful send. GE-AC registers identity-only (tx_rebuild=False): decoded
+  identity matches/collapses signals, but TX always replays the captured
+  raw, since re-encoding AC state risks transmitting wrong state.
 
 Signal fingerprinting details:
 - Uses S/L (short/long) pulse-duration classification. Each pulse is classified as
@@ -120,7 +136,8 @@ Signal fingerprinting details:
 - Covers all major consumer IR protocols: NEC, Samsung, JVC, LG, Sony, RC-5, RC-6.
 - Source-remote grouping uses carrier frequency and preamble fingerprinting, so the
   Sniffer can identify which remote sent a signal without decoding the protocol.
-- When a captured signal can be read as a known protocol (NEC today), HAIR also
+- When a captured signal can be read as a known protocol (NEC plus the seven
+  v0.6.0 registry protocols), HAIR also
   stores the decoded identity alongside the raw timings as a cache layer. Raw
   timings stay the source of truth; the decoded form gives stronger matching and
   lets transmit re-encode clean timings instead of replaying captured ones.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,10 @@ test = [
     # (decode paths in protocol_decode.py are defensively guarded either
     # way). PyPI currently publishes through 5.8.1, so CI installs the
     # newest 5.x today and picks up 6.x automatically once it is published.
-    "infrared-protocols>=5.6,<7.0; python_version >= '3.13'",
+    # Upstream moved to 7.x in 2026-07; the commands.Command contract is
+    # unchanged from 5.x (verified against the 7.5.0 source), so the cap
+    # tracks the next major.
+    "infrared-protocols>=5.6,<8.0; python_version >= '3.13'",
 ]
 lint = [
     "ruff>=0.4",


### PR DESCRIPTION
Ships the v0.6.0 protocol decode registry and seven local decoders: Sony SIRC (12, 15, and 20 bit), Symphony, RC-5 including RC5X, Samsung32, Sharp, Kaseikyo, and Marantz Extended. The registry feature-detects the bundled infrared-protocols library per protocol and prefers it whenever it can decode; the local classes are upstream-shaped polyfills intended for donation upstream. Fixes the v0.5.8 field reports: one button yields one identity regardless of frame count or receiver jitter, fragmented catalogs heal at load, and RC-5 toggle state is tracked and alternated on send. Bench verified on live hardware: all three Sony variants, Sharp, Kaseikyo, Samsung32, RC-5, and NEC regression, including TX to RX loopback. Full story in the CHANGELOG under 0.6.0.