### PR TITLE
v0.6.1 (Hot Towel Finish): NEC capture recovery, AC thermostats, Samsung32 fused pulses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to HAIR will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-07-18 -- Hot Towel Finish
+
+### Fixed
+
+- A single jittery pulse no longer splits an NEC button into two rows. Real receivers occasionally deliver a capture where one pulse measures in the dead zone between the protocol's two legal widths while every other pulse is fine; the strict decoder rightly rejected the frame, so the capture fell back to byte-level identity and became a second row for the same button. When the strict decode fails, HAIR now re-reads the frame leniently and accepts the result only if NEC's own built-in checksum validates, so a one-pulse wobble cannot fake a different button and a genuinely corrupt frame still decodes as nothing. Reported by @blalor with two captures of his Previous Track button, which are now permanent fixtures in the test suite.
+- NEC captures that start with leftover repeat chatter from a previous press decode now. The decoder used to require the capture to open on the main frame's leader; HAIR now seeks forward past a stray repeat marker or partial burst to the true frame start. This was the class behind several bench remotes whose buttons never decoded.
+- Air conditioner devices finally expose real target temperatures. The climate entity has supported temperature presets since the entity work landed, but nothing could create them from the UI. Commands named like "Temp 22" or "Temperature 26" now map themselves to the matching temperature step and register the degree value on the thermostat, the same way "Mode: Cool" and "Fan: High" have always self-mapped. Deleting a temp command retires its step. Found by @ripolltata (GH #45), who read the source and correctly identified a half-shipped feature; thank you for the precise report.
+- The thermostat dial is draggable from the start. Without an initial target temperature the dial rendered no handle, and nothing could ever set the first target, so a preset-equipped AC was stuck read-only. The entity now starts at the middle preset; nothing transmits until you actually move it.
+- The climate entity follows your installation's temperature unit instead of assuming Fahrenheit. Metric users' presets are Celsius now, as they always should have been.
+- Samsung32 captures whose end pulse arrives fused with a following frame decode now. Some emitters replay the whole packet for repeats with no gap at the junction, welding the end pulse to the next frame's leader; the decoder tolerates the fused pulse while the protocol checksum keeps gating every decode. Found on the bench with real captures, which are now fixtures.
+
+### Changed
+
+- The most-recent-hit Assign button in the Sniffer wears a mint rim, and each new hit blooms it into a mint ring. The old pulse used the same green as the button fill, so the halo disappeared into it.
+- The adopters table gains SMLIGHT Ultima native receiving (HA 2026.7), the second receiver source after ESPHome.
+- The infrared-protocols test dependency cap moved from <8.0 to <9.0; upstream's 8.0.0 changes only Edifier code sets and keeps the command contract.
+
+### Known issues
+
+- When the startup heal merges duplicate rows, a trigger created on one of the merged rows can lose its yellow badge in the Sniffer, because the surviving row carries a different waveform identity. The trigger itself keeps firing normally; only the row badge and count display are affected. A proper fix (triggers following decoded identity, the way commands already do) is planned as its own release.
+
 ## [0.6.0] - 2026-07-17 -- Shave and a Haircut
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ HAIR works with any integration that exposes HA's native `infrared` entity platf
 | [ESPHome](https://esphome.io/) | Core | Yes | Yes | No | Since 2026.4 (TX), 2026.6 (native RX) |
 | [Tuya Local](https://github.com/make-all/tuya-local) | HACS | Yes | No | Yes | TX since 2026.4, Pluck since 2026.6.2 |
 | [Broadlink](https://www.home-assistant.io/integrations/broadlink/) | Core | Yes | No | No | Since 2026.5 |
-| [SMLIGHT](https://www.home-assistant.io/integrations/smlight/) | Core | Yes | No | No | Since 2026.5 |
+| [SMLIGHT](https://www.home-assistant.io/integrations/smlight/) | Core | Yes | Yes | No | TX since 2026.5, native RX (Ultima) since 2026.7 |
 
 On HA 2026.6+, HAIR subscribes to native `InfraredReceiverEntity` instances via `infrared.async_subscribe_receiver()`. Any integration that implements the receiver entity works as a HAIR receiver automatically. On HA 2026.4-2026.5, HAIR falls back to the legacy ESPHome event bus bridge (see [ESPHome Receiver Setup](#esphome-receiver-setup) below).
 
@@ -51,7 +51,7 @@ When HAIR can read a captured signal as a known protocol (NEC today), it also st
 
 - Home Assistant **2026.4** or later
 - Python 3.12+
-- **For capture (RX):** any integration that exposes HA's native `InfraredReceiverEntity` (HA 2026.6+) -- ESPHome IR receivers work day-one, and any other integration that adopts the receiver entity works automatically. On HA 2026.4-2026.5, HAIR falls back to the legacy ESPHome event-bus bridge (see [ESPHome Receiver Setup](#esphome-receiver-setup) for the YAML stub).
+- **For capture (RX):** any integration that exposes HA's native `InfraredReceiverEntity` (HA 2026.6+) -- ESPHome IR receivers work day-one, SMLIGHT Ultima receivers work natively since HA 2026.7, and any other integration that adopts the receiver entity works automatically. On HA 2026.4-2026.5, HAIR falls back to the legacy ESPHome event-bus bridge (see [ESPHome Receiver Setup](#esphome-receiver-setup) for the YAML stub).
 - **For send (TX):** at least one integration on HA's native infrared platform (ESPHome infrared entities, [Tuya Local](https://github.com/make-all/tuya-local) IR blasters, Broadlink RM series, SMLIGHT SLZB devices, etc.)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ There are five ways to add a device.
 
 Navigate to the Sniffer tab and press buttons on your physical remote. HAIR captures each signal in real time. Expand the source device row, then click on a signal to assign it to one of your HAIR devices. Pick a command name from the device-type-aware template list (e.g., "Power On," "Volume Up," "Mode: Cool") or enter a custom name. While assigning you can also set a "Send times" count for a device that needs the command repeated to register; you can change it later in the command editor.
 
+For air conditioners, command names like "Temp 22" and "Temp 24" wire themselves up: each one maps to its temperature step and the climate card grows a real thermostat bounded to your steps, snapping to the nearest one as you drag. Deleting a temp command removes its step.
+
 When you don't have the physical remote to hand, build the command in the Clipper instead: paste the button's Pronto code on the Clipper tab, then Assign it to a device exactly as you would a sniffed signal. Sniffed and clipped signals are interchangeable once captured.
 
 When the code already lives in a vendor blaster (such as Tuya Local), use the Plucker tab to pull it into HAIR by name without re-learning it at a receiver. Register the blaster with "+ Add Blaster", then "+ Pluck Signal" with the command name you used in the vendor's app, and the resulting signal is interchangeable with sniffed and clipped ones for assignment, alias, trigger, and promote.

--- a/custom_components/hair/climate.py
+++ b/custom_components/hair/climate.py
@@ -87,7 +87,6 @@ class HAIRClimateEntity(ClimateEntity):
     _attr_has_entity_name = True
     _attr_should_poll = False
     _attr_assumed_state = True
-    _attr_temperature_unit = UnitOfTemperature.FAHRENHEIT
     _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(self, device: IRDevice, device_manager) -> None:
@@ -98,6 +97,37 @@ class HAIRClimateEntity(ClimateEntity):
         self._hvac_mode = HVACMode.OFF
         self._target_temperature: float | None = None
         self._fan_mode: str | None = None
+        self._seed_target_temperature()
+
+    @property
+    def temperature_unit(self) -> str:
+        """The installation's unit system, not a hardcoded scale.
+
+        Presets are unit-agnostic integers (a "Temp 22" command is 22
+        in whatever unit the user's HA runs), so the entity must
+        declare the installation's unit. Hardcoding Fahrenheit made a
+        metric user's 16..30C presets display as -9C to -3C (the
+        third-party review's B3, surfaced for real by GH #45).
+        """
+        if self.hass is not None:
+            return self.hass.config.units.temperature_unit
+        return UnitOfTemperature.FAHRENHEIT
+
+    def _seed_target_temperature(self) -> None:
+        """Give the thermostat dial a handle to grab.
+
+        The dial renders no draggable target while the target
+        temperature is None, and nothing else can set the first
+        target, so a preset-equipped entity would be stuck read-only
+        (v0.6.1 bench find). Seed the median preset; purely local
+        state, nothing transmits until the user actually drags.
+        """
+        if self._target_temperature is not None:
+            return
+        presets = self._device.entity_config.temperature_presets
+        if presets:
+            ordered = sorted(presets)
+            self._target_temperature = float(ordered[len(ordered) // 2])
 
     @property
     def device_info(self) -> dict[str, Any]:
@@ -218,6 +248,9 @@ class HAIRClimateEntity(ClimateEntity):
     @callback
     def update_device(self, device: IRDevice) -> None:
         self._device = device
+        # Presets can appear after entity creation (the assign path adds
+        # "Temp N" commands to a live device); seed the dial then too.
+        self._seed_target_temperature()
         if self.hass is None:
             # Race: entity instantiated and tracked in the platform's local
             # dict but not yet registered with HA via async_add_entities.

--- a/custom_components/hair/decoders/nec_recovery.py
+++ b/custom_components/hair/decoders/nec_recovery.py
@@ -1,0 +1,122 @@
+"""NEC capture recovery: leader-seek and checksum-backed salvage.
+
+These are NOT a decoder. The upstream ``NECCommand.from_raw_timings``
+remains the only strict NEC decoder HAIR uses. This module recovers two
+classes of real-world capture that the strict decoder rightly rejects,
+without loosening it:
+
+Leader-seek (v0.6.1, bench Remotes 9-12): real receivers sometimes
+deliver a capture that starts with junk ahead of the NEC main frame,
+typically the tail of a previous press's repeat chatter (a 9000/2250
+repeat marker) or a partial burst. The strict decoder requires the
+capture to OPEN with the 9000/4500 main leader, so it gives up. The
+seek scans forward to the first true main leader and hands the strict
+decoder the capture from there. Trailing repeat markers are untouched;
+upstream counts those as dittos.
+
+Checksum salvage (v0.6.1, blalor's Previous Track case): a capture can
+be one jittery pulse away from valid, e.g. a single data space
+measuring ~815us, in the dead zone between the two legal NEC spaces
+(~562 and ~1687), while every other pulse is in bounds and the frame's
+own integrity check holds. The salvage re-classifies data pulses by
+midpoint inside wide sanity bounds and accepts the result ONLY if
+NEC's built-in check passes: command XOR command_inverse == 0xFF.
+Extended NEC addresses are allowed (no address-inverse requirement),
+matching the upstream decoder's behavior. The checksum is what makes
+the leniency honest -- the same philosophy as the Sony decoder's
+midpoint classification, except NEC hands us a checksum where Sony
+needed majority voting.
+
+License note: written from the public NEC format description only, no
+third-party decoder code consulted, per the package licensing rule.
+"""
+
+from __future__ import annotations
+
+# Main-frame leader nominals (microseconds) with the library's usual
+# 40% tolerance. The repeat-marker space (2250us nominal, upper bound
+# 3150 at +40%) stays clear of the leader-space lower bound (2700), so
+# a repeat marker can never be mistaken for a main leader.
+_LEADER_MARK = 9000
+_LEADER_SPACE = 4500
+_TOLERANCE = 0.4
+
+# Sanity bounds for salvage classification. Deliberately wide: the
+# whole point is admitting pulses outside the strict windows, with the
+# checksum as the gate. A data mark is nominally 562us; a data space is
+# 562 (zero) or 1687 (one). The midpoint between the two legal spaces
+# separates bit values.
+_MARK_MIN = 200
+_MARK_MAX = 1200
+_SPACE_MIN = 250
+_SPACE_MAX = 2400
+_SPACE_MIDPOINT = 1125
+
+_DATA_BITS = 32
+
+
+def _within(value: int, nominal: int) -> bool:
+    margin = nominal * _TOLERANCE
+    return nominal - margin <= value <= nominal + margin
+
+
+def seek_main_leader(timings: list[int]) -> list[int]:
+    """Return ``timings`` from the first NEC main leader onward.
+
+    Scans for the first mark/space pair matching the 9000/4500 main
+    leader and returns the capture sliced to start there. When the
+    capture already starts on the leader, or no leader exists anywhere,
+    the input is returned unchanged (the strict decoder then judges it
+    exactly as it would have before this pass existed).
+    """
+    for index in range(len(timings) - 1):
+        mark = timings[index]
+        space = -timings[index + 1]
+        if mark > 0 and _within(mark, _LEADER_MARK) and _within(
+            space, _LEADER_SPACE
+        ):
+            return timings if index == 0 else timings[index:]
+    return timings
+
+
+def salvage_decode(timings: list[int]) -> tuple[int, int] | None:
+    """Midpoint-decode one NEC frame, gated on the protocol checksum.
+
+    Expects a capture that opens on a main leader (run
+    :func:`seek_main_leader` first). Returns ``(address, command)``
+    with the address in the same 16-bit little-endian packing the
+    upstream decoder reports, or ``None`` when the frame cannot be
+    salvaged honestly.
+    """
+    if len(timings) < 2 + 2 * _DATA_BITS:
+        return None
+    if not (timings[0] > 0 and _within(timings[0], _LEADER_MARK)):
+        return None
+    if not _within(-timings[1], _LEADER_SPACE):
+        return None
+
+    bits: list[int] = []
+    index = 2
+    for _ in range(_DATA_BITS):
+        if index + 1 >= len(timings):
+            return None
+        mark = timings[index]
+        space = -timings[index + 1]
+        if not _MARK_MIN <= mark <= _MARK_MAX:
+            return None
+        if not _SPACE_MIN <= space <= _SPACE_MAX:
+            return None
+        bits.append(1 if space > _SPACE_MIDPOINT else 0)
+        index += 2
+
+    data = [0, 0, 0, 0]
+    for bit_index, bit in enumerate(bits):
+        data[bit_index // 8] |= bit << (bit_index % 8)
+
+    # NEC's built-in integrity check: the fourth byte is the bitwise
+    # inverse of the command byte. Without it, no salvage.
+    if data[2] ^ data[3] != 0xFF:
+        return None
+
+    address = data[0] | (data[1] << 8)
+    return (address, data[2])

--- a/custom_components/hair/decoders/samsung.py
+++ b/custom_components/hair/decoders/samsung.py
@@ -34,6 +34,10 @@ _ONE_SPACE_US = 1690
 _SPACE_MIDPOINT_US = 1125
 _MARK_MIN_US = 220
 _MARK_MAX_US = 1000
+# End pulse fused with a replayed packet's 4500us leader (no junction
+# gap): 560 + 4500 = 5060 nominal, plus tolerance for clock-slow
+# emitters. Applies to the end pulse ONLY; data marks keep _MARK_MAX_US.
+_FUSED_END_MARK_MAX_US = 6200
 _SPACE_MIN_US = 220
 _SPACE_MAX_US = 2400
 _FRAME_PERIOD_US = 108000
@@ -140,7 +144,15 @@ class Samsung32Command(Command):
             if space > _SPACE_MIDPOINT_US:
                 data |= 1 << i
 
-        if not _MARK_MIN_US <= frame[66] <= _MARK_MAX_US:
+        # End pulse. Nominally 560us, but real emitters that replay the
+        # packet for repeats can butt the next replay's 4500us leader
+        # directly against it with no gap, fusing both into one mark of
+        # up to ~5100us (v0.6.1 bench: Broadlink TX honors the command's
+        # repeat_count on top of the timings' baked repeat frames, and
+        # the packet junction carries no space). The 32 data bits and
+        # the inverted-command checksum still gate the decode, so a
+        # fused end pulse costs nothing in honesty.
+        if not _MARK_MIN_US <= frame[66] <= _FUSED_END_MARK_MAX_US:
             return None
         if any(value > 0 for value in frame[67:]):
             return None

--- a/custom_components/hair/decoders/samsung.py
+++ b/custom_components/hair/decoders/samsung.py
@@ -34,10 +34,6 @@ _ONE_SPACE_US = 1690
 _SPACE_MIDPOINT_US = 1125
 _MARK_MIN_US = 220
 _MARK_MAX_US = 1000
-# End pulse fused with a replayed packet's 4500us leader (no junction
-# gap): 560 + 4500 = 5060 nominal, plus tolerance for clock-slow
-# emitters. Applies to the end pulse ONLY; data marks keep _MARK_MAX_US.
-_FUSED_END_MARK_MAX_US = 6200
 _SPACE_MIN_US = 220
 _SPACE_MAX_US = 2400
 _FRAME_PERIOD_US = 108000
@@ -145,14 +141,15 @@ class Samsung32Command(Command):
                 data |= 1 << i
 
         # End pulse. Nominally 560us, but real emitters that replay the
-        # packet for repeats can butt the next replay's 4500us leader
-        # directly against it with no gap, fusing both into one mark of
-        # up to ~5100us (v0.6.1 bench: Broadlink TX honors the command's
-        # repeat_count on top of the timings' baked repeat frames, and
-        # the packet junction carries no space). The 32 data bits and
-        # the inverted-command checksum still gate the decode, so a
-        # fused end pulse costs nothing in honesty.
-        if not _MARK_MIN_US <= frame[66] <= _FUSED_END_MARK_MAX_US:
+        # packet for repeats can butt the replay directly against it
+        # with no junction gap, fusing the end mark with whatever comes
+        # next into one long mark (v0.6.1 bench: Broadlink TX honors
+        # the command's repeat_count on top of the timings' baked
+        # repeat frames; observed fusions of ~4900us and ~7000us). So
+        # the end pulse has NO upper bound: once fusion is possible its
+        # length carries no information, and the 32 data pairs plus the
+        # inverted-command checksum already gate the decode.
+        if frame[66] < _MARK_MIN_US:
             return None
         if any(value > 0 for value in frame[67:]):
             return None

--- a/custom_components/hair/device_manager.py
+++ b/custom_components/hair/device_manager.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.core import HomeAssistant
@@ -29,6 +30,14 @@ _LOGGER = logging.getLogger(__name__)
 # Maps a captured command name (lowercased) → a feature key on the entity.
 # The key space is platform-specific; the entity reads
 # ``entity_config.command_mapping[<feature key>]`` to find the command name.
+# Temp N naming convention for AC target temperatures (v0.6.1, GH #45).
+# Matches "Temp 24", "Temp: 24", "Temperature 24" (case-insensitive,
+# 1-3 digits). The degree value is unit-agnostic; HA interprets it in
+# the installation's unit system.
+_TEMP_COMMAND_PATTERN = re.compile(
+    r"temp(?:erature)?\s*:?\s*(\d{1,3})", re.IGNORECASE
+)
+
 AUTO_MAP_RULES: dict[str, str] = {
     "power": "power_toggle",
     "power on": "turn_on",
@@ -467,6 +476,28 @@ class DeviceManager:
     def _auto_map_command(self, device: IRDevice, command: IRCommand) -> None:
         feature = AUTO_MAP_RULES.get(command.name.casefold())
         if feature is None:
+            # Pattern rule (v0.6.1, GH #45): "Temp 24" / "Temp: 24" /
+            # "Temperature 24" on an AC device maps to the temp_24
+            # feature the climate entity already dispatches to, and
+            # registers 24 as a temperature preset so the thermostat
+            # card gains the step. Unit-agnostic: presets are plain
+            # integers interpreted in the installation's unit system,
+            # so 16..30 behaves as Celsius on a metric install.
+            if device.device_type == DeviceType.AC:
+                match = _TEMP_COMMAND_PATTERN.fullmatch(command.name.strip())
+                if match is not None:
+                    degrees = int(match.group(1))
+                    device.entity_config.command_mapping[
+                        f"temp_{degrees}"
+                    ] = command.name
+                    presets = list(
+                        device.entity_config.temperature_presets or []
+                    )
+                    if degrees not in presets:
+                        presets.append(degrees)
+                        device.entity_config.temperature_presets = sorted(
+                            presets
+                        )
             return
         device.entity_config.command_mapping[feature] = command.name
 
@@ -498,6 +529,18 @@ class DeviceManager:
         for key, value in list(mapping.items()):
             if value.casefold() == command.name.casefold():
                 mapping.pop(key, None)
+                # Deleting a temp command retires its preset too, so the
+                # thermostat's min/max and snap targets track reality.
+                if key.startswith("temp_") and key[5:].isdigit():
+                    degrees = int(key[5:])
+                    presets = list(
+                        device.entity_config.temperature_presets or []
+                    )
+                    if degrees in presets:
+                        presets.remove(degrees)
+                        device.entity_config.temperature_presets = (
+                            sorted(presets) or None
+                        )
 
     def get_device(self, device_id: str) -> IRDevice | None:
         return self._store.get_device(device_id)

--- a/custom_components/hair/frontend/dist/ha-panel-ir-devices.js
+++ b/custom_components/hair/frontend/dist/ha-panel-ir-devices.js
@@ -6602,7 +6602,7 @@ function e(e,t,i,s){var o,a=arguments.length,r=a<3?t:null===s?s=Object.getOwnPro
                       ></ir-add-device-dialog>
                   `:""}
 
-            <div class="version-footer">v${"0.6.0"}</div>
+            <div class="version-footer">v${"0.6.1"}</div>
             </ha-top-app-bar-fixed>
         `:B`<div class="loading">Loading…</div>`}};fs.styles=r`
         :host {

--- a/custom_components/hair/frontend/dist/ha-panel-ir-devices.js
+++ b/custom_components/hair/frontend/dist/ha-panel-ir-devices.js
@@ -4514,11 +4514,14 @@ function e(e,t,i,s){var o,a=arguments.length,r=a<3?t:null===s?s=Object.getOwnPro
             pointer-events: none;
         }
 
-        /* Latest signal: bright green filled Assign button */
+        /* Latest signal: deep green fill (AA contrast with the white
+           label) with a mint rim that previews the hit ring. Locked
+           design: sniffer-hit-glow.md -- the earlier same-green halo
+           read as a blob against the fill. */
         .action-btn.assign-btn.recent-latest {
             color: #fff;
             background: #2e7d32;
-            border-color: #2e7d32;
+            border-color: #69f0ae;
         }
         .action-btn.assign-btn.recent-latest:hover {
             background: #1b5e20;
@@ -4534,14 +4537,15 @@ function e(e,t,i,s){var o,a=arguments.length,r=a<3?t:null===s?s=Object.getOwnPro
             background: rgba(46, 125, 50, 0.12);
         }
 
-        /* Glow pulse animation on hit */
+        /* Hit pulse: the mint rim blooms into a ring, brighter than
+           the fill so the halo separates instead of blobbing. */
         .action-btn.assign-btn.glow {
-            animation: assign-glow 1.2s ease-out;
+            animation: assign-glow 1.4s ease-out;
         }
         @keyframes assign-glow {
-            0% { box-shadow: 0 0 0 0 rgba(46, 125, 50, 0.6); }
-            50% { box-shadow: 0 0 8px 3px rgba(46, 125, 50, 0.3); }
-            100% { box-shadow: 0 0 0 0 rgba(46, 125, 50, 0); }
+            0% { box-shadow: 0 0 0 0 rgba(105, 240, 174, 0.9); }
+            35% { box-shadow: 0 0 0 2px #69f0ae, 0 0 12px 5px rgba(105, 240, 174, 0.55); }
+            100% { box-shadow: 0 0 0 0 rgba(105, 240, 174, 0); }
         }
 
         /* Hit count flash animation */

--- a/custom_components/hair/frontend/src/ha-panel-ir-devices.ts
+++ b/custom_components/hair/frontend/src/ha-panel-ir-devices.ts
@@ -18,7 +18,7 @@ import type { DeviceSummary, IRDevice } from "./types.js";
 // Bump alongside manifest.json on every release. Surfaced as a quiet
 // footer line at the bottom of the panel so users (and bug reporters)
 // can identify the installed HAIR version without opening Settings.
-const HAIR_VERSION = "0.6.0";
+const HAIR_VERSION = "0.6.1";
 
 type PanelTab = "devices" | "sniffer" | "clips" | "plucker";
 

--- a/custom_components/hair/frontend/src/ir-signal-monitor.ts
+++ b/custom_components/hair/frontend/src/ir-signal-monitor.ts
@@ -1904,11 +1904,14 @@ export class IrSignalMonitor extends LitElement {
             pointer-events: none;
         }
 
-        /* Latest signal: bright green filled Assign button */
+        /* Latest signal: deep green fill (AA contrast with the white
+           label) with a mint rim that previews the hit ring. Locked
+           design: sniffer-hit-glow.md -- the earlier same-green halo
+           read as a blob against the fill. */
         .action-btn.assign-btn.recent-latest {
             color: #fff;
             background: #2e7d32;
-            border-color: #2e7d32;
+            border-color: #69f0ae;
         }
         .action-btn.assign-btn.recent-latest:hover {
             background: #1b5e20;
@@ -1924,14 +1927,15 @@ export class IrSignalMonitor extends LitElement {
             background: rgba(46, 125, 50, 0.12);
         }
 
-        /* Glow pulse animation on hit */
+        /* Hit pulse: the mint rim blooms into a ring, brighter than
+           the fill so the halo separates instead of blobbing. */
         .action-btn.assign-btn.glow {
-            animation: assign-glow 1.2s ease-out;
+            animation: assign-glow 1.4s ease-out;
         }
         @keyframes assign-glow {
-            0% { box-shadow: 0 0 0 0 rgba(46, 125, 50, 0.6); }
-            50% { box-shadow: 0 0 8px 3px rgba(46, 125, 50, 0.3); }
-            100% { box-shadow: 0 0 0 0 rgba(46, 125, 50, 0); }
+            0% { box-shadow: 0 0 0 0 rgba(105, 240, 174, 0.9); }
+            35% { box-shadow: 0 0 0 2px #69f0ae, 0 0 12px 5px rgba(105, 240, 174, 0.55); }
+            100% { box-shadow: 0 0 0 0 rgba(105, 240, 174, 0); }
         }
 
         /* Hit count flash animation */

--- a/custom_components/hair/manifest.json
+++ b/custom_components/hair/manifest.json
@@ -1,7 +1,7 @@
 {
     "domain": "hair",
     "name": "HAIR",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "documentation": "https://github.com/DAB-LABS/HAIR",
     "issue_tracker": "https://github.com/DAB-LABS/HAIR/issues",
     "dependencies": ["infrared"],

--- a/custom_components/hair/protocol_decode.py
+++ b/custom_components/hair/protocol_decode.py
@@ -77,6 +77,15 @@ class ProtocolSpec:
     extract: Any  # Callable[[command], (label, address, command, extras|None)]
     construct: Any  # Callable[[label, address, command, extras|None], command|None]
     labels: tuple[str, ...] = field(default=())  # labels this spec serves
+    # Optional recovery hooks (v0.6.1, NEC only today).
+    # ``seek``: pre-pass trimming leading junk before the decode attempt.
+    # ``salvage``: lenient re-read tried ONLY when the strict decoder
+    # rejects; must gate on the protocol's own integrity check and
+    # return (address, command) or None. Both apply to this spec's
+    # attempt alone; later specs in the probe order see the original
+    # capture untouched.
+    seek: Any = None  # Callable[[list[int]], list[int]] | None
+    salvage: Any = None  # Callable[[list[int]], tuple[int, int] | None] | None
 
 
 def _import_class(module_name: str, class_name: str) -> type | None:
@@ -303,6 +312,15 @@ def _build_registry() -> list[ProtocolSpec]:
         if resolved is None:
             continue
         cls, source = resolved
+        seek = salvage = None
+        if key == "nec":
+            # v0.6.1 recovery hooks: leader-seek admits repeat-prefix
+            # captures to the strict decoder; checksum salvage rescues
+            # single-pulse dead-zone jitter (blalor's Previous Track).
+            from .decoders import nec_recovery
+
+            seek = nec_recovery.seek_main_leader
+            salvage = nec_recovery.salvage_decode
         specs.append(
             ProtocolSpec(
                 key=key,
@@ -312,6 +330,8 @@ def _build_registry() -> list[ProtocolSpec]:
                 extract=extract,
                 construct=construct,
                 labels=labels,
+                seek=seek,
+                salvage=salvage,
             )
         )
     return specs
@@ -401,11 +421,35 @@ def try_decode_identity(raw_timings: list[int] | None) -> DecodedIdentity | None
     if not raw_timings:
         return None
     for spec in _ensure_registry():
+        attempt = list(raw_timings)
+        if spec.seek is not None:
+            try:
+                attempt = spec.seek(attempt)
+            except Exception:  # a broken seek must not cost the strict path
+                attempt = list(raw_timings)
         try:
-            cmd = spec.command_cls.from_raw_timings(list(raw_timings))
+            cmd = spec.command_cls.from_raw_timings(attempt)
         except Exception:  # never break capture on a malformed-input error
-            continue
+            cmd = None
         if cmd is None:
+            if spec.salvage is not None:
+                try:
+                    salvaged = spec.salvage(attempt)
+                except Exception:
+                    salvaged = None
+                if salvaged is not None:
+                    address, command = salvaged
+                    protocol = spec.labels[0]
+                    return DecodedIdentity(
+                        protocol=protocol,
+                        address=address,
+                        command=command,
+                        fingerprint=format_fingerprint(
+                            protocol, address, command, None
+                        ),
+                        extras=None,
+                        source=spec.source,
+                    )
             continue
         try:
             protocol, address, command, extras = spec.extract(cmd)

--- a/custom_components/hair/tests/test_decoders.py
+++ b/custom_components/hair/tests/test_decoders.py
@@ -542,3 +542,53 @@ class TestRejectionMatrix:
         assert (
             _DECODERS[decoder_name].from_raw_timings([1000, -1000] * 200) is None
         )
+
+
+# --- Samsung32 fused end pulse (v0.6.1 bench, Broadlink packet replay) ------
+
+
+def test_samsung32_fused_end_pulse_real_capture():
+    """Real loopback capture: Broadlink replayed the packet for the
+    command's repeat_count with no junction gap, fusing the 560us end
+    mark with the replay's 4500us leader into one ~4944us mark. Data
+    and checksum are intact; the decode must survive the fused tail."""
+    pairs = (
+        "00A0 009F 0014 003B 0014 003B 0014 003A 0014 0013 0014 0013"
+        " 0015 0013 0014 0013 0014 0013 0014 003B 0014 003A 0015 003A"
+        " 0014 0013 0014 0013 0014 0013 0014 0013 0014 0013 0014 0013"
+        " 0014 003B 0014 0012 0015 0012 0014 0013 0014 0013 0014 0013"
+        " 0014 0013 0014 003B 0014 0013 0014 003B 0014 003A 0014 003B"
+        " 0014 003B 0014 003B 0014 003B 00BC 017C"
+    )
+    unit = 0x6D * 0.241246
+    words = [int(w, 16) for w in pairs.split()]
+    timings = [
+        round(w * unit) if i % 2 == 0 else -round(w * unit)
+        for i, w in enumerate(words)
+    ]
+    cmd = Samsung32Command.from_raw_timings(timings)
+    assert cmd is not None
+    assert cmd.address == 0x0007
+
+
+def test_samsung32_fused_end_pulse_still_checksum_gated():
+    """A fused tail does not loosen the gate: corrupt one command bit
+    and the frame must still decode as nothing."""
+    base = Samsung32Command(address=0x0007, command=0x07).get_raw_timings()
+    # Fuse the end pulse as the junction artifact does.
+    fused = [*base[:-1], base[-1] + 4500]
+    assert Samsung32Command.from_raw_timings(fused) is not None
+    # Now flip a command bit's space (bit 16 pair space index 3 + 2*16).
+    corrupt = list(fused)
+    idx = 3 + 2 * 16
+    corrupt[idx] = -1690 if corrupt[idx] > -1125 else -560
+    assert Samsung32Command.from_raw_timings(corrupt) is None
+
+
+def test_samsung32_data_marks_keep_strict_bounds():
+    """The fused allowance applies to the end pulse only; an oversized
+    DATA mark still rejects the frame."""
+    base = Samsung32Command(address=0x0007, command=0x07).get_raw_timings()
+    bad = list(base)
+    bad[2] = 4944  # first data mark
+    assert Samsung32Command.from_raw_timings(bad) is None

--- a/custom_components/hair/tests/test_decoders.py
+++ b/custom_components/hair/tests/test_decoders.py
@@ -571,6 +571,28 @@ def test_samsung32_fused_end_pulse_real_capture():
     assert cmd.address == 0x0007
 
 
+def test_samsung32_larger_fusion_real_capture():
+    """Second real junction variant: ~6968us fused end mark. The end
+    pulse has no upper bound once fusion is possible."""
+    pairs = (
+        "00A0 009F 0014 003B 0014 003B 0014 003A 0014 0013 0014 0013"
+        " 0014 0013 0014 0013 0015 0012 0014 003B 0014 003A 0015 003A"
+        " 0014 0013 0014 0013 0014 0013 0014 0013 0014 0013 0014 003B"
+        " 0014 003A 0015 003A 0014 0013 0014 0013 0014 0013 0014 0013"
+        " 0014 0013 0014 0013 0014 0013 0014 0013 0014 003A 0014 003B"
+        " 0014 003B 0014 003B 0014 003B 0109 017C"
+    )
+    unit = 0x6D * 0.241246
+    words = [int(w, 16) for w in pairs.split()]
+    timings = [
+        round(w * unit) if i % 2 == 0 else -round(w * unit)
+        for i, w in enumerate(words)
+    ]
+    cmd = Samsung32Command.from_raw_timings(timings)
+    assert cmd is not None
+    assert cmd.address == 0x0007
+
+
 def test_samsung32_fused_end_pulse_still_checksum_gated():
     """A fused tail does not loosen the gate: corrupt one command bit
     and the frame must still decode as nothing."""

--- a/custom_components/hair/tests/test_device_manager.py
+++ b/custom_components/hair/tests/test_device_manager.py
@@ -516,3 +516,100 @@ class TestApplyAutoMap:
         assert (
             manager._store.get_device(dev.id).entity_config.command_mapping == {}
         )
+
+
+# --- Temp N auto-map (v0.6.1, GH #45) ---------------------------------------
+
+
+def _mock_device_registry():
+    return patch(
+        "custom_components.hair.device_manager.dr.async_get",
+        return_value=MagicMock(
+            async_get_or_create=MagicMock(return_value=MagicMock(id="x")),
+            async_get_device=MagicMock(return_value=None),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_temp_commands_auto_map_and_derive_presets(manager):
+    """"Temp 24" maps to temp_24 and registers the preset, sorted."""
+    device = IRDevice(
+        name="AC", device_type=DeviceType.AC, emitter_entity_ids=["infrared.a"]
+    )
+    with _mock_device_registry():
+        await manager.async_create_device(device)
+    for name in ("Temp 24", "Temp: 22", "temperature 26"):
+        await manager.async_add_command(
+            device.id, IRCommand(name=name, protocol="NEC", code="0x1")
+        )
+    refreshed = manager.get_device(device.id)
+    mapping = refreshed.entity_config.command_mapping
+    assert mapping["temp_24"] == "Temp 24"
+    assert mapping["temp_22"] == "Temp: 22"
+    assert mapping["temp_26"] == "temperature 26"
+    # Presets deduped and sorted; these drive the thermostat min/max,
+    # so a metric user's 16..30 set behaves as Celsius end to end.
+    assert refreshed.entity_config.temperature_presets == [22, 24, 26]
+
+
+@pytest.mark.asyncio
+async def test_temp_pattern_ignores_non_ac_devices(manager):
+    device = IRDevice(
+        name="TV",
+        device_type=DeviceType.MEDIA_PLAYER,
+        emitter_entity_ids=["infrared.a"],
+    )
+    with _mock_device_registry():
+        await manager.async_create_device(device)
+    await manager.async_add_command(
+        device.id, IRCommand(name="Temp 24", protocol="NEC", code="0x1")
+    )
+    refreshed = manager.get_device(device.id)
+    assert "temp_24" not in refreshed.entity_config.command_mapping
+    assert refreshed.entity_config.temperature_presets is None
+
+
+@pytest.mark.asyncio
+async def test_temp_preset_deduplicates(manager):
+    device = IRDevice(
+        name="AC", device_type=DeviceType.AC, emitter_entity_ids=["infrared.a"]
+    )
+    with _mock_device_registry():
+        await manager.async_create_device(device)
+    await manager.async_add_command(
+        device.id, IRCommand(name="Temp 24", protocol="NEC", code="0x1")
+    )
+    await manager.async_add_command(
+        device.id, IRCommand(name="TEMP 24", protocol="NEC", code="0x2")
+    )
+    refreshed = manager.get_device(device.id)
+    assert refreshed.entity_config.temperature_presets == [24]
+
+
+@pytest.mark.asyncio
+async def test_removing_temp_command_retires_preset(manager):
+    device = IRDevice(
+        name="AC", device_type=DeviceType.AC, emitter_entity_ids=["infrared.a"]
+    )
+    with _mock_device_registry():
+        await manager.async_create_device(device)
+    await manager.async_add_command(
+        device.id, IRCommand(name="Temp 24", protocol="NEC", code="0x1")
+    )
+    await manager.async_add_command(
+        device.id, IRCommand(name="Temp 26", protocol="NEC", code="0x2")
+    )
+    refreshed = manager.get_device(device.id)
+    target = next(
+        c for c in refreshed.commands if c.name == "Temp 24"
+    )
+    await manager.async_remove_command(device.id, target.id)
+    refreshed = manager.get_device(device.id)
+    assert "temp_24" not in refreshed.entity_config.command_mapping
+    assert refreshed.entity_config.temperature_presets == [26]
+    # Removing the last one clears the feature entirely (None, not []).
+    target = next(c for c in refreshed.commands if c.name == "Temp 26")
+    await manager.async_remove_command(device.id, target.id)
+    refreshed = manager.get_device(device.id)
+    assert refreshed.entity_config.temperature_presets is None

--- a/custom_components/hair/tests/test_entities.py
+++ b/custom_components/hair/tests/test_entities.py
@@ -12,6 +12,7 @@ from homeassistant.components.media_player import (
     MediaPlayerEntityFeature,
     MediaPlayerState,
 )
+from homeassistant.const import UnitOfTemperature
 
 from custom_components.hair.climate import (
     HAIRClimateEntity,
@@ -989,3 +990,56 @@ class TestHAIRCoverEntity:
         entity.update_device(new_device)
         assert entity._device.name == "Updated Screen"
         entity.async_write_ha_state.assert_called()
+
+
+class TestClimateTargetSeedingAndUnits:
+    """v0.6.1 bench finds: dial handle seeding + installation units."""
+
+    def _make(self, temperature_presets=None):
+        config = EntityConfig(
+            platform="climate",
+            command_mapping={},
+            temperature_presets=temperature_presets,
+        )
+        device = _device(
+            device_type=DeviceType.AC, commands=[], entity_config=config
+        )
+        mgr = _manager()
+        entity = HAIRClimateEntity(device, mgr)
+        _patch_write_state(entity)
+        return entity, mgr
+
+    def test_presets_seed_median_target_at_init(self):
+        entity, mgr = self._make(temperature_presets=[22, 24, 26])
+        assert entity.target_temperature == 24.0
+        mgr.async_send_command.assert_not_awaited()  # seeding never transmits
+
+    def test_no_presets_no_seed(self):
+        entity, _ = self._make()
+        assert entity.target_temperature is None
+
+    def test_presets_arriving_later_seed_via_update_device(self):
+        entity, mgr = self._make()
+        assert entity.target_temperature is None
+        device = entity._device
+        device.entity_config.temperature_presets = [16, 22, 30]
+        entity.update_device(device)
+        assert entity.target_temperature == 22.0
+        mgr.async_send_command.assert_not_awaited()
+
+    def test_seed_does_not_clobber_user_target(self):
+        entity, _ = self._make(temperature_presets=[22, 24, 26])
+        entity._target_temperature = 26.0
+        entity.update_device(entity._device)
+        assert entity.target_temperature == 26.0
+
+    def test_temperature_unit_follows_installation(self):
+        entity, _ = self._make(temperature_presets=[16, 22, 30])
+        # Without hass: conservative fallback (previous behavior).
+        entity.hass = None
+        assert entity.temperature_unit == UnitOfTemperature.FAHRENHEIT
+        # With hass: the installation's unit system wins (B3 / GH #45).
+        hass = MagicMock()
+        hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
+        entity.hass = hass
+        assert entity.temperature_unit == UnitOfTemperature.CELSIUS

--- a/custom_components/hair/tests/test_entities.py
+++ b/custom_components/hair/tests/test_entities.py
@@ -545,6 +545,27 @@ class TestHAIRClimateEntity:
         assert entity._target_temperature == 72.0
 
     @pytest.mark.asyncio
+    async def test_set_temperature_metric_presets_end_to_end(self):
+        """Celsius-range presets (GH #45 reporter is metric) drive the
+        thermostat bounds and snap-and-send, with no unit assumptions."""
+        cmds = [_cmd("c16", "Temp 16"), _cmd("c22", "Temp 22"),
+                _cmd("c30", "Temp 30")]
+        entity, mgr = self._make(
+            command_mapping={
+                "temp_16": "Temp 16",
+                "temp_22": "Temp 22",
+                "temp_30": "Temp 30",
+            },
+            commands=cmds,
+            temperature_presets=[16, 22, 30],
+        )
+        assert entity.min_temp == 16.0
+        assert entity.max_temp == 30.0
+        await entity.async_set_temperature(temperature=23)
+        mgr.async_send_command.assert_awaited_once_with("dev-1", "c22")
+        assert entity._target_temperature == 22.0
+
+    @pytest.mark.asyncio
     async def test_set_temperature_no_target_noop(self):
         entity, mgr = self._make()
         await entity.async_set_temperature()

--- a/custom_components/hair/tests/test_nec_recovery.py
+++ b/custom_components/hair/tests/test_nec_recovery.py
@@ -1,0 +1,165 @@
+"""NEC leader-seek and checksum salvage (v0.6.1, hot-towel-finish).
+
+The two real captures below are blalor's Previous Track button, posted
+on the HA community launch thread (post #109, 2026-07-17) after the
+v0.6.0 release. Capture 2 is textbook clean and decodes strictly.
+Capture 1 was rejected by the strict decoder over a single data space
+measuring ~815us, in the dead zone between NEC's two legal spaces,
+while the frame's command checksum held. Both are the same button:
+NEC address 0xC7EA, command 0x34. These fixtures pin that forever.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.hair.decoders import nec_recovery
+from custom_components.hair.protocol_decode import try_decode_identity
+
+# --- fixtures: blalor's Previous Track captures (Pronto, 006D carrier) ------
+
+BLALOR_JITTERED = (
+    "0158 00AB 0017 0014 0018 003D 0017 0015 0015 0040 0015 0017 0014 003F"
+    " 0017 003F 0015 003F 0016 0040 0016 003F 0016 0040 0014 0017 0014 0016"
+    " 0015 0016 0015 0041 0016 003F 0015 0015 0015 0016 0015 0041 0014 0017"
+    " 0014 0046 000F 0040 0015 0016 0015 0016 0015 0043 0012 0049 000C 0019"
+    " 0012 0043 0013 0015 0015 001F 000C 0042 0013 0041 0014 017C"
+)
+
+BLALOR_CLEAN = (
+    "0157 00AB 0016 0015 0016 003F 0016 0015 0016 003F 0016 0015 0016 003F"
+    " 0016 003F 0016 003F 0016 003F 0016 003F 0016 003F 0016 0015 0016 0015"
+    " 0016 0015 0016 003F 0016 003F 0016 0015 0016 0015 0016 003F 0016 0015"
+    " 0016 003F 0016 003F 0016 0015 0016 0015 0016 003F 0016 003F 0016 0015"
+    " 0016 003F 0016 0015 0016 0015 0016 003F 0016 003F 0016 017C"
+)
+
+BLALOR_FINGERPRINT = "NEC:0xc7ea:0x34"
+
+# Pronto unit for frequency code 0x006D, microseconds per unit.
+_PRONTO_UNIT_US = 0x6D * 0.241246
+
+
+def pronto_pairs_to_timings(pairs_hex: str) -> list[int]:
+    """Convert Pronto burst pairs (hex words) to signed microseconds."""
+    words = [int(word, 16) for word in pairs_hex.split()]
+    timings: list[int] = []
+    for index, word in enumerate(words):
+        value = round(word * _PRONTO_UNIT_US)
+        timings.append(value if index % 2 == 0 else -value)
+    return timings
+
+
+def _clean_nec_timings(address: int = 0xC7EA, command: int = 0x34) -> list[int]:
+    """Encode a clean NEC frame via the upstream library."""
+    nec = pytest.importorskip("infrared_protocols.commands.nec")
+    return nec.NECCommand(address=address, command=command).get_raw_timings()
+
+
+# --- the real captures -------------------------------------------------------
+
+
+def test_blalor_clean_capture_decodes_strictly() -> None:
+    identity = try_decode_identity(pronto_pairs_to_timings(BLALOR_CLEAN))
+    assert identity is not None
+    assert identity.protocol == "NEC"
+    assert identity.fingerprint == BLALOR_FINGERPRINT
+
+
+def test_blalor_jittered_capture_salvages_to_same_identity() -> None:
+    """One dead-zone pulse must no longer split a button into two rows."""
+    identity = try_decode_identity(pronto_pairs_to_timings(BLALOR_JITTERED))
+    assert identity is not None
+    assert identity.protocol == "NEC"
+    assert (identity.address, identity.command) == (0xC7EA, 0x34)
+    assert identity.fingerprint == BLALOR_FINGERPRINT
+
+
+def test_both_blalor_captures_unify() -> None:
+    first = try_decode_identity(pronto_pairs_to_timings(BLALOR_JITTERED))
+    second = try_decode_identity(pronto_pairs_to_timings(BLALOR_CLEAN))
+    assert first is not None and second is not None
+    assert first.fingerprint == second.fingerprint
+
+
+# --- salvage honesty: the checksum is the gate -------------------------------
+
+
+def test_salvage_rejects_broken_checksum() -> None:
+    """Flip one decoded bit's worth of space width: salvage must refuse."""
+    timings = pronto_pairs_to_timings(BLALOR_JITTERED)
+    # Data pulse pairs start at index 2 (leader mark, leader space first).
+    # Pair n occupies indices (2 + 2n, 3 + 2n); flip bit 16 (first command
+    # bit) from its current classification by swapping its space width.
+    space_index = 3 + 2 * 16
+    timings[space_index] = -1600 if timings[space_index] > -1125 else -560
+    assert nec_recovery.salvage_decode(timings) is None
+    assert try_decode_identity(timings) is None
+
+
+def test_salvage_rejects_non_nec_shapes() -> None:
+    assert nec_recovery.salvage_decode([]) is None
+    assert nec_recovery.salvage_decode([9000, -4500, 560]) is None
+    # Sony-shaped leader: not an NEC main leader.
+    assert nec_recovery.salvage_decode([2400, -600] + [600, -600] * 40) is None
+
+
+def test_salvage_does_not_fire_when_strict_succeeds() -> None:
+    """A clean frame is upstream's to decode; extract path unchanged."""
+    identity = try_decode_identity(_clean_nec_timings())
+    assert identity is not None
+    assert identity.fingerprint == BLALOR_FINGERPRINT
+
+
+# --- leader-seek: repeat-prefix and junk-prefix captures ---------------------
+
+
+def test_seek_passes_through_clean_capture() -> None:
+    timings = _clean_nec_timings()
+    assert nec_recovery.seek_main_leader(timings) == timings
+
+
+def test_repeat_prefix_capture_decodes_after_seek() -> None:
+    """A stray repeat marker ahead of the main frame no longer blocks it."""
+    prefix = [9000, -2250, 560, -40000]  # previous press's repeat marker
+    timings = prefix + _clean_nec_timings()
+    identity = try_decode_identity(timings)
+    assert identity is not None
+    assert identity.fingerprint == BLALOR_FINGERPRINT
+
+
+def test_junk_prefix_capture_decodes_after_seek() -> None:
+    """Partial-burst noise ahead of the leader is skipped, not fatal."""
+    prefix = [420, -380, 560, -1700, 430, -12000]
+    timings = prefix + _clean_nec_timings()
+    identity = try_decode_identity(timings)
+    assert identity is not None
+    assert identity.fingerprint == BLALOR_FINGERPRINT
+
+
+def test_seek_without_any_leader_changes_nothing() -> None:
+    junk = [420, -380, 560, -1700, 430, -12000]
+    assert nec_recovery.seek_main_leader(junk) == junk
+    assert try_decode_identity(junk) is None
+
+
+def test_repeat_marker_alone_is_not_salvaged() -> None:
+    """A lone repeat frame has no data payload; it must stay undecoded."""
+    marker = [9000, -2250, 560, -96000]
+    assert try_decode_identity(marker) is None
+
+
+# --- the other protocols keep their lanes ------------------------------------
+
+
+def test_sony_capture_still_decodes_as_sony() -> None:
+    """The NEC seek/salvage hooks must not siphon other protocols."""
+    real_sony = [
+        2446, -579, 1210, -605, 1210, -605, 1236, -579, 605, -605,
+        605, -605, 1210, -605, 631, -579, 1210, -605, 1210, -605,
+        1236, -579, 605, -605, 1210, -605, 605, -605, 631, -579,
+        1210, -10124,
+    ]
+    identity = try_decode_identity(real_sony)
+    assert identity is not None
+    assert identity.protocol == "SONY15"

--- a/custom_components/hair/tests/test_nec_recovery.py
+++ b/custom_components/hair/tests/test_nec_recovery.py
@@ -60,6 +60,7 @@ def _clean_nec_timings(address: int = 0xC7EA, command: int = 0x34) -> list[int]:
 
 
 def test_blalor_clean_capture_decodes_strictly() -> None:
+    pytest.importorskip("infrared_protocols.commands.nec")
     identity = try_decode_identity(pronto_pairs_to_timings(BLALOR_CLEAN))
     assert identity is not None
     assert identity.protocol == "NEC"
@@ -68,6 +69,7 @@ def test_blalor_clean_capture_decodes_strictly() -> None:
 
 def test_blalor_jittered_capture_salvages_to_same_identity() -> None:
     """One dead-zone pulse must no longer split a button into two rows."""
+    pytest.importorskip("infrared_protocols.commands.nec")
     identity = try_decode_identity(pronto_pairs_to_timings(BLALOR_JITTERED))
     assert identity is not None
     assert identity.protocol == "NEC"
@@ -76,6 +78,7 @@ def test_blalor_jittered_capture_salvages_to_same_identity() -> None:
 
 
 def test_both_blalor_captures_unify() -> None:
+    pytest.importorskip("infrared_protocols.commands.nec")
     first = try_decode_identity(pronto_pairs_to_timings(BLALOR_JITTERED))
     second = try_decode_identity(pronto_pairs_to_timings(BLALOR_CLEAN))
     assert first is not None and second is not None

--- a/llms.txt
+++ b/llms.txt
@@ -161,9 +161,9 @@ Signal fingerprinting details:
   observation does not auto-set the TX Ditto count; the user acts on it.
 
 Supported capture providers (auto-discovered):
-- Native InfraredReceiverEntity instances (HA 2026.6+, hardware-agnostic)
+- Native InfraredReceiverEntity instances (HA 2026.6+, hardware-agnostic;
+  ESPHome receivers and SMLIGHT Ultima receivers ship this today)
 - ESPHome devices with the remote_receiver component (legacy bridge)
-- Broadlink RM series devices
 
 Supported transmit hardware: any IR emitter exposed to HA's infrared platform,
 including ESPHome IR LEDs, Tuya Local IR blasters, Broadlink RM series, and

--- a/llms.txt
+++ b/llms.txt
@@ -125,6 +125,20 @@ Key components:
   successful send. GE-AC registers identity-only (tx_rebuild=False): decoded
   identity matches/collapses signals, but TX always replays the captured
   raw, since re-encoding AC state risks transmitting wrong state.
+  Recovery passes (v0.6.1): registry specs can carry optional seek and
+  salvage hooks, wired for NEC today. Seek trims junk ahead of the main
+  leader (stray repeat markers, partial bursts) before the strict decode;
+  salvage runs only after a strict reject, re-reads data pulses by
+  midpoint, and accepts solely on the protocol's own checksum. Samsung32
+  additionally tolerates an end pulse fused with a replayed packet's
+  leader (emitters that honor repeat_count on top of baked repeat frames
+  leave no junction gap); its inverted-command checksum still gates.
+  AC climate mapping (v0.6.1): commands named "Temp N" on an AC device
+  auto-map to temp_N and derive temperature_presets (deduped, sorted);
+  deleting one retires the preset. The climate entity seeds its target
+  from the median preset so the thermostat dial has a handle, and
+  reports the installation's temperature unit rather than a hardcoded
+  scale.
 
 Signal fingerprinting details:
 - Uses S/L (short/long) pulse-duration classification. Each pulse is classified as

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ test = [
     # Upstream moved to 7.x in 2026-07; the commands.Command contract is
     # unchanged from 5.x (verified against the 7.5.0 source), so the cap
     # tracks the next major.
-    "infrared-protocols>=5.6,<8.0; python_version >= '3.13'",
+    "infrared-protocols>=5.6,<9.0; python_version >= '3.13'",
 ]
 lint = [
     "ruff>=0.4",


### PR DESCRIPTION
Cleanup release. NEC leader-seek and checksum-backed salvage (blalor fixtures), Temp N auto-map with preset derivation and thermostat fixes (GH #45), Samsung32 fused end pulse tolerance (bench fixtures), sniffer hit glow per the locked spec, test pin to <9.0, adopters table update. Known issue documented in CHANGELOG: heal-merged rows can orphan trigger badges (triggers keep firing); fix planned as its own release.