### PR TITLE
Add the RC-6 decoder: mode 0 and mode 6A, double-width trailer

### DIFF
--- a/custom_components/hair/decoders/rc6.py
+++ b/custom_components/hair/decoders/rc6.py
@@ -1,0 +1,436 @@
+"""RC-6 IR command (Philips) with decode support.
+
+Upstream ``infrared_protocols`` ships no RC-6 module at all (verified
+against the CI-parity venv), so this class serves both directions. It is
+written to the same shape as every module in this package so the donation
+stays a near-file-copy.
+
+IRP-style summary of the two forms this module handles::
+
+    mode 0   {36k,444,msb}<-1,1|1,-1>(6,-2,1:1,0:3,<-2,2|2,-2>(T:1),D:8,F:8,^107m)
+    mode 6A  {36k,444,msb}<-1,1|1,-1>(6,-2,1:1,6:3,-2,2,C:8|16,T:1,D:7,F:8,^107m)
+
+RC-6 is Manchester coded like RC-5 but with INVERTED polarity: a logic 1
+is mark-then-space, a logic 0 is space-then-mark. Adjacent same-sign
+halves merge on the wire exactly as they do in ``rc5``. The unit time t is
+444us, sixteen periods of the 36 kHz nominal carrier; real captures
+routinely measure nearer 38 kHz, which is receiver measurement spread and
+not a different protocol (the same spread shows on NEC).
+
+Frame layout: a 6t mark + 2t space leader (RC-5 has no leader at all --
+this is the structural discriminator between the two), then a start bit
+which is always 1, then three mode bits, then the TRAILER BIT AT DOUBLE
+WIDTH -- its two halves are 2t each where every other half-bit is 1t.
+That mid-stream symbol-width change is the classic RC-6 implementation
+trap: a uniform half-bit quantizer misaligns every bit after the trailer.
+It also means a legal RC-6 waveform contains runs of 1t, 2t AND 3t (a 2t
+trailer half abutting a same-sign 1t neighbour), so a two-bucket
+short/long classifier cannot slice this protocol. The lattice walk below
+therefore reads each symbol at its own declared width rather than
+quantizing the frame uniformly up front.
+
+WHERE THE TOGGLE LIVES, which differs by mode:
+
+- Mode 0 spends the trailer bit on its traditional job: it is the toggle,
+  flipping once per key press, and address and command are 8 bits each.
+- Mode 6 does NOT. In mode 6 the trailer is the SUBMODE bit (0 = mode 6A,
+  the command form; 1 = mode 6B, reserved for pointing devices), so it
+  reads as permanently constant and the toggle has to live somewhere
+  else. It moved into the payload: the first data bit after the customer
+  field is the toggle, leaving 7 bits of address and 8 of command. This
+  is documented for the Microsoft Media Center variant (customer 0x800F,
+  described as RC6-6-32 with the standard toggle bit zero and a
+  nonstandard toggle added) and it is what MaxRower's VU+ set-top-box
+  captures do as well (customer 0x8052, GH #33): across two presses of
+  one button the trailer stayed 0 and exactly one bit alternated, the
+  most significant bit of what would otherwise be the address byte.
+  Two independent OEMs, same structure. This module applies the T:1,
+  D:7, F:8 split to every mode 6 frame; the documented anchor is MCE and
+  the second witness is the VU+ capture set, so treat a third OEM that
+  contradicts it as a finding, not as a reason to widen the rule here.
+
+Mode 6 also carries a customer/OEM field whose LENGTH is signalled by its
+own first bit: a leading 0 means an 8-bit field holding a 7-bit value,
+a leading 1 means a 16-bit field holding a 15-bit value. The value is
+quoted inclusive of that flag bit throughout this module, which is the
+universal convention for the family (MCE is always written 0x800F, never
+0x000F). Mode and customer are IDENTITY -- they separate two remotes that
+share an address and command -- and are folded into the fingerprint
+suffix by the registry. The toggle is press state and is excluded from
+identity, exactly as in RC-5.
+
+Mode 6A does not encode its own payload length; the spec leaves the width
+to the OEM and offers only the signal-free time as a terminator. Rather
+than guess, this decoder accepts a 16-bit remainder after the customer
+field (either customer width) and refuses anything else, so an unknown
+variant stays undecoded and matches on the raw tiers instead of being
+handed a wrong identity.
+
+The known deferral is RC6-6-20: mode 6 with an 8-bit customer and a
+12-bit remainder, 241 signals in Flipper-IRDB, concentrated in Sky,
+Amstrad, Thomson and Philips set-top boxes. Its leaders measure clean, so
+these are real RC-6 -- but how those 12 bits split into toggle, address
+and command is not in any open source consulted here, and a guessed split
+would mint wrong identities for a whole device family. They stay
+undecoded until somebody has captures that settle it.
+
+Held keys re-send the frame with the toggle constant, so multi-frame
+captures majority-vote like every decoder in this package, and a lone
+frame decodes standalone.
+
+License rule (package docstring): written from open protocol
+documentation and validated against real captures. No GPL/LGPL-derived
+implementation was consulted.
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Self, override
+
+from . import decode_frames_majority, is_close, split_frames
+from ._base import Command
+from .rc5 import _append_signed_us, _strip_idle_edges
+
+_UNIT_US = 444
+_MODULATION_HZ = 36000
+# RC-6 pads the frame to a ~107ms period the way RC-5 pads to 114ms. The
+# figure is well attested in protocol references but not in a primary
+# specification, and reference versions disagree over whether mode 6
+# carries it at all, so it is used ONLY to space encoded repeats and is
+# never a decode constraint.
+_REPEAT_PERIOD_US = 107000
+
+_LEADER_MARK_UNITS = 6
+_LEADER_SPACE_UNITS = 2
+_TRAILER_HALF_UNITS = 2
+
+# The longest legitimate run inside a frame is 3t: a 2t trailer half
+# abutting a same-sign 1t neighbour half. Doubling that for receiver
+# spread gives ~2664us, while a repeating RC-6 remote leaves tens of
+# milliseconds between frames (a ~107ms period around a ~47ms frame).
+# 5000us sits with roughly 2x headroom above the worst legitimate
+# internal run and an order of magnitude below the real inter-frame
+# silence, so it can neither split a frame nor fuse two.
+_FRAME_GAP_US = 5000
+
+_MAX_RUN_UNITS = 3
+# Half-bit widths are classified by rounding to whole units and then
+# bounds-checking, so a run has to land within half a unit of a legal
+# width. 0.4 matches the package tolerance used everywhere else.
+#
+# The leader is checked at the same tolerance, and deliberately is NOT
+# tightened to make it a better filter. Measured over the 1670 Flipper-
+# IRDB signals this decoder accepts, real leader spaces run from 0.77 to
+# 1.06 of nominal, while a Sony SIRC frame opens 2400/600 -- 0.68 of
+# nominal. The two populations are only ~13 percent apart, so no
+# tolerance separates them without dropping real captures. The leader is
+# therefore the discriminator against RC-5 (which has no leader at all),
+# and what actually rejects a Sony frame is the structure behind it: the
+# fixed start bit, the mode gate, the exact payload width, and the
+# Manchester consistency of every symbol. That combination rejected all
+# 129,772 non-RC6 raw signals in the archive with no false positive.
+_UNIT_TOLERANCE = 0.4
+
+_MODE_0 = 0
+_MODE_6 = 6
+_SUBMODE_6A = 0
+
+_MODE_0_DATA_BITS = 16
+_MODE_6_REMAINDER_BITS = 16
+_SCC_FIELD_BITS = 8
+_LCC_FIELD_BITS = 16
+
+
+def _bits_to_int(bits: Sequence[int]) -> int:
+    """Fold MSB-first bits into an integer."""
+    value = 0
+    for bit in bits:
+        value = (value << 1) | bit
+    return value
+
+
+def _customer_field_bits(customer: int) -> int:
+    """Return the on-wire width of ``customer``, or 0 when unrepresentable.
+
+    The field's own first bit signals its length, so only two ranges are
+    encodable: 0x00..0x7F rides an 8-bit field behind a leading 0, and
+    0x8000..0xFFFF rides a 16-bit field behind a leading 1. A value
+    between the two has no wire form.
+    """
+    if 0 <= customer <= 0x7F:
+        return _SCC_FIELD_BITS
+    if 0x8000 <= customer <= 0xFFFF:
+        return _LCC_FIELD_BITS
+    return 0
+
+
+class RC6Command(Command):
+    """RC-6 IR command (Philips and derivatives) with decode support."""
+
+    address: int
+    command: int
+    toggle: int
+    mode: int
+    customer: int | None
+
+    def __init__(
+        self,
+        *,
+        address: int,
+        command: int,
+        toggle: int = 0,
+        mode: int = _MODE_0,
+        customer: int | None = None,
+        modulation: int = _MODULATION_HZ,
+        repeat_count: int = 0,
+    ) -> None:
+        """Initialize the RC-6 IR command."""
+        if mode not in (_MODE_0, _MODE_6):
+            raise ValueError("RC-6 mode must be 0 or 6")
+        if mode == _MODE_0:
+            if customer is not None:
+                raise ValueError("RC-6 mode 0 carries no customer field")
+            if not 0 <= address <= 0xFF:
+                raise ValueError("RC-6 mode 0 address must be in range 0x00..0xFF")
+        else:
+            if customer is None:
+                raise ValueError("RC-6 mode 6 requires a customer field")
+            if not _customer_field_bits(customer):
+                raise ValueError(
+                    "RC-6 customer must be 0x00..0x7F (8-bit field) or "
+                    "0x8000..0xFFFF (16-bit field)"
+                )
+            if not 0 <= address <= 0x7F:
+                raise ValueError("RC-6 mode 6 address must be in range 0x00..0x7F")
+        if not 0 <= command <= 0xFF:
+            raise ValueError("RC-6 command must be in range 0x00..0xFF")
+        super().__init__(modulation=modulation, repeat_count=repeat_count)
+        self.address = address
+        self.command = command
+        self.toggle = toggle & 1
+        self.mode = mode
+        self.customer = customer
+
+    # -- encode ------------------------------------------------------------
+
+    @override
+    def get_raw_timings(self) -> list[int]:
+        """Get raw timings for the RC-6 command (leader + Manchester body)."""
+        frame: list[int] = []
+        _append_signed_us(frame, _LEADER_MARK_UNITS * _UNIT_US)
+        _append_signed_us(frame, -_LEADER_SPACE_UNITS * _UNIT_US)
+
+        self._encode_bit(frame, 1, 1)  # start bit, always 1
+        for shift in (2, 1, 0):
+            self._encode_bit(frame, (self.mode >> shift) & 1, 1)
+
+        # Mode 0 spends the trailer on the toggle; mode 6 spends it on
+        # the submode flag and moves the toggle into the payload.
+        trailer = self.toggle if self.mode == _MODE_0 else _SUBMODE_6A
+        self._encode_bit(frame, trailer, _TRAILER_HALF_UNITS)
+
+        for bit in self._payload_bits():
+            self._encode_bit(frame, bit, 1)
+        _strip_idle_edges(frame)
+
+        timings = list(frame)
+        if self.repeat_count > 0:
+            frame_duration = sum(abs(t) for t in frame)
+            gap = _REPEAT_PERIOD_US - frame_duration
+            for _ in range(self.repeat_count):
+                timings.append(-gap)
+                timings.extend(frame)
+        return timings
+
+    def _payload_bits(self) -> list[int]:
+        """Build the MSB-first payload bits that follow the trailer."""
+        bits: list[int] = []
+        if self.mode == _MODE_0:
+            for shift in range(7, -1, -1):
+                bits.append((self.address >> shift) & 1)
+        else:
+            customer = self.customer or 0
+            width = _customer_field_bits(customer)
+            for shift in range(width - 1, -1, -1):
+                bits.append((customer >> shift) & 1)
+            bits.append(self.toggle)
+            for shift in range(6, -1, -1):
+                bits.append((self.address >> shift) & 1)
+        for shift in range(7, -1, -1):
+            bits.append((self.command >> shift) & 1)
+        return bits
+
+    @staticmethod
+    def _encode_bit(timings: list[int], bit: int, half_units: int) -> None:
+        """Append one Manchester symbol of ``half_units`` per half.
+
+        RC-6 polarity: logic 1 is mark-then-space, logic 0 is
+        space-then-mark -- the opposite of RC-5.
+        """
+        half_us = half_units * _UNIT_US
+        if bit:
+            _append_signed_us(timings, half_us)
+            _append_signed_us(timings, -half_us)
+        else:
+            _append_signed_us(timings, -half_us)
+            _append_signed_us(timings, half_us)
+
+    # -- decode ------------------------------------------------------------
+
+    @classmethod
+    def from_raw_timings(cls, timings: list[int]) -> Self | None:
+        """Decode raw IR timings into an RC6Command.
+
+        Returns the majority identity across the frames in the capture,
+        with ``repeat_count`` set to the number of extra agreeing frames,
+        or None when no frame decodes as RC-6.
+        """
+        frames = split_frames(timings, _FRAME_GAP_US)
+        result = decode_frames_majority(frames, cls._decode_frame)
+        if result is None:
+            return None
+        (mode, customer, address, command, toggle), votes = result
+        return cls(
+            address=address,
+            command=command,
+            toggle=toggle,
+            mode=mode,
+            customer=customer,
+            repeat_count=votes - 1,
+        )
+
+    @classmethod
+    def _decode_frame(
+        cls, frame: Sequence[int]
+    ) -> tuple[int, int | None, int, int, int] | None:
+        """Decode one frame to ``(mode, customer, address, command, toggle)``."""
+        halves = cls._to_half_bits(frame)
+        if halves is None:
+            return None
+
+        walk = _LatticeWalk(halves)
+        start = walk.read(1)
+        if start != 1:  # the start bit is always 1
+            return None
+        mode_bits = [walk.read(1) for _ in range(3)]
+        if any(bit is None for bit in mode_bits):
+            return None
+        mode = _bits_to_int([b for b in mode_bits if b is not None])
+        trailer = walk.read(_TRAILER_HALF_UNITS)
+        if trailer is None:
+            return None
+
+        data = walk.read_rest()
+        if data is None:
+            return None
+
+        if mode == _MODE_0:
+            if len(data) != _MODE_0_DATA_BITS:
+                return None
+            address = _bits_to_int(data[:8])
+            command = _bits_to_int(data[8:])
+            return (mode, None, address, command, trailer)
+
+        if mode == _MODE_6:
+            # In mode 6 the trailer is the submode bit, not a toggle.
+            # 6B is the pointing-device form and is not a command frame.
+            if trailer != _SUBMODE_6A:
+                return None
+            if not data:
+                return None
+            width = _LCC_FIELD_BITS if data[0] else _SCC_FIELD_BITS
+            if len(data) != width + _MODE_6_REMAINDER_BITS:
+                return None
+            customer = _bits_to_int(data[:width])
+            rest = data[width:]
+            toggle = rest[0]
+            address = _bits_to_int(rest[1:8])
+            command = _bits_to_int(rest[8:])
+            return (mode, customer, address, command, toggle)
+
+        return None
+
+    @staticmethod
+    def _to_half_bits(frame: Sequence[int]) -> list[int] | None:
+        """Expand a leader-bearing frame into +/-1 half-bit units.
+
+        The leader is verified and consumed; everything after it becomes
+        one entry per unit, so a 2t run contributes two entries and the
+        double-width trailer occupies four. A trailing space longer than
+        any legal run is the signal-free time and is dropped.
+        """
+        if len(frame) < 4:
+            return None
+        if frame[0] <= 0 or frame[1] >= 0:
+            return None
+        if not is_close(frame[0], _LEADER_MARK_UNITS * _UNIT_US, _UNIT_TOLERANCE):
+            return None
+        if not is_close(-frame[1], _LEADER_SPACE_UNITS * _UNIT_US, _UNIT_TOLERANCE):
+            return None
+
+        body = list(frame[2:])
+        if body and body[-1] < 0:
+            units = round(-body[-1] / _UNIT_US)
+            if units > _MAX_RUN_UNITS:
+                body.pop()  # signal-free time, not a half-bit
+        if not body:
+            return None
+
+        halves: list[int] = []
+        for value in body:
+            magnitude = abs(value)
+            units = round(magnitude / _UNIT_US)
+            if not 1 <= units <= _MAX_RUN_UNITS:
+                return None
+            if not is_close(magnitude, units * _UNIT_US, _UNIT_TOLERANCE):
+                return None
+            halves.extend([1 if value > 0 else -1] * units)
+        return halves
+
+
+class _LatticeWalk:
+    """Cursor over a half-bit lattice that reads symbols at their own width.
+
+    RC-6 changes symbol width mid-frame (the double-width trailer), so the
+    walk cannot pre-slice the lattice into fixed-size bits. Each read
+    consumes ``2 * width`` halves and checks that the two halves are
+    uniform and opposite, which is what makes a misaligned frame fail
+    loudly instead of decoding to a plausible wrong value.
+    """
+
+    def __init__(self, halves: Sequence[int]) -> None:
+        self._halves = list(halves)
+        self._pos = 0
+
+    def read(self, width: int) -> int | None:
+        """Read one Manchester symbol whose halves are ``width`` units each."""
+        need = 2 * width
+        remaining = len(self._halves) - self._pos
+        if remaining < need:
+            # A frame ending on a logic 1 loses its trailing space to the
+            # signal-free time, so a mark-only tail of the right width is
+            # a complete symbol.
+            if remaining == width and all(
+                h > 0 for h in self._halves[self._pos :]
+            ):
+                self._pos = len(self._halves)
+                return 1
+            return None
+        first = self._halves[self._pos : self._pos + width]
+        second = self._halves[self._pos + width : self._pos + need]
+        self._pos += need
+        if all(h > 0 for h in first) and all(h < 0 for h in second):
+            return 1  # RC-6: mark-then-space is logic 1
+        if all(h < 0 for h in first) and all(h > 0 for h in second):
+            return 0
+        return None
+
+    def read_rest(self) -> list[int] | None:
+        """Read single-width symbols until the lattice is exhausted."""
+        bits: list[int] = []
+        while self._pos < len(self._halves):
+            bit = self.read(1)
+            if bit is None:
+                return None
+            bits.append(bit)
+        return bits

--- a/custom_components/hair/protocol_decode.py
+++ b/custom_components/hair/protocol_decode.py
@@ -173,6 +173,32 @@ def _construct_rc5(cls: type, label: str, address: int, command: int,
     return cls(address=address, command=command, toggle=toggle & 1)
 
 
+def _extract_rc6(cmd: Any) -> tuple[str, int, int, dict[str, int] | None]:
+    # Mode and customer/OEM are IDENTITY -- two remotes can share an
+    # address and command and be told apart only by them -- so they ride
+    # the fingerprint suffix. Toggle is press state: in mode 0 it is the
+    # trailer bit, in mode 6 it is the first payload bit (the trailer is
+    # spent on the submode flag there), but either way it flips per press
+    # and stays out of the fingerprint.
+    extras: dict[str, int] = {"mode": int(cmd.mode), "toggle": int(cmd.toggle)}
+    if cmd.customer is not None:
+        extras["customer"] = int(cmd.customer)
+    return ("RC6", int(cmd.address), int(cmd.command), extras)
+
+
+def _construct_rc6(cls: type, label: str, address: int, command: int,
+                   extras: Any) -> Any:
+    bag = extras or {}
+    customer = bag.get("customer")
+    return cls(
+        address=address,
+        command=command,
+        toggle=int(bag.get("toggle", 0)) & 1,
+        mode=int(bag.get("mode", 0)),
+        customer=None if customer is None else int(customer),
+    )
+
+
 def _extract_sharp(cmd: Any) -> tuple[str, int, int, dict[str, int] | None]:
     extension = int(cmd.extension)
     return ("SHARP", int(cmd.address), int(cmd.command),
@@ -311,6 +337,16 @@ def _identity_suffix(protocol: str, extras: Mapping[str, int] | None) -> str:
     if protocol == "NOKIA32":
         # X (system/OEM) separates Foxtel/Sky/Mediamaster on one protocol.
         return f":x{int(extras.get('extension', 0)):02x}"
+    if protocol == "RC6":
+        # Mode picks the frame shape; the customer/OEM field separates
+        # Media Center from a VU+ box from any other mode 6 vendor that
+        # happens to reuse an address and command. Mode 0 has no
+        # customer field and gets the mode alone.
+        suffix = f":m{int(extras.get('mode', 0)):x}"
+        customer = extras.get("customer")
+        if customer is not None:
+            suffix += f":c{int(customer):04x}"
+        return suffix
     return ""
 
 
@@ -352,6 +388,16 @@ _REGISTRATIONS: tuple[tuple, ...] = (
      "MarantzExtendedCommand",
      "custom_components.hair.decoders.marantz_extended", True,
      _extract_marantz, _construct_marantz, ("MARANTZ",)),
+    # RC-6 probes AHEAD of RC-5: it carries a 6t/2t leader and a
+    # structured header where RC-5 has neither, so it is the more
+    # specific match of the two Manchester formats -- the same
+    # specific-before-generic reasoning that puts Marantz ahead of RC-5.
+    # Upstream ships no rc6 module today, so this resolves local; if the
+    # library ever adds RC6Command with from_raw_timings, HAIR defers to
+    # it automatically.
+    ("rc6", "infrared_protocols.commands.rc6", "RC6Command",
+     "custom_components.hair.decoders.rc6", True,
+     _extract_rc6, _construct_rc6, ("RC6",)),
     ("rc5", "infrared_protocols.commands.rc5", "RC5Command",
      "custom_components.hair.decoders.rc5", True,
      _extract_rc5, _construct_rc5, ("RC5",)),

--- a/custom_components/hair/tests/test_decoders.py
+++ b/custom_components/hair/tests/test_decoders.py
@@ -29,6 +29,7 @@ from custom_components.hair.decoders.kaseikyo import KaseikyoCommand
 from custom_components.hair.decoders.marantz_extended import MarantzExtendedCommand
 from custom_components.hair.decoders.nokia32 import Nokia32Command
 from custom_components.hair.decoders.rc5 import RC5Command
+from custom_components.hair.decoders.rc6 import RC6Command
 from custom_components.hair.decoders.rca import RCACommand
 from custom_components.hair.decoders.samsung import Samsung32Command
 from custom_components.hair.decoders.sharp import SharpCommand
@@ -686,6 +687,7 @@ _DECODERS = {
     "dyson": DysonCommand,
     "sony": SonyCommand,
     "rc5": RC5Command,
+    "rc6": RC6Command,
     "rca": RCACommand,
     "samsung": Samsung32Command,
     "sharp": SharpCommand,
@@ -702,6 +704,13 @@ def _samples() -> dict[str, list[int]]:
             address=0xA5, address_bits=8, command=0x69, repeat_count=2
         ).get_raw_timings(),
         "rc5": RC5Command(address=5, command=0x35, repeat_count=2).get_raw_timings(),
+        # Mode 6A/LCC is the shape both documented RC-6 variants use
+        # (Media Center 0x800F, VU+ 0x8052) and the widest frame the
+        # decoder accepts, so it is the strongest cross-rejection sample.
+        "rc6": RC6Command(
+            address=0x10, command=0x59, toggle=1, mode=6, customer=0x8052,
+            repeat_count=2,
+        ).get_raw_timings(),
         "samsung": Samsung32Command(
             address=0x07, command=0x02, repeat_count=2
         ).get_raw_timings(),

--- a/custom_components/hair/tests/test_protocol_registry.py
+++ b/custom_components/hair/tests/test_protocol_registry.py
@@ -63,11 +63,11 @@ class TestRegistryContents:
     def test_expected_protocols_registered(self):
         listing = {row["protocol"]: row for row in registered_protocols()}
 
-        # The eight decoder protocols are always present: upstream when
+        # The local decoder protocols are always present: upstream when
         # the bundled library decodes them (none as of 7.5.0), local
         # polyfill otherwise -- including on the no-library CI leg.
         for key in ("samsung32", "sony", "sharp", "rca", "marantz", "rc5",
-                    "kaseikyo", "symphony"):
+                    "rc6", "kaseikyo", "symphony"):
             assert key in listing, f"{key} missing from registry"
             assert listing[key]["source"] == "local"
             assert listing[key]["tx_rebuild"] is True
@@ -90,16 +90,22 @@ class TestRegistryContents:
         # The checksum-free tail: Dyson (15 strict-timed bits) then
         # Symphony (the loosest match in the registry) dead last.
         assert keys[-2:] == ["dyson", "symphony"]
-        # Marantz (specific) probes before RC-5 (its generic parent).
+        # Marantz (specific) probes before RC-5 (its generic parent), and
+        # RC-6 does too: it carries a leader and a structured header
+        # where RC-5 has neither.
         assert keys.index("marantz") < keys.index("rc5")
         # RCA carries a strict whole-payload complement, so it sits in
         # the strict tier -- after Sharp, ahead of the checksum-free
-        # tail and ahead of every checksum-free protocol in it.
+        # tail and ahead of every checksum-free protocol in it. RC-6 is
+        # in that tail: it has no checksum at all, so RCA must probe
+        # ahead of it too.
         assert keys.index("sharp") < keys.index("rca")
-        for checksum_free in ("rc5", "nokia32", "marantz", "dyson", "symphony"):
+        for checksum_free in ("rc5", "rc6", "nokia32", "marantz", "dyson",
+                              "symphony"):
             assert keys.index("rca") < keys.index(checksum_free), (
                 f"RCA must probe before {checksum_free}"
             )
+        assert keys.index("rc6") < keys.index("rc5")
 
     def test_get_spec_resolves_variant_labels(self):
         assert get_spec("SONY15") is not None
@@ -108,6 +114,7 @@ class TestRegistryContents:
         assert get_spec("SYMPHONY12").key == "symphony"
         assert get_spec("RC5").key == "rc5"
         assert get_spec("RCA").key == "rca"
+        assert get_spec("RC6").key == "rc6"
         assert get_spec("UNKNOWN99") is None
         assert get_spec(None) is None
 

--- a/custom_components/hair/tests/test_rc6_decoder.py
+++ b/custom_components/hair/tests/test_rc6_decoder.py
@@ -1,0 +1,683 @@
+"""Tests for the RC-6 decoder (GH #33, MaxRower's VU+ type VI remote).
+
+The cross-protocol rejection matrix for RC-6 lives with every other
+decoder's in ``test_decoders.py``; this file carries what is specific to
+RC-6: the two mode shapes, the double-width trailer, the real capture
+fixtures, and the toggle's ride on the existing per-press machinery.
+
+The four Pronto codes are MaxRower's, posted verbatim in the GH #33
+thread: two presses of the VU+ down button, each press learned as two
+jittered rows by his ESPHome receiver. They are committed exactly as he
+posted them, so the fixtures stay auditable against the thread.
+"""
+from __future__ import annotations
+
+import pytest
+
+from custom_components.hair.decoders.rc5 import RC5Command
+from custom_components.hair.decoders.rc6 import RC6Command
+from custom_components.hair.protocol_decode import (
+    build_protocol_command,
+    format_fingerprint,
+    get_spec,
+    registered_protocols,
+    try_decode_identity,
+)
+
+# --- MaxRower's captures, GH #33 -------------------------------------------
+
+_PRESS_1_ROW_1 = (
+    "0000 006D 001E 0000 0068 0020 0013 000E 0013 000F 0013 0020 0013 0020"
+    " 0034 0020 0013 0011 0011 0012 0011 0011 0012 0011 0011 0012 0011 0012"
+    " 0011 0012 0021 0022 0021 0022 0011 0012 0022 0022 0011 0011 0011 0012"
+    " 0011 0012 0021 0022 0011 0012 0011 0012 0011 0012 0011 0011 0022 0023"
+    " 0021 0012 0011 0022 0011 0012 0021 017C"
+)
+_PRESS_1_ROW_2 = (
+    "0000 006D 001E 0000 0065 0022 0012 0011 0011 0012 0011 0022 0011 0022"
+    " 0032 0022 0011 0012 0011 0012 0011 0011 0011 0012 0011 0012 0011 0012"
+    " 0011 0011 0023 0022 0021 0022 0011 0012 0021 0022 0012 0011 0011 0012"
+    " 0011 0012 0021 0022 0011 0012 0011 0012 0011 0011 0011 0012 0022 0022"
+    " 0021 0012 0011 0022 0011 0012 0021 017C"
+)
+_PRESS_2_ROW_1 = (
+    "0000 006D 001D 0000 0068 0020 0014 000F 0013 000F 0013 0020 0013 0021"
+    " 0034 0020 0013 000F 0013 0010 0012 0011 0011 0012 0011 0012 0011 0011"
+    " 0011 0012 0021 0023 0022 0022 0011 0012 0021 0022 0021 0024 0011 0011"
+    " 0023 0022 0011 0011 0012 0011 0011 0012 0010 0012 0021 0022 0022 0011"
+    " 0011 0022 0011 0012 0022 017C"
+)
+_PRESS_2_ROW_2 = (
+    "0000 006D 001D 0000 0065 0022 0011 0012 0011 0012 0011 0023 0011 0022"
+    " 0032 0022 0011 0012 0011 0012 0011 0011 0011 0012 0011 0012 0011 0011"
+    " 0012 0011 0022 0022 0021 0022 0011 0012 0021 0022 0022 0022 0011 0012"
+    " 0021 0023 0011 0012 0011 0011 0011 0011 0012 0011 0022 0022 0021 0012"
+    " 0011 0022 0011 0012 0021 017C"
+)
+
+_MAXROWER_PRESS_1 = (_PRESS_1_ROW_1, _PRESS_1_ROW_2)
+_MAXROWER_PRESS_2 = (_PRESS_2_ROW_1, _PRESS_2_ROW_2)
+_MAXROWER_ALL = _MAXROWER_PRESS_1 + _MAXROWER_PRESS_2
+
+# His remote is a VU+ set-top box handset: RC-6 mode 6A, 16-bit customer.
+_VU_CUSTOMER = 0x8052
+_VU_ADDRESS = 0x10
+_VU_DOWN = 0x59
+
+
+def _build_frame(symbols: list[tuple[int, int]]) -> list[int]:
+    """Build RC-6 timings from explicit ``(bit, half_width_units)`` symbols.
+
+    A second, deliberately naive implementation of the wire rules, used to
+    construct frames the encoder will not produce (a mode 6B submode, a
+    trailer at the wrong width). Merging adjacent same-sign halves is the
+    whole of the wire format, so this stays a few lines and does not
+    borrow anything from the module under test.
+    """
+    unit = 444
+    timings: list[int] = [6 * unit, -2 * unit]  # leader
+    for bit, width in symbols:
+        halves = [width * unit, -width * unit] if bit else [-width * unit, width * unit]
+        for half in halves:
+            if timings and (timings[-1] > 0) == (half > 0):
+                timings[-1] += half
+            else:
+                timings.append(half)
+    if timings[-1] < 0:
+        timings.pop()
+    return timings
+
+
+def _bits(value: int, width: int) -> list[tuple[int, int]]:
+    """MSB-first single-width symbols for ``value``."""
+    return [((value >> shift) & 1, 1) for shift in range(width - 1, -1, -1)]
+
+
+def _pronto_to_us(text: str) -> list[int]:
+    """Convert a learned (0000) Pronto hex string to signed us timings."""
+    words = [int(w, 16) for w in text.split()]
+    assert words[0] == 0, "learned Pronto only"
+    unit = words[1] * 0.241246
+    body = words[4:]
+    return [
+        round(w * unit) if i % 2 == 0 else -round(w * unit)
+        for i, w in enumerate(body)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Round trips
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    """Encode then decode recovers every field, in both modes."""
+
+    @pytest.mark.parametrize("address", [0x00, 0x05, 0x7F, 0xC3, 0xFF])
+    @pytest.mark.parametrize("command", [0x00, 0x0C, 0x59, 0xFF])
+    @pytest.mark.parametrize("toggle", [0, 1])
+    def test_mode_0(self, address, command, toggle):
+        cmd = RC6Command(address=address, command=command, toggle=toggle)
+        back = RC6Command.from_raw_timings(cmd.get_raw_timings())
+        assert back is not None
+        assert (back.mode, back.customer) == (0, None)
+        assert (back.address, back.command, back.toggle) == (
+            address, command, toggle,
+        )
+
+    @pytest.mark.parametrize(
+        "customer",
+        [0x00, 0x52, 0x7F, 0x8000, 0x800F, _VU_CUSTOMER, 0xFFFF],
+    )
+    @pytest.mark.parametrize("address", [0x00, 0x10, 0x74, 0x7F])
+    @pytest.mark.parametrize("command", [0x00, 0x0C, _VU_DOWN, 0xFF])
+    @pytest.mark.parametrize("toggle", [0, 1])
+    def test_mode_6(self, customer, address, command, toggle):
+        cmd = RC6Command(
+            address=address, command=command, toggle=toggle,
+            mode=6, customer=customer,
+        )
+        back = RC6Command.from_raw_timings(cmd.get_raw_timings())
+        assert back is not None
+        assert (back.mode, back.customer) == (6, customer)
+        assert (back.address, back.command, back.toggle) == (
+            address, command, toggle,
+        )
+
+    def test_repeat_count_counts_extra_agreeing_frames(self):
+        cmd = RC6Command(
+            address=_VU_ADDRESS, command=_VU_DOWN, toggle=1,
+            mode=6, customer=_VU_CUSTOMER, repeat_count=3,
+        )
+        back = RC6Command.from_raw_timings(cmd.get_raw_timings())
+        assert back is not None
+        assert back.repeat_count == 3
+        assert back.address == _VU_ADDRESS
+
+    def test_lone_frame_decodes_standalone(self):
+        """A single frame with no repeats must decode on its own.
+
+        MaxRower learns two rows per press, which means his receiver
+        hands us frames one at a time rather than as a multi-frame
+        capture -- a decoder that needed two agreeing frames would
+        reject every row he has.
+        """
+        cmd = RC6Command(
+            address=_VU_ADDRESS, command=_VU_DOWN,
+            mode=6, customer=_VU_CUSTOMER, repeat_count=0,
+        )
+        timings = cmd.get_raw_timings()
+        back = RC6Command.from_raw_timings(timings)
+        assert back is not None
+        assert back.repeat_count == 0
+        assert (back.address, back.command) == (_VU_ADDRESS, _VU_DOWN)
+
+
+class TestFieldValidation:
+    """The constructor refuses field values that have no wire form."""
+
+    def test_mode_must_be_0_or_6(self):
+        with pytest.raises(ValueError):
+            RC6Command(address=1, command=1, mode=3)
+
+    def test_mode_0_takes_no_customer(self):
+        with pytest.raises(ValueError):
+            RC6Command(address=1, command=1, mode=0, customer=0x800F)
+
+    def test_mode_6_requires_a_customer(self):
+        with pytest.raises(ValueError):
+            RC6Command(address=1, command=1, mode=6)
+
+    @pytest.mark.parametrize("customer", [0x80, 0x100, 0x7FFF, 0x10000, -1])
+    def test_customer_outside_either_field_width_is_refused(self, customer):
+        """The field's first bit signals its length, so 0x80..0x7FFF has
+        no encoding: too big for the 7-bit value behind a leading 0, and
+        without the leading 1 that would buy the 15-bit form."""
+        with pytest.raises(ValueError):
+            RC6Command(address=1, command=1, mode=6, customer=customer)
+
+    def test_mode_6_address_is_seven_bits(self):
+        """Mode 6 spends the top payload bit on the toggle, so an
+        address of 0x80 or more cannot be represented."""
+        with pytest.raises(ValueError):
+            RC6Command(address=0x80, command=1, mode=6, customer=_VU_CUSTOMER)
+
+    def test_mode_0_address_is_eight_bits(self):
+        RC6Command(address=0xFF, command=1, mode=0)
+        with pytest.raises(ValueError):
+            RC6Command(address=0x100, command=1, mode=0)
+
+    def test_command_is_eight_bits(self):
+        with pytest.raises(ValueError):
+            RC6Command(address=1, command=0x100, mode=0)
+
+
+# ---------------------------------------------------------------------------
+# Wire format pin
+# ---------------------------------------------------------------------------
+
+
+def test_wire_format_pin_mode_0():
+    """One explicit timing vector, hand-derived from the protocol.
+
+    Fields: mode 0, address 0x00, command 0x00, toggle 0. Unit t = 444us.
+
+    Symbols, before any merging (RC-6 polarity: 1 is mark-then-space,
+    0 is space-then-mark)::
+
+        leader                 M6 S2
+        start bit    1         M1 S1
+        mode bit 2   0         S1 M1
+        mode bit 1   0         S1 M1
+        mode bit 0   0         S1 M1
+        trailer      0  (2t)   S2 M2
+        D and F      sixteen 0 bits, each S1 M1
+
+    Adjacent same-sign halves then merge on the wire. Only two merges
+    happen here: the start bit's trailing space runs into mode bit 2's
+    leading space (S1+S1 = S2), and nothing else abuts a same-sign
+    neighbour, because a 0 bit ends on a mark and the next 0 bit opens
+    on a space. The trailer therefore stands alone as a clean 2t space
+    followed by a clean 2t mark. The final bit ends on a mark, so no
+    trailing idle is stripped.
+    """
+    timings = RC6Command(address=0x00, command=0x00, toggle=0).get_raw_timings()
+    assert timings == [
+        2664, -888,          # leader: 6t mark, 2t space
+        444, -888,           # start bit's mark, then S1+S1 merged
+        444, -444,           # mode bit 2
+        444, -444,           # mode bit 1
+        444, -888,           # mode bit 0's mark, then the trailer's 2t space
+        888,                 # the trailer's 2t mark
+        *([-444, 444] * 16),  # D=0x00 and F=0x00, sixteen 0 bits
+    ]
+
+
+def test_wire_format_total_duration_pins_the_double_width_trailer():
+    """The trailer costs 4t, not 2t, and the whole frame's length says so.
+
+    A mode 0 frame is leader 8t + start 2t + mode 6t + trailer 4t +
+    sixteen data bits 32t = 52t. A decoder or encoder that treated the
+    trailer as an ordinary bit would produce 50t, which this catches
+    without depending on where any individual merge falls.
+    """
+    timings = RC6Command(address=0x00, command=0x00, toggle=0).get_raw_timings()
+    assert sum(abs(t) for t in timings) == 52 * 444
+
+
+def test_wire_format_leader_is_the_rc5_discriminator():
+    """RC-5 has no leader; RC-6 opens with 6t mark + 2t space."""
+    rc6 = RC6Command(address=0x00, command=0x00).get_raw_timings()
+    assert rc6[0] == 6 * 444
+    assert rc6[1] == -2 * 444
+    rc5 = RC5Command(address=0x00, command=0x00).get_raw_timings()
+    assert rc5[0] < 3 * 444
+
+
+# ---------------------------------------------------------------------------
+# The double-width trailer
+# ---------------------------------------------------------------------------
+
+
+class TestTrailerWidth:
+    """The trailer's 2t halves are modelled explicitly, not quantized."""
+
+    def test_trailer_mark_merges_with_a_following_one_bit(self):
+        """The 3t run that only RC-6 produces.
+
+        Mode 6 with a 16-bit customer puts a 1 bit (mark-first) straight
+        after the trailer, so the trailer's 2t mark absorbs it into a 3t
+        run. That run is why a two-bucket short/long classifier cannot
+        slice this protocol, and why the frame-gap constant has to clear
+        3t rather than 2t.
+        """
+        timings = RC6Command(
+            address=0x00, command=0x00, mode=6, customer=0x8000,
+        ).get_raw_timings()
+        assert 3 * 444 in timings
+        assert max(abs(t) for t in timings[2:]) == 3 * 444
+
+    def test_trailer_mark_stands_alone_before_a_zero_bit(self):
+        """With a 0 bit (space-first) after it, the trailer's 2t mark is
+        undisguised by any merge."""
+        timings = RC6Command(
+            address=0x00, command=0x00, mode=6, customer=0x00,
+        ).get_raw_timings()
+        assert 2 * 444 in timings
+
+    def test_post_trailer_bits_survive_the_width_change(self):
+        """The regression this pins: a uniform half-bit quantizer reads
+        the trailer's four halves as two bits and misaligns every data
+        bit after it, which silently yields a plausible wrong identity
+        rather than a rejection. Sweeping the byte-wide command through
+        values whose bit runs straddle the trailer catches that."""
+        for command in range(0x100):
+            cmd = RC6Command(address=0x2A, command=command, toggle=1)
+            back = RC6Command.from_raw_timings(cmd.get_raw_timings())
+            assert back is not None, f"command {command:#04x} failed to decode"
+            assert back.command == command
+            assert back.address == 0x2A
+            assert back.toggle == 1
+
+    def test_the_independent_builder_agrees_with_the_encoder(self):
+        """Guard on the guard: the naive builder used by the next two
+        tests must reproduce the encoder exactly for a frame both can
+        express, or its negative results would prove nothing."""
+        built = _build_frame(
+            [(1, 1), (0, 1), (0, 1), (0, 1), (1, 2), *_bits(0x2A, 8), *_bits(0x59, 8)]
+        )
+        assert built == RC6Command(
+            address=0x2A, command=0x59, toggle=1
+        ).get_raw_timings()
+
+    def test_trailer_at_single_width_is_rejected(self):
+        """A frame identical in every way except that its trailer is
+        transmitted at 1t must not decode. Accepting it would mean the
+        walk is quantizing uniformly rather than reading the trailer at
+        its declared width -- and a uniform read of a real frame silently
+        produces a plausible wrong identity."""
+        symbols = [(1, 1), (0, 1), (0, 1), (0, 1), (1, 2)]
+        symbols += [*_bits(0x2A, 8), *_bits(0x59, 8)]
+        assert RC6Command.from_raw_timings(_build_frame(symbols)) is not None
+
+        narrowed = list(symbols)
+        narrowed[4] = (1, 1)  # trailer at ordinary width
+        assert RC6Command.from_raw_timings(_build_frame(narrowed)) is None
+
+    def test_mode_6b_submode_is_not_a_command_frame(self):
+        """In mode 6 the trailer is the submode bit, not a toggle: 0 is
+        mode 6A, the command form, and 1 is mode 6B, reserved for
+        pointing devices. A 6B frame must not decode as a command."""
+        payload = [*_bits(_VU_CUSTOMER, 16), (0, 1), *_bits(_VU_ADDRESS, 7)]
+        payload += _bits(_VU_DOWN, 8)
+        mode_6 = [(1, 1), (1, 1), (1, 1), (0, 1)]
+
+        as_6a = _build_frame([*mode_6, (0, 2), *payload])
+        assert RC6Command.from_raw_timings(as_6a) is not None
+
+        as_6b = _build_frame([*mode_6, (1, 2), *payload])
+        assert RC6Command.from_raw_timings(as_6b) is None
+
+
+# ---------------------------------------------------------------------------
+# MaxRower's fixtures
+# ---------------------------------------------------------------------------
+
+
+class TestMaxRowerFixtures:
+    """GH #33: four captures, one identity, two toggle values."""
+
+    @pytest.mark.parametrize("pronto", _MAXROWER_ALL)
+    def test_every_capture_decodes(self, pronto):
+        cmd = RC6Command.from_raw_timings(_pronto_to_us(pronto))
+        assert cmd is not None
+        assert cmd.mode == 6
+        assert cmd.customer == _VU_CUSTOMER
+        assert cmd.address == _VU_ADDRESS
+        assert cmd.command == _VU_DOWN
+
+    def test_all_four_collapse_to_one_identity(self):
+        decoded = [
+            RC6Command.from_raw_timings(_pronto_to_us(p)) for p in _MAXROWER_ALL
+        ]
+        assert all(c is not None for c in decoded)
+        identities = {
+            (c.mode, c.customer, c.address, c.command) for c in decoded
+        }
+        assert identities == {(6, _VU_CUSTOMER, _VU_ADDRESS, _VU_DOWN)}
+
+    def test_exactly_two_toggle_values_split_along_press_boundaries(self):
+        press_1 = {
+            RC6Command.from_raw_timings(_pronto_to_us(p)).toggle
+            for p in _MAXROWER_PRESS_1
+        }
+        press_2 = {
+            RC6Command.from_raw_timings(_pronto_to_us(p)).toggle
+            for p in _MAXROWER_PRESS_2
+        }
+        # Both rows of one press agree; the two presses differ.
+        assert len(press_1) == 1
+        assert len(press_2) == 1
+        assert press_1 != press_2
+        assert press_1 | press_2 == {0, 1}
+
+    def test_the_toggle_is_the_only_difference_between_the_presses(self):
+        """The point of the whole exercise: MaxRower sees two catalog
+        rows per button because the presses differ. They differ in the
+        toggle and in nothing else, so excluding the toggle from
+        identity is what collapses them."""
+        one = RC6Command.from_raw_timings(_pronto_to_us(_PRESS_1_ROW_1))
+        two = RC6Command.from_raw_timings(_pronto_to_us(_PRESS_2_ROW_1))
+        assert one.toggle != two.toggle
+        assert (one.mode, one.customer, one.address, one.command) == (
+            two.mode, two.customer, two.address, two.command,
+        )
+
+    @pytest.mark.parametrize("pronto", _MAXROWER_ALL)
+    def test_captures_do_not_decode_as_rc5(self, pronto):
+        assert RC5Command.from_raw_timings(_pronto_to_us(pronto)) is None
+
+    @pytest.mark.parametrize("pronto", _MAXROWER_ALL)
+    def test_capture_re_encodes_to_the_same_identity(self, pronto):
+        """Canonical re-encode is what HAIR transmits, so a capture that
+        decodes must survive the round trip back through the wire."""
+        original = RC6Command.from_raw_timings(_pronto_to_us(pronto))
+        rebuilt = RC6Command.from_raw_timings(original.get_raw_timings())
+        assert rebuilt is not None
+        assert (
+            rebuilt.mode, rebuilt.customer, rebuilt.address,
+            rebuilt.command, rebuilt.toggle,
+        ) == (
+            original.mode, original.customer, original.address,
+            original.command, original.toggle,
+        )
+
+
+class TestRC5CapturesRejectAsRC6:
+    """Neither Manchester format may claim the other's frames."""
+
+    @pytest.mark.parametrize("address", [0x00, 0x05, 0x14, 0x1F])
+    @pytest.mark.parametrize("command", [0x01, 0x35, 0x40, 0x7F])
+    @pytest.mark.parametrize("toggle", [0, 1])
+    def test_rc5_frames_are_not_rc6(self, address, command, toggle):
+        rc5 = RC5Command(
+            address=address, command=command, toggle=toggle, repeat_count=2,
+        ).get_raw_timings()
+        assert RC6Command.from_raw_timings(rc5) is None
+
+    @pytest.mark.parametrize("mode,customer", [(0, None), (6, _VU_CUSTOMER)])
+    def test_rc6_frames_are_not_rc5(self, mode, customer):
+        rc6 = RC6Command(
+            address=0x10, command=0x59, toggle=1, mode=mode, customer=customer,
+            repeat_count=2,
+        ).get_raw_timings()
+        assert RC5Command.from_raw_timings(rc6) is None
+
+
+# ---------------------------------------------------------------------------
+# Registry wiring
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_rc6_is_registered_local(self):
+        listing = {row["protocol"]: row for row in registered_protocols()}
+        assert "rc6" in listing
+        assert listing["rc6"]["source"] == "local"
+        assert listing["rc6"]["tx_rebuild"] is True
+
+    def test_rc6_probes_before_rc5(self):
+        keys = [row["protocol"] for row in registered_protocols()]
+        assert keys.index("rc6") < keys.index("rc5")
+
+    def test_get_spec_resolves_rc6(self):
+        spec = get_spec("RC6")
+        assert spec is not None
+        assert spec.key == "rc6"
+
+    def test_identity_decodes_through_the_registry(self):
+        identity = try_decode_identity(_pronto_to_us(_PRESS_1_ROW_1))
+        assert identity is not None
+        assert identity.protocol == "RC6"
+        assert identity.address == _VU_ADDRESS
+        assert identity.command == _VU_DOWN
+        assert identity.extras == {
+            "mode": 6, "toggle": 0, "customer": _VU_CUSTOMER,
+        }
+
+    def test_toggle_is_excluded_from_the_fingerprint(self):
+        """The whole collapse depends on this: two presses, one
+        fingerprint."""
+        one = try_decode_identity(_pronto_to_us(_PRESS_1_ROW_1))
+        two = try_decode_identity(_pronto_to_us(_PRESS_2_ROW_1))
+        assert one.extras["toggle"] != two.extras["toggle"]
+        assert one.fingerprint == two.fingerprint
+
+    def test_all_four_captures_share_one_fingerprint(self):
+        prints = {
+            try_decode_identity(_pronto_to_us(p)).fingerprint
+            for p in _MAXROWER_ALL
+        }
+        assert len(prints) == 1
+
+    def test_mode_and_customer_are_identity(self):
+        """Same address and command, different mode or customer, must be
+        different signals -- otherwise a Media Center remote and a VU+
+        box would land on one catalog row."""
+        base = format_fingerprint(
+            "RC6", _VU_ADDRESS, _VU_DOWN,
+            {"mode": 6, "customer": _VU_CUSTOMER, "toggle": 0},
+        )
+        other_customer = format_fingerprint(
+            "RC6", _VU_ADDRESS, _VU_DOWN,
+            {"mode": 6, "customer": 0x800F, "toggle": 0},
+        )
+        mode_0 = format_fingerprint(
+            "RC6", _VU_ADDRESS, _VU_DOWN, {"mode": 0, "toggle": 0},
+        )
+        assert base != other_customer
+        assert base != mode_0
+        assert other_customer != mode_0
+
+    def test_fingerprint_ignores_toggle_only_changes(self):
+        with_toggle = format_fingerprint(
+            "RC6", _VU_ADDRESS, _VU_DOWN,
+            {"mode": 6, "customer": _VU_CUSTOMER, "toggle": 1},
+        )
+        without = format_fingerprint(
+            "RC6", _VU_ADDRESS, _VU_DOWN,
+            {"mode": 6, "customer": _VU_CUSTOMER, "toggle": 0},
+        )
+        assert with_toggle == without
+
+    @pytest.mark.parametrize(
+        "extras",
+        [
+            {"mode": 6, "customer": _VU_CUSTOMER, "toggle": 1},
+            {"mode": 0, "toggle": 1},
+        ],
+    )
+    def test_build_protocol_command_rebuilds_for_tx(self, extras):
+        address = _VU_ADDRESS if extras["mode"] == 6 else 0xC3
+        cmd = build_protocol_command("RC6", address, _VU_DOWN, extras=extras)
+        assert cmd is not None
+        assert cmd.mode == extras["mode"]
+        assert cmd.customer == extras.get("customer")
+        assert cmd.address == address
+        assert cmd.command == _VU_DOWN
+        assert cmd.toggle == 1
+
+    def test_rebuilt_command_transmits_the_captured_waveform(self):
+        """Canonical re-encode must land back on the captured identity,
+        which is what makes a HAIR send match the row it came from."""
+        identity = try_decode_identity(_pronto_to_us(_PRESS_1_ROW_1))
+        cmd = build_protocol_command(
+            identity.protocol, identity.address, identity.command,
+            extras=identity.extras,
+        )
+        assert cmd is not None
+        again = try_decode_identity(cmd.get_raw_timings())
+        assert again is not None
+        assert again.fingerprint == identity.fingerprint
+
+
+# ---------------------------------------------------------------------------
+# Toggle rides the existing per-press machinery
+# ---------------------------------------------------------------------------
+
+
+class TestToggleFlipMachinery:
+    """No new toggle code: RC-6 rides the v0.6.0 flip both send paths use.
+
+    ``device_manager.async_send_command`` and
+    ``signal_monitor.test_signal`` both flip any ``decoded_extras``
+    entry named ``toggle`` once per logical press. These pin that RC-6's
+    extras are shaped to ride it and that a flip produces the other real
+    press, rather than re-testing the send paths themselves.
+    """
+
+    def test_extras_carry_a_toggle_key(self):
+        identity = try_decode_identity(_pronto_to_us(_PRESS_1_ROW_1))
+        assert "toggle" in identity.extras
+
+    def test_flipping_extras_yields_the_other_press(self):
+        first = try_decode_identity(_pronto_to_us(_PRESS_1_ROW_1))
+        second = try_decode_identity(_pronto_to_us(_PRESS_2_ROW_1))
+
+        extras = dict(first.extras)
+        extras["toggle"] = int(extras["toggle"]) ^ 1  # the send-path flip
+        assert extras["toggle"] == second.extras["toggle"]
+
+        flipped = build_protocol_command(
+            "RC6", first.address, first.command, extras=extras
+        )
+        assert flipped is not None
+        # The re-encoded frame carries the second press's toggle and the
+        # first press's identity, which is exactly what a second send
+        # from HAIR should put on the air.
+        again = try_decode_identity(flipped.get_raw_timings())
+        assert again.extras["toggle"] == second.extras["toggle"]
+        assert again.fingerprint == first.fingerprint
+
+    def test_flip_is_an_involution(self):
+        """Two presses return to the starting toggle, so a held-button
+        pair of sends reproduces the two frames the remote emits."""
+        identity = try_decode_identity(_pronto_to_us(_PRESS_1_ROW_1))
+        toggle = int(identity.extras["toggle"])
+        assert ((toggle ^ 1) ^ 1) == toggle
+
+    def test_send_count_repeats_the_same_toggle(self):
+        """send_count is whole-frame retransmission inside ONE logical
+        press, so every frame in the burst carries the same toggle --
+        the flip happens once, after the send loop."""
+        cmd = RC6Command(
+            address=_VU_ADDRESS, command=_VU_DOWN, toggle=1,
+            mode=6, customer=_VU_CUSTOMER, repeat_count=3,
+        )
+        timings = cmd.get_raw_timings()
+        back = RC6Command.from_raw_timings(timings)
+        assert back is not None
+        assert back.repeat_count == 3
+        # Every frame in the capture agrees on the toggle, so the
+        # majority vote is unanimous rather than split.
+        assert back.toggle == 1
+
+
+# ---------------------------------------------------------------------------
+# Malformed input
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedInput:
+    @pytest.mark.parametrize(
+        "timings",
+        [
+            [],
+            [100],
+            [2664],
+            [2664, -888],
+            [1000, -1000] * 200,
+            [-888, 2664, 444, -444],       # starts on a space
+            [2664, 888, 444, -444],        # leader space is a mark
+        ],
+    )
+    def test_garbage_returns_none(self, timings):
+        assert RC6Command.from_raw_timings(timings) is None
+
+    def test_wrong_leader_width_is_rejected(self):
+        timings = RC6Command(address=0x10, command=0x59).get_raw_timings()
+        assert RC6Command.from_raw_timings(timings) is not None
+        bad = list(timings)
+        bad[0] = 444  # a 1t leader mark is not a leader
+        assert RC6Command.from_raw_timings(bad) is None
+
+    def test_start_bit_must_be_one(self):
+        """The start bit is fixed at 1; a frame whose first symbol reads
+        as 0 is not RC-6."""
+        timings = RC6Command(address=0x10, command=0x59).get_raw_timings()
+        bad = list(timings)
+        bad[2] = -444          # turn the start bit's mark-then-space
+        bad.insert(3, 444)     # into space-then-mark
+        assert RC6Command.from_raw_timings(bad) is None
+
+    def test_unsupported_payload_width_stays_undecoded(self):
+        """Mode 6A does not encode its own length. Rather than guess at a
+        width the family does not use, the decoder refuses -- an absent
+        identity leaves the signal on the raw tiers, a wrong one would
+        match the wrong command forever."""
+        cmd = RC6Command(
+            address=0x10, command=0x59, mode=6, customer=_VU_CUSTOMER,
+        )
+        timings = cmd.get_raw_timings()
+        # Drop the final data bit, leaving a 15-bit remainder.
+        truncated = timings[:-2]
+        assert RC6Command.from_raw_timings(truncated) is None
+
+    def test_a_run_longer_than_three_units_is_not_a_half_bit(self):
+        """3t is the longest legal run inside a frame (a 2t trailer half
+        abutting a 1t neighbour). Anything longer mid-frame is corruption,
+        not a symbol."""
+        timings = RC6Command(address=0x10, command=0x59).get_raw_timings()
+        bad = list(timings)
+        bad[4] = 4 * 444
+        assert RC6Command.from_raw_timings(bad) is None


### PR DESCRIPTION
The RC6 protocol (Philips gear, Windows Media Center remotes, Sky and VU+ set top boxes). Manchester coded behind a leader, with the trailer bit at double width; in mode 6 the trailer is the submode bit and the toggle moves into the payload, which the captures settled. Toggle rides in extras and is excluded from identity, so alternating press codes collapse to one row and both send paths flip the toggle per logical press on the existing machinery. Probes immediately before RC-5; registry order verified with the RCA decoder already on main. Fixtures: the four captures from issue 33 collapse to one identity with two toggle values on the press boundary. Flipper-IRDB sweep: 1670 decodes across 54 files, no false positives; RC6-6-20 deferred rather than guessed. Benched on the test box including a Broadlink to Athom air loopback.