### PR TITLE
v0.10.0 credits: the requests that became Remotes, pinning, and presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   settings the matching Device. Making a trigger now asks which
   Remote owns it, HAIR Triggers by default; only HAIR Triggers
   offers a receiver picker, since a named Remote's triggers follow
-  that Remote's own receivers.
+  that Remote's own receivers. Requested by @Spamfast (GH #69), whose
+  EyeTV-remote-as-keypad thread on the HA forum started this whole
+  release, and by StePhan McKillen on the same thread.
 - **Pin a Remote to a Device.** Pressing the handset then sends the
   matching command out that Device's emitters, with HAIR working out
   which button matches which command. Open the PIN row on a Remote's
@@ -41,7 +43,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pairing ever does run away, HAIR cuts that one pairing for a
   minute and writes a warning naming the Remote, the Device and the
   command, while the handset keeps firing its triggers throughout.
-  The Mirror marks pinned sends with their own chip.
+  The Mirror marks pinned sends with their own chip. Requested by
+  @bwarden (GH #90), who wanted a DVR remote heard in one room to
+  drive the DVR in another.
 - **Air-conditioner handsets can be Remotes.** An AC Remote carries
   the same STATE MATRIX card an AC Device has, but for listening:
   press the handset and the mode, fan, swing and temperature it sent
@@ -61,7 +65,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   what the command is named; click again to remove it. It works for
   learned commands and for states saved out of the STATE MATRIX card
   with + Command. Presets are local to the device and do not travel
-  with a wig.
+  with a wig. Requested by @mode0192 (GH #96) as native AC favourites;
+  the listening side of an AC Remote covers the state-tracking half of
+  that request.
 - **Ten languages.** Every new word in this release is translated in
   all ten panel languages, including the "State heard" trigger name
   as it reads in the automation editor.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,26 @@
+# Contributors
+
+People whose code, reports, requests, or testing shaped HAIR. Code
+contributors also appear on the GitHub contributors graph; the rest are
+listed here so the record is complete. Newest release first.
+
+## 0.10.0 -- Remotes Have Been Buffed
+
+- **Spamfast** -- asked for "a generic remote receiver for a physical
+  IR remote control from the sniffer that just sends HA events" on the
+  HA Community launch thread, then opened GH #69. That request became
+  Remotes.
+- **StePhan McKillen** -- same thread, same day, ten coloured-button
+  triggers used as a keypad; the second data point that made Remotes a
+  demand-backed feature.
+- **bwarden** -- GH #90, relay a whole remote heard in one room to a
+  device in another. That request became pinning.
+- **mode0192** -- GH #96, native AC favourites as one-tap presets. That
+  request became the thermostat preset star, and the AC Remote's
+  listening side answers its state-tracking half.
+
+## Earlier releases
+
+Credits for earlier releases live in the matching CHANGELOG entries
+("Reported by", "Requested by") and in the release notes on GitHub.
+Code contributions: see the GitHub contributors graph.


### PR DESCRIPTION
v0.10.0 credits: the requests that became Remotes, pinning, and presets

CHANGELOG lines and a CONTRIBUTORS.md naming the people whose requests
became the headline features of 0.10.0: Spamfast (GH #69) and StePhan
McKillen for Remotes, bwarden (GH #90) for pinning, mode0192 (GH #96)
for the thermostat preset star. The co-author lines below credit those
requests, not code; the code was written by the maintainer.

Closes #69
Closes #90
Closes #96

Co-authored-by: Spamfast <54712028+Spamfast@users.noreply.github.com>
Co-authored-by: bwarden <300149+bwarden@users.noreply.github.com>
Co-authored-by: mode0192 <41920498+mode0192@users.noreply.github.com>
