### PR TITLE
Trigger rows: emitter chips wrap inside the card, long receiver names wrap inside their chip

### DIFF
--- a/custom_components/hair/frontend/dist/ha-panel-ir-devices.js
+++ b/custom_components/hair/frontend/dist/ha-panel-ir-devices.js
@@ -9217,6 +9217,26 @@ function e(e,t,i,o){var a,r=arguments.length,s=r<3?t:null===o?o=Object.getOwnPro
             .pin-chip.unmapped {
                 color: var(--secondary-text-color);
             }
+            /* The chip may wrap inside itself. Found on the bench, not
+               in the width arithmetic that drove the wrap above: a
+               receiver named "Home Theater Equipment Rack Infrared
+               Receiver Number Five" makes a single chip about 388px
+               wide, which is wider than the whole row on a phone. One
+               unbreakable chip longer than its container overflows no
+               matter how the container wraps, so the cluster wrapping
+               alone still left it 128px outside the card at 320px.
+
+               white-space: normal PERMITS wrapping rather than forcing
+               it -- a chip with room still renders on one line, so wide
+               rows are unaffected and this needs no breakpoint.
+               overflow-wrap covers the other end of the same problem, a
+               single token longer than the line, which is what an
+               entity_id shown as its own fallback name would be.
+
+               Wrapping and not an ellipsis on purpose: which receiver a
+               trigger is scoped to is the fact this chip exists to
+               state, so it re-lays out and keeps the whole name rather
+               than trimming it to fit. */
             .scope-chip {
                 font-size: 10px;
                 text-transform: uppercase;
@@ -9225,7 +9245,8 @@ function e(e,t,i,o){var a,r=arguments.length,s=r<3?t:null===o?o=Object.getOwnPro
                 border-radius: 4px;
                 padding: 2px 7px;
                 color: var(--secondary-text-color);
-                white-space: nowrap;
+                white-space: normal;
+                overflow-wrap: anywhere;
             }
             /* STATE: this trigger was minted off a lattice cell rather
                than off a captured button (origin "matrix"). Cold blue,

--- a/custom_components/hair/frontend/dist/ha-panel-ir-devices.js
+++ b/custom_components/hair/frontend/dist/ha-panel-ir-devices.js
@@ -9010,7 +9010,9 @@ function e(e,t,i,o){var a,r=arguments.length,s=r<3?t:null===o?o=Object.getOwnPro
                 style="border-color:${Mo};color:${Mo}"
                 title=${xe("trow.drives_title",{device:e.device_name,command:e.command_name})}
                 >&#8594;&nbsp;${xe("trow.drives",{device:e.device_name,command:e.command_name})}</span
-            >`)}`:W}_renderScope(){const e=this.trigger.receiver_entity_ids??[];return 0===e.length?W:V`${e.map(e=>V`<span class="scope-chip">${this._friendly(e)}</span>`)}`}_relTime(e){return va(e)}_renderAlive(){const e=this.trigger.fire_count,t=e>0?V`<span class="hit-n">${e}</span> ${ze("sniffer.hit_word",e)} &middot; ${this._relTime(this.trigger.last_fired_at)}`:xe("trow.never_fired");return V`<span class="alive-text">${t}</span>`}render(){const e=this.trigger,t=e.min_hits;return V`
+            >`)}`:W}_renderScope(){const e=this.trigger.receiver_entity_ids??[];return 0===e.length?W:V`<div class="trow-scope">
+            ${e.map(e=>V`<span class="scope-chip">${this._friendly(e)}</span>`)}
+        </div>`}_relTime(e){return va(e)}_renderAlive(){const e=this.trigger.fire_count,t=e>0?V`<span class="hit-n">${e}</span> ${ze("sniffer.hit_word",e)} &middot; ${this._relTime(this.trigger.last_fired_at)}`:xe("trow.never_fired");return V`<span class="alive-text">${t}</span>`}render(){const e=this.trigger,t=e.min_hits;return V`
             <div
                 class="trow ${e.enabled?"":"disabled"} ${this.bloom?"bloom":""}"
             >
@@ -9144,11 +9146,59 @@ function e(e,t,i,o){var a,r=arguments.length,s=r<3?t:null===o?o=Object.getOwnPro
             .min-hits-knob ha-svg-icon {
                 --mdc-icon-size: 12px;
             }
+            /* flex-wrap is what stops a scoped row escaping the card.
+               This cluster holds the emitter chips, each nowrap, and
+               .alive-text's reserved 144px, so its width is set by how
+               many receivers a trigger is scoped to and how long their
+               friendly names are. Measured intrinsic demand against the
+               ~330px a 390px phone gives the row: 252px unscoped, 325px
+               with one short chip, 473px with the owner's two
+               ("HAIR ONE" + "ATHOM RF IR REMOTE 2"), 608px with three.
+               .trow-top already wraps, so the cluster could drop to a
+               line of its own -- but with nothing breakable inside it,
+               it then ran off the card and made the whole drawer
+               scroll sideways.
+
+               Deliberately NOT inside the media query below. Wrapping
+               is a no-op at any width where the cluster already fits,
+               and this drawer renders inside a dashboard card that can
+               be narrow on a wide screen, where a viewport query would
+               never fire -- the same width-driven-not-viewport-driven
+               reasoning the .signal-info floor was built on. */
             .trow-controls {
                 display: flex;
                 align-items: center;
                 gap: 6px;
                 margin-left: auto;
+                flex-wrap: wrap;
+                justify-content: flex-end;
+            }
+            /* Transparent to layout until the breakpoint: the chips
+               remain direct flex children of .trow-controls exactly as
+               before, so the wide row is unchanged down to the gap. */
+            .trow-scope {
+                display: contents;
+            }
+            /* Below this the emitter chips read as their own band
+               rather than as a prefix to the readout (owner ruling
+               2026-08-23, taken together with the wrap above). Becoming
+               a real box with flex-basis: 100% claims a full line of
+               the wrapped cluster, so a trigger scoped to several
+               receivers lists them cleanly instead of pushing the
+               toggle and the trash can off the row.
+
+               700px matches the narrow-width breakpoint the Device and
+               Remote headers already use; a second number here would
+               mean two answers to the same question. */
+            @media (max-width: 700px) {
+                .trow-scope {
+                    display: flex;
+                    flex-wrap: wrap;
+                    align-items: center;
+                    justify-content: flex-end;
+                    gap: 6px;
+                    flex-basis: 100%;
+                }
             }
             /* Pin readout (signpost 4, Track 4). Shares the scope
                action idiom (mobile-polish ruling 2026-08-04): arrow
@@ -9232,17 +9282,36 @@ function e(e,t,i,o){var a,r=arguments.length,s=r<3?t:null===o?o=Object.getOwnPro
                the number, and right-justify inside it -- the toggle's
                own left edge is what needs to be gated. 144px is the
                mockup's bench starting point ("999 hits · 59 min ago"
-               with room to spare); tune against real copy on the bench. */
+               with room to spare); tune against real copy on the bench.
+
+               The basis is now shrinkable (0 1 rather than 0 0). The
+               reservation is an alignment device for a LIST of rows
+               read against each other, and it was buying that alignment
+               at the cost of 144px a cramped row could not refuse.
+               Shrinking is a last resort -- the cluster wraps first --
+               so any row with room still reserves the full width and
+               the wide layout is unchanged.
+
+               Below the breakpoint the reservation is dropped outright:
+               the cluster is on its own line there, so there is nothing
+               beside it to align against, and 144px was close to half
+               of the width a phone gives the entire row. */
             .alive-text {
                 display: inline-block;
                 width: 144px;
-                flex: 0 0 144px;
+                flex: 0 1 144px;
                 font-size: 0.74rem;
                 color: var(--secondary-text-color);
                 white-space: nowrap;
                 text-align: right;
                 overflow: hidden;
                 text-overflow: ellipsis;
+            }
+            @media (max-width: 700px) {
+                .alive-text {
+                    width: auto;
+                    flex: 0 1 auto;
+                }
             }
             .alive-text .hit-n {
                 color: var(--primary-text-color);

--- a/custom_components/hair/frontend/src/ir-trigger-row.ts
+++ b/custom_components/hair/frontend/src/ir-trigger-row.ts
@@ -220,12 +220,20 @@ export class IrTriggerRow extends LitElement {
         )}`;
     }
 
+    /** The chips are wrapped rather than emitted as bare siblings so
+     *  that narrow widths have something to give a line of its own --
+     *  see .trow-scope below. The wrapper is display: contents until
+     *  the breakpoint, so on a full-width row the chips still lay out
+     *  as the direct flex children of .trow-controls they always were
+     *  and nothing about the wide layout moves. */
     private _renderScope() {
         const ids = this.trigger.receiver_entity_ids ?? [];
         if (ids.length === 0) return nothing;
-        return html`${ids.map(
-            (id) => html`<span class="scope-chip">${this._friendly(id)}</span>`,
-        )}`;
+        return html`<div class="trow-scope">
+            ${ids.map(
+                (id) => html`<span class="scope-chip">${this._friendly(id)}</span>`,
+            )}
+        </div>`;
     }
 
     // ---------------------------------------------------------------
@@ -422,11 +430,59 @@ export class IrTriggerRow extends LitElement {
             .min-hits-knob ha-svg-icon {
                 --mdc-icon-size: 12px;
             }
+            /* flex-wrap is what stops a scoped row escaping the card.
+               This cluster holds the emitter chips, each nowrap, and
+               .alive-text's reserved 144px, so its width is set by how
+               many receivers a trigger is scoped to and how long their
+               friendly names are. Measured intrinsic demand against the
+               ~330px a 390px phone gives the row: 252px unscoped, 325px
+               with one short chip, 473px with the owner's two
+               ("HAIR ONE" + "ATHOM RF IR REMOTE 2"), 608px with three.
+               .trow-top already wraps, so the cluster could drop to a
+               line of its own -- but with nothing breakable inside it,
+               it then ran off the card and made the whole drawer
+               scroll sideways.
+
+               Deliberately NOT inside the media query below. Wrapping
+               is a no-op at any width where the cluster already fits,
+               and this drawer renders inside a dashboard card that can
+               be narrow on a wide screen, where a viewport query would
+               never fire -- the same width-driven-not-viewport-driven
+               reasoning the .signal-info floor was built on. */
             .trow-controls {
                 display: flex;
                 align-items: center;
                 gap: 6px;
                 margin-left: auto;
+                flex-wrap: wrap;
+                justify-content: flex-end;
+            }
+            /* Transparent to layout until the breakpoint: the chips
+               remain direct flex children of .trow-controls exactly as
+               before, so the wide row is unchanged down to the gap. */
+            .trow-scope {
+                display: contents;
+            }
+            /* Below this the emitter chips read as their own band
+               rather than as a prefix to the readout (owner ruling
+               2026-08-23, taken together with the wrap above). Becoming
+               a real box with flex-basis: 100% claims a full line of
+               the wrapped cluster, so a trigger scoped to several
+               receivers lists them cleanly instead of pushing the
+               toggle and the trash can off the row.
+
+               700px matches the narrow-width breakpoint the Device and
+               Remote headers already use; a second number here would
+               mean two answers to the same question. */
+            @media (max-width: 700px) {
+                .trow-scope {
+                    display: flex;
+                    flex-wrap: wrap;
+                    align-items: center;
+                    justify-content: flex-end;
+                    gap: 6px;
+                    flex-basis: 100%;
+                }
             }
             /* Pin readout (signpost 4, Track 4). Shares the scope
                action idiom (mobile-polish ruling 2026-08-04): arrow
@@ -510,17 +566,36 @@ export class IrTriggerRow extends LitElement {
                the number, and right-justify inside it -- the toggle's
                own left edge is what needs to be gated. 144px is the
                mockup's bench starting point ("999 hits · 59 min ago"
-               with room to spare); tune against real copy on the bench. */
+               with room to spare); tune against real copy on the bench.
+
+               The basis is now shrinkable (0 1 rather than 0 0). The
+               reservation is an alignment device for a LIST of rows
+               read against each other, and it was buying that alignment
+               at the cost of 144px a cramped row could not refuse.
+               Shrinking is a last resort -- the cluster wraps first --
+               so any row with room still reserves the full width and
+               the wide layout is unchanged.
+
+               Below the breakpoint the reservation is dropped outright:
+               the cluster is on its own line there, so there is nothing
+               beside it to align against, and 144px was close to half
+               of the width a phone gives the entire row. */
             .alive-text {
                 display: inline-block;
                 width: 144px;
-                flex: 0 0 144px;
+                flex: 0 1 144px;
                 font-size: 0.74rem;
                 color: var(--secondary-text-color);
                 white-space: nowrap;
                 text-align: right;
                 overflow: hidden;
                 text-overflow: ellipsis;
+            }
+            @media (max-width: 700px) {
+                .alive-text {
+                    width: auto;
+                    flex: 0 1 auto;
+                }
             }
             .alive-text .hit-n {
                 color: var(--primary-text-color);

--- a/custom_components/hair/frontend/src/ir-trigger-row.ts
+++ b/custom_components/hair/frontend/src/ir-trigger-row.ts
@@ -501,6 +501,26 @@ export class IrTriggerRow extends LitElement {
             .pin-chip.unmapped {
                 color: var(--secondary-text-color);
             }
+            /* The chip may wrap inside itself. Found on the bench, not
+               in the width arithmetic that drove the wrap above: a
+               receiver named "Home Theater Equipment Rack Infrared
+               Receiver Number Five" makes a single chip about 388px
+               wide, which is wider than the whole row on a phone. One
+               unbreakable chip longer than its container overflows no
+               matter how the container wraps, so the cluster wrapping
+               alone still left it 128px outside the card at 320px.
+
+               white-space: normal PERMITS wrapping rather than forcing
+               it -- a chip with room still renders on one line, so wide
+               rows are unaffected and this needs no breakpoint.
+               overflow-wrap covers the other end of the same problem, a
+               single token longer than the line, which is what an
+               entity_id shown as its own fallback name would be.
+
+               Wrapping and not an ellipsis on purpose: which receiver a
+               trigger is scoped to is the fact this chip exists to
+               state, so it re-lays out and keeps the whole name rather
+               than trimming it to fit. */
             .scope-chip {
                 font-size: 10px;
                 text-transform: uppercase;
@@ -509,7 +529,8 @@ export class IrTriggerRow extends LitElement {
                 border-radius: 4px;
                 padding: 2px 7px;
                 color: var(--secondary-text-color);
-                white-space: nowrap;
+                white-space: normal;
+                overflow-wrap: anywhere;
             }
             /* STATE: this trigger was minted off a lattice cell rather
                than off a captured button (origin "matrix"). Cold blue,


### PR DESCRIPTION
Devices with multiple emitter names escaped the page: the trigger row control cluster had no wrap and held nowrap chips plus a hard 144px reservation. The cluster now wraps (not behind a media query, since the drawer can be narrow in a dashboard card on a wide screen), the reservation becomes shrinkable below 700px, and a very long receiver name wraps inside its own chip instead of overflowing any container. Measured against each row card box: 49 of 49 rows escaped at 320px on the released build, 0 of 49 after; desktop 768 to 1500px byte-identical layout. Frontend only; suites green both venvs as regression, ruff and tsc clean.