### PR TITLE
feat(decoders): add Nokia32 (RC-MM) guest decoder + Foxtel identity

### DIFF
--- a/custom_components/hair/decoders/nokia32.py
+++ b/custom_components/hair/decoders/nokia32.py
@@ -1,0 +1,186 @@
+"""Nokia32 (Philips RC-MM / NRC17 family) IR command with decode support.
+
+Encode side mirrors ``infrared_protocols.commands.nokia32.Nokia32Command``
+byte-for-byte (asserted by round-trip tests). Decode side follows the
+upstream ``from_raw_timings`` conventions, wrapped in HAIR's frame-split +
+majority-vote so a held button (Nokia32 re-sends the whole frame on a
+~100ms period, it has no distinct repeat frame) collapses to one identity.
+
+Nokia32 is a 32-bit, 36 kHz, MSB-first protocol used by RC-MM set-top
+boxes -- Foxtel (AU), Sky/Digibox (Pace/Amstrad, UK/IE), Nokia
+Mediamaster / d-box (EU):
+
+- Leader: 412us mark, 276us space.
+- Payload ``D:8 S:8 T:1 X:7 F:8`` sent MSB-first as sixteen 2-bit symbols.
+  Every symbol is a 164us mark followed by one of four spaces encoding the
+  symbol value 0..3: 276, 445, 614, 783us.
+- Closing 164us mark, then the ~100ms inter-frame period.
+
+``device``/``subdevice`` address the box, ``extension`` (X) is the 7-bit
+system/OEM code that separates Foxtel from Sky from Mediamaster on the
+same protocol, ``function`` is the button, ``toggle`` flips between
+distinct presses (press state, not identity).
+
+Protocol work and the Foxtel iQ capture set: @rohrsh (HAIR #52).
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Self, override
+
+from . import decode_frames_majority, is_close, split_frames
+from ._base import Command
+
+_LEADER_MARK_US = 412
+_LEADER_SPACE_US = 276
+_BIT_MARK_US = 164
+# 2-bit symbol value (0..3) -> trailing space duration in microseconds.
+_SYMBOL_SPACE_US = (276, 445, 614, 783)
+# Nokia32's tolerance is tighter than the NEC default; the four symbol
+# spaces are only ~170us apart, so keep the upstream 0.3 band.
+_TOLERANCE = 0.3
+
+_DATA_SYMBOLS = 16  # 32 payload bits, 2 bits per symbol
+# leader pair (2) + 16 symbol pairs (32) + closing mark (1)
+_MIN_FRAME_LEN = 2 + _DATA_SYMBOLS * 2 + 1
+# Largest intra-frame space is 783us; the inter-frame period is ~100ms.
+# Any space of 8ms+ is a frame boundary, never a symbol.
+_FRAME_GAP_US = 8000
+
+
+class Nokia32Command(Command):
+    """Nokia32 IR command with decode support."""
+
+    device: int
+    subdevice: int
+    toggle: int
+    extension: int
+    function: int
+
+    def __init__(
+        self,
+        *,
+        device: int,
+        subdevice: int,
+        function: int,
+        extension: int = 0,
+        toggle: int = 0,
+        modulation: int = 36000,
+    ) -> None:
+        """Initialize the Nokia32 IR command.
+
+        :param device: box device code D (8 bits)
+        :param subdevice: box subdevice code S (8 bits)
+        :param function: button code F (8 bits)
+        :param extension: system/OEM code X (7 bits)
+        :param toggle: press-state toggle T (1 bit)
+        """
+        super().__init__(modulation=modulation)
+        self.device = device & 0xFF
+        self.subdevice = subdevice & 0xFF
+        self.toggle = toggle & 0x1
+        self.extension = extension & 0x7F
+        self.function = function & 0xFF
+
+    @override
+    def get_raw_timings(self) -> list[int]:
+        """Get raw timings for the Nokia32 command.
+
+        Positive values are mark (high) durations in microseconds; negative
+        values are space (low) durations. Byte-identical to the upstream
+        encoder: a single frame, no repeat (Nokia32 has no repeat frame).
+        """
+        third = (self.toggle << 7) | self.extension
+        value = (
+            (self.device << 24)
+            | (self.subdevice << 16)
+            | (third << 8)
+            | self.function
+        )
+        timings: list[int] = [_LEADER_MARK_US, -_LEADER_SPACE_US]
+        for shift in range(2 * (_DATA_SYMBOLS - 1), -1, -2):  # MSB-first
+            symbol = (value >> shift) & 0b11
+            timings.append(_BIT_MARK_US)
+            timings.append(-_SYMBOL_SPACE_US[symbol])
+        timings.append(_BIT_MARK_US)  # closing mark
+        return timings
+
+    @classmethod
+    def from_raw_timings(cls, timings: list[int]) -> Self | None:
+        """Decode raw IR timings into a Nokia32Command, or None if no match.
+
+        The capture is split into frames at the ~100ms inter-frame period;
+        each frame decodes independently and the majority vote wins, so a
+        single tap and a jittery multi-frame hold of one button yield the
+        same identity. Toggle is recovered for transmit but does not split
+        the vote (a held button keeps one toggle value).
+        """
+        frames = split_frames(timings, _FRAME_GAP_US)
+        result = decode_frames_majority(frames, cls._decode_frame)
+        if result is None:
+            return None
+        (device, subdevice, toggle, extension, function), _votes = result
+        return cls(
+            device=device,
+            subdevice=subdevice,
+            function=function,
+            extension=extension,
+            toggle=toggle,
+        )
+
+    @classmethod
+    def _decode_frame(
+        cls, frame: Sequence[int]
+    ) -> tuple[int, int, int, int, int] | None:
+        """Decode one Nokia32 frame to (device, subdevice, toggle, ext, fn).
+
+        Mirrors the upstream per-symbol checks: leader, then sixteen
+        164us-mark / classified-space symbols, then the closing mark. Any
+        timing outside tolerance rejects the frame (this is what keeps a
+        clean frame of another protocol from decoding as Nokia32).
+        """
+        if len(frame) < _MIN_FRAME_LEN:
+            return None
+        if not is_close(frame[0], _LEADER_MARK_US, _TOLERANCE):
+            return None
+        if not is_close(-frame[1], _LEADER_SPACE_US, _TOLERANCE):
+            return None
+
+        value = 0
+        for i in range(_DATA_SYMBOLS):
+            mark = frame[2 + 2 * i]
+            space = -frame[3 + 2 * i]
+            if not is_close(mark, _BIT_MARK_US, _TOLERANCE):
+                return None
+            symbol = cls._classify_symbol(space)
+            if symbol is None:
+                return None
+            value = (value << 2) | symbol
+
+        closing = frame[2 + 2 * _DATA_SYMBOLS]
+        if not is_close(closing, _BIT_MARK_US, _TOLERANCE):
+            return None
+        # Only spaces may follow the closing mark (a truncated trailer or
+        # the start of the inter-frame gap); a further mark is another frame
+        # that split_frames should have separated -- reject to be safe.
+        if any(value_after > 0 for value_after in frame[_MIN_FRAME_LEN:]):
+            return None
+
+        third = (value >> 8) & 0xFF
+        return (
+            (value >> 24) & 0xFF,  # device
+            (value >> 16) & 0xFF,  # subdevice
+            (third >> 7) & 0x1,    # toggle
+            third & 0x7F,          # extension
+            value & 0xFF,          # function
+        )
+
+    @staticmethod
+    def _classify_symbol(space_us: int) -> int | None:
+        """Classify a trailing space into a 2-bit symbol value, or None."""
+        best = min(
+            range(4), key=lambda i: abs(space_us - _SYMBOL_SPACE_US[i])
+        )
+        if is_close(space_us, _SYMBOL_SPACE_US[best], _TOLERANCE):
+            return best
+        return None

--- a/custom_components/hair/protocol_decode.py
+++ b/custom_components/hair/protocol_decode.py
@@ -185,6 +185,27 @@ def _construct_sharp(cls: type, label: str, address: int, command: int,
     return cls(address=address, command=command, extension=extension & 1)
 
 
+def _extract_nokia32(cmd: Any) -> tuple[str, int, int, dict[str, int] | None]:
+    # device/subdevice pack into the 16-bit box address; function is the
+    # command; X (system/OEM) is identity and rides in the suffix; toggle
+    # is press state, carried for TX but kept out of the fingerprint.
+    address = (int(cmd.device) << 8) | int(cmd.subdevice)
+    return ("NOKIA32", address, int(cmd.function),
+            {"extension": int(cmd.extension), "toggle": int(cmd.toggle)})
+
+
+def _construct_nokia32(cls: type, label: str, address: int, command: int,
+                       extras: Any) -> Any:
+    bag = extras or {}
+    return cls(
+        device=(address >> 8) & 0xFF,
+        subdevice=address & 0xFF,
+        function=command,
+        extension=int(bag.get("extension", 0)) & 0x7F,
+        toggle=int(bag.get("toggle", 0)) & 1,
+    )
+
+
 def _extract_marantz(cmd: Any) -> tuple[str, int, int, dict[str, int] | None]:
     return ("MARANTZ", int(cmd.address), int(cmd.command),
             {"extension": int(cmd.extension), "toggle": int(cmd.toggle)})
@@ -260,6 +281,9 @@ def _identity_suffix(protocol: str, extras: Mapping[str, int] | None) -> str:
         return ":x1"
     if protocol == "MARANTZ":
         return f":x{int(extras.get('extension', 0)):02x}"
+    if protocol == "NOKIA32":
+        # X (system/OEM) separates Foxtel/Sky/Mediamaster on one protocol.
+        return f":x{int(extras.get('extension', 0)):02x}"
     return ""
 
 
@@ -283,6 +307,12 @@ _REGISTRATIONS: tuple[tuple, ...] = (
     ("sharp", "infrared_protocols.commands.sharp", "SharpCommand",
      "custom_components.hair.decoders.sharp", True,
      _extract_sharp, _construct_sharp, ("SHARP",)),
+    # Upstream ships no Nokia32 yet, so this resolves to the local decoder;
+    # if the library ever adds Nokia32Command with from_raw_timings, HAIR
+    # defers to it automatically (rohrsh's branch, discussion #70).
+    ("nokia32", "infrared_protocols.commands.nokia32", "Nokia32Command",
+     "custom_components.hair.decoders.nokia32", True,
+     _extract_nokia32, _construct_nokia32, ("NOKIA32",)),
     ("marantz", "infrared_protocols.commands.marantz_extended",
      "MarantzExtendedCommand",
      "custom_components.hair.decoders.marantz_extended", True,

--- a/custom_components/hair/tests/test_decoders.py
+++ b/custom_components/hair/tests/test_decoders.py
@@ -18,6 +18,7 @@ frames) are built from the field reports that motivated each decoder.
 """
 from __future__ import annotations
 
+import base64
 import importlib.util
 import itertools
 
@@ -25,6 +26,7 @@ import pytest
 
 from custom_components.hair.decoders.kaseikyo import KaseikyoCommand
 from custom_components.hair.decoders.marantz_extended import MarantzExtendedCommand
+from custom_components.hair.decoders.nokia32 import Nokia32Command
 from custom_components.hair.decoders.rc5 import RC5Command
 from custom_components.hair.decoders.samsung import Samsung32Command
 from custom_components.hair.decoders.sharp import SharpCommand
@@ -37,6 +39,20 @@ _needs_library = pytest.mark.skipif(
     not _HAS_LIBRARY,
     reason="infrared-protocols unavailable (requires Python 3.13+)",
 )
+
+
+def _broadlink_to_us(b64: str) -> list[int]:
+    """Convert a Broadlink RM base64 IR payload to signed us timings."""
+    raw = base64.b64decode(b64 + "=" * (-len(b64) % 4))
+    length = raw[2] | (raw[3] << 8)
+    ticks = list(raw[4 : 4 + length])
+    while ticks and ticks[-1] == 0:
+        ticks = ticks[:-1]
+    tick_us = 1_000_000 / 32768
+    return [
+        round(v * tick_us) if i % 2 == 0 else -round(v * tick_us)
+        for i, v in enumerate(ticks)
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -119,6 +135,33 @@ class TestEncoderParity:
             address=0x10, command=0x0C, extension=0x20, toggle=1, repeat_count=2
         )
         assert local.get_raw_timings() == upstream.get_raw_timings()
+
+    def test_nokia32(self):
+        # Nokia32 is not in the released library yet (it lives on the
+        # upstream branch from discussion #70), so unlike its siblings this
+        # needs a per-module guard: _needs_library only proves the library
+        # is installed, not that it ships this protocol.
+        upstream_mod = pytest.importorskip(
+            "infrared_protocols.commands.nokia32",
+            reason="upstream library has no Nokia32 yet",
+        )
+        Upstream = upstream_mod.Nokia32Command
+
+        for device, subdevice, function, extension, toggle in (
+            (33, 160, 12, 38, 0),   # Foxtel iQ POWER
+            (33, 160, 253, 38, 1),  # Foxtel iQ ACTIVE, toggled
+            (0, 0, 0, 0, 0),
+        ):
+            local = Nokia32Command(
+                device=device, subdevice=subdevice, function=function,
+                extension=extension, toggle=toggle,
+            )
+            upstream = Upstream(
+                device=device, subdevice=subdevice, function=function,
+                extension=extension, toggle=toggle,
+            )
+            assert local.get_raw_timings() == upstream.get_raw_timings()
+            assert local.modulation == upstream.modulation
 
 
 # ---------------------------------------------------------------------------
@@ -354,6 +397,65 @@ class TestRoundTrips:
             decoded.toggle,
         ) == (address, command, extension, toggle)
 
+    @pytest.mark.parametrize(
+        ("device", "subdevice", "function", "extension", "toggle"),
+        [
+            (33, 160, 12, 38, 0),    # Foxtel iQ POWER
+            (33, 160, 16, 38, 0),    # Foxtel iQ VOLUME_UP
+            (33, 160, 253, 38, 1),   # Foxtel iQ ACTIVE, toggle set
+            (0, 0, 0, 0, 0),
+            (0xFF, 0xFF, 0xFF, 0x7F, 1),
+        ],
+    )
+    def test_nokia32(self, device, subdevice, function, extension, toggle):
+        encoded = Nokia32Command(
+            device=device, subdevice=subdevice, function=function,
+            extension=extension, toggle=toggle,
+        ).get_raw_timings()
+        decoded = Nokia32Command.from_raw_timings(encoded)
+        assert decoded is not None
+        assert (
+            decoded.device, decoded.subdevice, decoded.function,
+            decoded.extension, decoded.toggle,
+        ) == (device, subdevice, function, extension, toggle)
+
+    def test_nokia32_held_button_multi_frame_same_identity(self):
+        """Nokia32 has no repeat frame -- a held key just re-sends the whole
+        frame on a ~100ms period. Three back-to-back frames (one toggle
+        value, as a real hold keeps) must majority-vote to one identity."""
+        one = Nokia32Command(
+            device=33, subdevice=160, function=12, extension=38, toggle=1,
+        ).get_raw_timings()
+        held = [*one, -90000, *one, -90000, *one]
+        decoded = Nokia32Command.from_raw_timings(held)
+        assert decoded is not None
+        assert (decoded.device, decoded.subdevice, decoded.function) == (33, 160, 12)
+        assert (decoded.extension, decoded.toggle) == (38, 1)
+
+    def test_nokia32_real_foxtel_captures(self):
+        """Real Foxtel iQ remote captures (Broadlink RM, base64). Device 33 /
+        subdevice 160 / system 38, verified bit-for-bit against the remote."""
+        captures = {
+            # function -> Broadlink base64 payload
+            12: "JgAkAA4JBQkFFAUJBQ8FFAUUBQkFCQUJBRQFDwUUBQkFCQUZBQkFAA0F",   # POWER
+            16: "JgAkAA4JBQkFFAUJBQ8FFAUUBQkFCQUJBRQFDwUUBQkFDwUJBQkFAA0F",   # VOLUME_UP
+            32: "JgAkAA4JBQkFFAUJBQ8FFAUUBQkFCQUJBRQFDwUUBQkFFAUJBQkFAA0F",   # CHANNEL_UP
+            56: "JgAkAA4JBQkFFAUJBQ8FFAUUBQkFCQUJBRQFDwUUBQkFGQUUBQkFAA0F",   # AV
+            92: "JgAkAA4JBQkFFAUJBQ8FFAUUBQkFCQUJBRQFDwUUBQ8FDwUZBQkFAA0F",   # SELECT
+            142: "JgAkAA4JBQkFFAUJBQ8FFAUUBQkFCQUJBRQFDwUUBRQFCQUZBRQFAA0F",  # FOXTEL
+            204: "JgAkAA4JBQkFFAUJBQ8FFAUUBQkFCQUJBRQFDwUUBRkFCQUZBQkFAA0F",  # TV_GUIDE
+            253: "JgAkAA4JBQkFFAUJBQ8FFAUUBQkFCQUJBRQFDwUUBRkFGQUZBQ8FAA0F",  # ACTIVE
+            9: "JgAkAA4JBQkFFAUJBQ8FFAUUBQkFCQUJBRQFDwUUBQkFCQUUBQ8FAA0F",    # NUM_9
+        }
+        for function, payload in captures.items():
+            timings = _broadlink_to_us(payload)
+            decoded = Nokia32Command.from_raw_timings(timings)
+            assert decoded is not None, f"real capture fn={function} refused"
+            assert (decoded.device, decoded.subdevice, decoded.extension) == (
+                33, 160, 38,
+            )
+            assert decoded.function == function
+
     def test_symphony(self):
         encoded = SymphonyCommand(data=0xC00, nbits=12, repeat_count=3).get_raw_timings()
         decoded = SymphonyCommand.from_raw_timings(encoded)
@@ -472,6 +574,19 @@ class TestDirtyCaptures:
         assert decoded is not None
         assert (decoded.data, decoded.nbits) == (0xC00, 12)
 
+    # Nokia32's marks are a short 164us, so the 0.3 band is only +-49us --
+    # tighter than the pulse-distance protocols. Real Foxtel captures sit
+    # well inside it (see test_nokia32_real_foxtel_captures); this just
+    # confirms symmetric in-band jitter does not shift identity.
+    @pytest.mark.parametrize("stretch", [-40, -20, 40])
+    def test_nokia32_jitter(self, stretch):
+        clean = Nokia32Command(
+            device=33, subdevice=160, function=12, extension=38,
+        ).get_raw_timings()
+        decoded = Nokia32Command.from_raw_timings(_jitter(clean, stretch, -stretch))
+        assert decoded is not None
+        assert (decoded.device, decoded.subdevice, decoded.function) == (33, 160, 12)
+
 
 # ---------------------------------------------------------------------------
 # 4. Rejection matrix
@@ -482,6 +597,7 @@ _DECODERS = {
     "rc5": RC5Command,
     "samsung": Samsung32Command,
     "sharp": SharpCommand,
+    "nokia32": Nokia32Command,
     "kaseikyo": KaseikyoCommand,
     "marantz": MarantzExtendedCommand,
     "symphony": SymphonyCommand,
@@ -499,6 +615,9 @@ def _samples() -> dict[str, list[int]]:
         ).get_raw_timings(),
         "sharp": SharpCommand(
             address=0x01, command=0x68, repeat_count=1
+        ).get_raw_timings(),
+        "nokia32": Nokia32Command(
+            device=33, subdevice=160, function=12, extension=38
         ).get_raw_timings(),
         "kaseikyo": KaseikyoCommand(
             address=0x2002, data=bytes([0x40, 0x04, 0x01, 0x00]), repeat_count=1

--- a/llms.txt
+++ b/llms.txt
@@ -128,10 +128,11 @@ Key components:
   precondition the trigger then randomly misses its own button. The dedup window
   slides and is keyed per trigger, so protocols that transmit several full frames
   per press (Sony sends 4-5) count as one press even when frames flip fingerprints.
-  Local-first decoders (v0.6.0): HAIR ships its own decoders for seven
+  Local-first decoders (v0.6.0): HAIR ships its own decoders for eight
   protocols -- Sony SIRC 12/15/20, Symphony (8/12/16-bit rc_switch family),
   Philips RC-5 (incl. RC5X), Samsung32, Sharp, Kaseikyo (Panasonic family),
-  and Marantz Extended -- in custom_components/hair/decoders/, each shaped
+  Marantz Extended, and Nokia32 (Philips RC-MM, the Foxtel/Sky/Mediamaster
+  set-top box family) -- in custom_components/hair/decoders/, each shaped
   exactly like an infrared_protocols module so it can be donated upstream as
   a near-file-copy. A registry in protocol_decode.py feature-detects per
   protocol: when the user's bundled infrared-protocols ships a decoder


### PR DESCRIPTION
## What

Adds Nokia32 (Philips RC-MM, 32-bit, 36 kHz) as a guest decoder: `decoders/nokia32.py`, its registry row and adapters in `protocol_decode.py`, and tests including real Foxtel iQ captures.

## Why

Nokia32 has no decoder in HAIR or in the bundled `infrared-protocols`, so RC-MM set-top boxes (Foxtel in AU, Sky/Digibox in UK/IE, Nokia Mediamaster / d-box in EU) never get a stable decoded identity. One decoder covers the whole family; the per-box codes are open data.

Follow-up to #52 and to home-assistant-libs/infrared-protocols discussion #70.

## How

Mapping is the one settled in #52:

- `address` = `device << 8 | subdevice`
- `command` = `function` (F)
- `extras` = `extension` (the 7-bit X system/OEM code) plus `toggle`
- X rides as an identity extra with a `:x%02x` fingerprint suffix, following the Sharp/Marantz precedent, so Foxtel, Sky and Mediamaster cannot collide on the same protocol
- `toggle` is press state and stays out of the fingerprint, following RC-5

The encoder is byte-identical to the upstream `Nokia32Command` on the infrared-protocols branch, so the registry swapping to upstream can never change what is transmitted. The registration names the upstream module, so if the library ever ships Nokia32 with `from_raw_timings`, `_resolve_class` defers to it automatically with no release needed.

Decode follows the package conventions: classmethod, signed microsecond timings, returns `Self | None`, bounds-checked indexing only, never raises on malformed input. Capture is split into frames at the ~100 ms inter-frame period and majority-voted, so a single tap and a jittery multi-frame hold of one button produce the same identity. Nokia32 has no distinct repeat frame, so there is no repeat handling by design.

### Tests

- Encoder parity with upstream, guarded by `pytest.importorskip` since Nokia32 is not in the released library yet
- Round-trips across representative and boundary values, including toggle
- Held-button multi-frame collapses to one identity
- Nine real Foxtel iQ remote captures (Broadlink RM base64)
- In-band jitter
- Cross-protocol rejection matrix in both directions: Nokia32 rejects all seven existing decoders' clean frames, and all seven reject Nokia32

### Robustness

A decoder parses untrusted over-the-air input, so I fuzzed `from_raw_timings` with 10,011 cases: random garbage, extreme magnitudes, corrupted and truncated valid frames, tolerance-boundary probing, a 100,000-element input and a 3,000-frame repeat. Zero exceptions raised, zero calls over 1 s (worst single call 2.8 ms), zero malformed returns, and zero out-of-range fields on anything accepted.

### Provenance

Original implementation. The protocol structure came from the Nokia32 IRP notation and written references (hifi-remote JP1 wiki, SB-Projects NRC17/RC-MM). No code from IRremote, LIRC, IRremoteESP8266 or ESPHome was consulted. The port was written fresh against the `decoders/` conventions and shaped after `sharp.py`.

Both review asks from #52 are addressed: rebased on current main (past #53), and the parity test now uses `pytest.importorskip` so it skips cleanly against the released library instead of erroring.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have read the CONTRIBUTING guide
- [ ] `pytest` passes locally - could not run the full suite in my environment (no Home Assistant install). The decoder logic was verified directly: all 9 real captures decode, round-trips and the rejection matrix pass in both directions. You reported 1121 green on the pre-rebase branch in #52.
- [ ] `ruff check .` passes locally - ruff was not available in my environment. Line lengths were checked manually against the configured 99.
- [x] Frontend builds cleanly - not applicable, no frontend changes
- [x] New code has tests where applicable
- [ ] Tested manually on a Home Assistant instance - not tested on a live HA instance
- [x] Documentation updated (docstrings)
- [x] `llms.txt` updated (seven local decoders becomes eight)

## Related Issues

Closes #52
