### PR TITLE
Restore completeness: entity state survives a restart

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -112,6 +112,12 @@ _stub("homeassistant.const", {
     "STATE_UNKNOWN": "unknown",
     "STATE_ON": "on",
     "STATE_OFF": "off",
+    # Cover's two real states (restore completeness, 2026-08-23). Real
+    # HA has carried both since forever; the stub only ever needed the
+    # on/off pair because no HAIR platform read a cover's state back
+    # until cover.py gained RestoreEntity.
+    "STATE_CLOSED": "closed",
+    "STATE_OPEN": "open",
     "ATTR_UNIT_OF_MEASUREMENT": "unit_of_measurement",
     "__version__": "2026.7.0",
 })

--- a/conftest.py
+++ b/conftest.py
@@ -314,6 +314,11 @@ class _FanEntity:
 _stub("homeassistant.components.fan", {
     "FanEntity": _FanEntity,
     "FanEntityFeature": _FanEntityFeature,
+    # Attribute keys, needed since fan.py restores percentage and
+    # oscillating from a stored state (restore completeness,
+    # 2026-08-23). Same strings real HA uses.
+    "ATTR_PERCENTAGE": "percentage",
+    "ATTR_OSCILLATING": "oscillating",
 })
 
 # --- homeassistant.util.percentage ---

--- a/conftest.py
+++ b/conftest.py
@@ -289,6 +289,9 @@ _stub("homeassistant.components.climate", {
     "ATTR_TEMPERATURE": "temperature",
     "ATTR_FAN_MODE": "fan_mode",
     "ATTR_SWING_MODE": "swing_mode",
+    # Needed since climate.py restores the starred preset with a match
+    # check (restore completeness, 2026-08-23).
+    "ATTR_PRESET_MODE": "preset_mode",
     "ClimateEntity": _ClimateEntity,
     "ClimateEntityFeature": _ClimateEntityFeature,
     "HVACMode": _HVACMode,

--- a/conftest.py
+++ b/conftest.py
@@ -245,6 +245,10 @@ _stub("homeassistant.components.media_player", {
     "MediaPlayerEntity": _MediaPlayerEntity,
     "MediaPlayerEntityFeature": _MediaPlayerEntityFeature,
     "MediaPlayerState": _MediaPlayerState,
+    # Attribute keys, needed since media_player.py restores volume and
+    # mute from a stored state (restore completeness, 2026-08-23).
+    "ATTR_MEDIA_VOLUME_LEVEL": "volume_level",
+    "ATTR_MEDIA_VOLUME_MUTED": "is_volume_muted",
 })
 
 class _ClimateEntityFeature:

--- a/custom_components/hair/climate.py
+++ b/custom_components/hair/climate.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.climate import (
     ATTR_FAN_MODE,
+    ATTR_PRESET_MODE,
     ATTR_SWING_MODE,
     ATTR_TEMPERATURE,
     ClimateEntity,
@@ -56,6 +57,7 @@ from .wig_climate import (
     state_display_name,
     unit_letter,
 )
+from .wig_format import cell_key
 
 if TYPE_CHECKING:
     from .wig_format import ClimateCell, ClimateMatrix
@@ -191,11 +193,36 @@ class HAIRClimateEntity(RestoreEntity, ClimateEntity):
         self._matrix_cell: str | None = None
         # Climate presets: the star (climate-presets-star.md). The
         # starred command last sent through async_set_preset_mode, or
-        # None. Deliberately NOT restored across restarts: this is an
-        # assumed-state entity, nothing tells us the unit is still in
-        # that state after a reboot, and None is the honest answer.
-        # Every other setter clears it (see the actions below) so the
-        # attribute never claims a preset the unit has since moved off.
+        # None. Every other setter clears it (see the actions below) so
+        # the attribute never claims a preset the unit has since moved
+        # off.
+        #
+        # SUPERSEDED 2026-08-23. The original reasoning, kept because it
+        # is the argument the new rule has to answer:
+        #
+        #   Deliberately NOT restored across restarts: this is an
+        #   assumed-state entity, nothing tells us the unit is still in
+        #   that state after a reboot, and None is the honest answer.
+        #
+        # That is sound in isolation and inconsistent in place. The
+        # audit (state-restore-audit.md, section 2c) put it plainly:
+        # the same argument applies verbatim to hvac_mode, temperature,
+        # fan_mode and swing_mode, which this file HAS always restored.
+        # HAIR was willing to say "this AC is in cool at 73 with the fan
+        # high" on no evidence and unwilling to say "and that
+        # combination is the preset you named" -- and on the audit's own
+        # device the preset was a NAME for exactly that restored triple.
+        # The card was already claiming the state and only declining to
+        # name it.
+        #
+        # RULED (owner, 2026-08-23, GH #115): restore it, WITH A MATCH
+        # CHECK. The preset comes back only when the restored
+        # mode/fan/temp still resolve to that starred command's own
+        # cell. Any miss leaves it None. That answers the honesty
+        # concern on its own terms rather than by ignoring it: the
+        # attribute can never claim a preset the restored state
+        # contradicts, which is a stronger guarantee than never
+        # claiming anything. See _async_restore_state.
         self._preset_mode: str | None = None
         # Power monitoring (Device Settings, 0.9.8). The mode this
         # entity was in the last time it went off (by any means -- a
@@ -287,6 +314,7 @@ class HAIRClimateEntity(RestoreEntity, ClimateEntity):
                     max(restored_temp, self._matrix.min_temp),
                     self._matrix.max_temp,
                 )
+            cell = None
             if restored_mode != HVACMode.OFF:
                 file_mode = self._file_mode_for(restored_mode)
                 cell = (
@@ -304,6 +332,32 @@ class HAIRClimateEntity(RestoreEntity, ClimateEntity):
             self._swing_mode = restored_swing
             if restored_temp is not None:
                 self._target_temperature = restored_temp
+            if cell is not None:
+                # matrix_cell, RE-DERIVED rather than read back
+                # (restore completeness, 2026-08-23). It was never
+                # scoped out; the readout simply postdates the 0.9.8
+                # restore list (it arrived with 0.10.1 item 7 / GH
+                # #105) and nobody added it when the feature landed, so
+                # the device page's current-cell line went blank after
+                # every restart.
+                #
+                # Re-derived from the cell the restored combination
+                # just resolved to, rather than read from the stored
+                # attribute, because re-derivation CANNOT disagree with
+                # the restored values. A stored string could: the
+                # lattice may have changed under it, or the display
+                # unit may have (the name carries a converted
+                # temperature), and then the readout would name a cell
+                # the entity is not in. Same derivation the live
+                # setters use, so the two doors cannot drift.
+                self._matrix_cell = self._cell_display_name(cell)
+                self._restore_preset(last_state, cell)
+            else:
+                # Restored OFF. The live async_turn_off writes exactly
+                # this, so the readout agrees with itself whichever way
+                # the entity got here. The preset stays None because
+                # turning off clears it.
+                self._matrix_cell = state_display_name("off")
         else:
             self._hvac_mode = restored_mode
             if restored_temp is not None:
@@ -970,25 +1024,79 @@ class HAIRClimateEntity(RestoreEntity, ClimateEntity):
                 return raw
         return None
 
-    async def _async_send_cell(self, cell: ClimateCell) -> None:
-        # The display grammar names the send (owner ruling 2026-07-29,
-        # mockup CC4): the Mirror row and the matrix_cell attribute
-        # both read "cool / fan: auto / 22", never the compact
-        # fittings key. The temperature part converts to the INSTALL's
-        # unit at send time (unit ruling 2026-07-29: live surfaces
-        # convert dynamically), so a C-file cell on an imperial
-        # install reads "cool / fan: auto / 72".
+    def _cell_display_name(self, cell: ClimateCell) -> str:
+        """This cell's readout name, in the install's display unit.
+
+        The display grammar names the send (owner ruling 2026-07-29,
+        mockup CC4): the Mirror row and the matrix_cell attribute both
+        read "cool / fan: auto / 22", never the compact fittings key.
+        The temperature part converts to the INSTALL's unit (unit
+        ruling 2026-07-29: live surfaces convert dynamically), so a
+        C-file cell on an imperial install reads
+        "cool / fan: auto / 72".
+
+        Factored out of ``_async_send_cell`` 2026-08-23 so restore can
+        re-derive the readout through the same derivation the live
+        setters use. Two doors, one answer; if this ever changes, it
+        changes for both at once.
+        """
         m = self._matrix
         display_unit = (
             unit_letter(self.hass.config.units.temperature_unit)
             if self.hass is not None else None
         )
-        name = cell_display_name(
+        return cell_display_name(
             cell,
             unit=m.unit if m is not None else "C",
             display_unit=display_unit,
             precision=m.precision if m is not None else 1.0,
         )
+
+    def _restore_preset(self, last_state: State, cell: ClimateCell) -> None:
+        """Restore the starred preset, but only if it still fits.
+
+        The ruled middle path (owner, 2026-08-23, GH #115; see the
+        superseded reasoning in ``__init__``). The stored preset name
+        comes back ONLY when the restored mode/fan/temp resolve to the
+        same cell that starred command itself resolves to. Any miss --
+        the name is not starred any more, the command was deleted, it
+        carries no coordinates, or the lattice moved under it -- leaves
+        the preset None and touches nothing else.
+
+        That is what keeps the attribute from ever claiming a preset
+        the restored state contradicts, which was the whole force of
+        the original refusal.
+
+        A STATE row carries its own coordinates on ``sent_state``
+        (0.10.1 item 7). A row minted before that and never matched by
+        the setup backfill has none, and there is no re-validating a
+        preset whose cell cannot be named: the live setter treats such
+        a row as readout-only and refuses to parse display grammar, and
+        so does this. Refusing here costs a preset name after a
+        restart; guessing would cost the guarantee above.
+        """
+        name = last_state.attributes.get(ATTR_PRESET_MODE)
+        if not name or name not in (self.preset_modes or []):
+            return
+        command = self._device.get_command_by_name(name)
+        if command is None:
+            return
+        state = command.sent_state or {}
+        if not state:
+            return
+        starred_cell = resolve_cell(
+            self._matrix,
+            state.get("mode"),
+            state.get("fan"),
+            state.get("swing"),
+            state.get("temp"),
+        ) if self._matrix is not None else None
+        if starred_cell is None or cell_key(starred_cell) != cell_key(cell):
+            return
+        self._preset_mode = name
+
+    async def _async_send_cell(self, cell: ClimateCell) -> None:
+        name = self._cell_display_name(cell)
         await self._manager.async_send_matrix_cell(
             self._device.id, name, cell.pronto, cell.send_count,
             # Own send: the dispatcher handler ignores origin "entity"

--- a/custom_components/hair/cover.py
+++ b/custom_components/hair/cover.py
@@ -10,8 +10,10 @@ from homeassistant.components.cover import (
     CoverEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_CLOSED, STATE_OPEN
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import DOMAIN, DeviceType
 from .models import IRDevice
@@ -61,7 +63,7 @@ async def async_setup_entry(
         _on_add(device)
 
 
-class HAIRCoverEntity(CoverEntity):
+class HAIRCoverEntity(RestoreEntity, CoverEntity):
     """IR-controlled cover (projector screen, shade, etc.)."""
 
     _attr_has_entity_name = True
@@ -100,6 +102,46 @@ class HAIRCoverEntity(CoverEntity):
     @property
     def is_closed(self) -> bool | None:
         return self._is_closed
+
+    async def async_added_to_hass(self) -> None:
+        await self._async_restore_state()
+
+    async def _async_restore_state(self) -> None:
+        """Reboot survival (restore completeness, 2026-08-23).
+
+        Cover was the one platform the 0.9.8 scoping rule missed
+        outright. That rule said "on/off platforms restore is_on", which
+        reads as though it covers the field; a cover has `is_closed`
+        rather than `is_on` and is not climate, so it fell through and
+        never got `RestoreEntity` at all. The audit
+        (`state-restore-audit.md`, section 2a) found the hole from both
+        ends: the entity came back `unknown` from both closed AND open,
+        and `core.restore_state` held no entry for it, because a
+        non-RestoreEntity never writes one.
+
+        Unknown is worse than stale here. A stale cover still draws on a
+        dashboard and still templates; an unknown one shows nothing and
+        breaks any automation reading `is_closed`.
+
+        Only the two states this platform can actually be in are
+        restored. Anything else -- `unknown`, `unavailable`, a state
+        from some other integration's history -- leaves `_is_closed`
+        None, which is the honest reading of "no evidence".
+
+        NO POWER-VERDICT SUBSCRIPTION, deliberately (owner ruling
+        2026-08-23). The other five platforms subscribe to
+        SIGNAL_POWER_VERDICT so a configured sensor can correct their
+        assumed state; cover does not, because a screen wired to a power
+        sensor is a corner case not worth the wiring. The asymmetry is a
+        decision, not the same oversight repeating.
+        """
+        last_state = await self.async_get_last_state()
+        if last_state is None:
+            return
+        if last_state.state == STATE_CLOSED:
+            self._is_closed = True
+        elif last_state.state == STATE_OPEN:
+            self._is_closed = False
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         await self._send("open_cover")

--- a/custom_components/hair/fan.py
+++ b/custom_components/hair/fan.py
@@ -1,10 +1,16 @@
 """Fan entity platform for HAIR."""
 from __future__ import annotations
 
+import contextlib
 import logging
 from typing import Any
 
-from homeassistant.components.fan import FanEntity, FanEntityFeature
+from homeassistant.components.fan import (
+    ATTR_OSCILLATING,
+    ATTR_PERCENTAGE,
+    FanEntity,
+    FanEntityFeature,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_ON
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
@@ -143,13 +149,44 @@ class HAIRFanEntity(RestoreEntity, FanEntity):
         state from the entity's state before this restart -- the power
         monitor's STARTUP SEED (power_monitor.py, commit 2) corrects it
         immediately after if a sensor is configured, so restore only
-        has to get close. Percentage and oscillation are scoped out
-        (the coding plan's "on/off platforms restore is_on"); they
-        reset to __init__'s defaults like any other restart today.
+        has to get close.
+
+        SCOPE WIDENED 2026-08-23 (state-restore-audit.md, GH #115).
+        Percentage and oscillation used to be scoped out here, citing
+        the 0.9.8 coding plan's "on/off platforms restore is_on". That
+        was a real decision for a release whose only job was making
+        power survive, and it is stale: a fan that comes back on at no
+        speed and not oscillating looks broken in a way "off" does not,
+        which is exactly what #115 reported.
+
+        Two things settle it beyond the user report. Both values are
+        already sitting in ``last_state.attributes`` -- this is a read,
+        not new bookkeeping, and it is the same shape climate.py has
+        always used for fan and swing. And the power-verdict handler
+        below already assumes they survive, in as many words: it says
+        an "on" verdict restores speed and oscillation for free. That
+        was only ever true mid-session; now it is true after a restart
+        too, and the file agrees with itself.
+
+        Type-tolerant on purpose. A missing attribute, a None, or
+        anything that will not convert falls back to __init__'s default
+        rather than raising: a pre-fix stored state carries neither
+        attribute, and a restore block that raises on a stale snapshot
+        takes the whole entity down with it.
         """
         last_state = await self.async_get_last_state()
-        if last_state is not None:
-            self._is_on = last_state.state == STATE_ON
+        if last_state is None:
+            return
+        self._is_on = last_state.state == STATE_ON
+
+        percentage = last_state.attributes.get(ATTR_PERCENTAGE)
+        if percentage is not None:
+            with contextlib.suppress(TypeError, ValueError):
+                self._percentage = max(0, min(100, int(percentage)))
+
+        oscillating = last_state.attributes.get(ATTR_OSCILLATING)
+        if oscillating is not None:
+            self._oscillating = bool(oscillating)
 
     @callback
     def _handle_power_verdict(self, device_id: str, verdict: PowerVerdict) -> None:

--- a/custom_components/hair/media_player.py
+++ b/custom_components/hair/media_player.py
@@ -1,10 +1,13 @@
 """Media player entity platform for HAIR."""
 from __future__ import annotations
 
+import contextlib
 import logging
 from typing import Any
 
 from homeassistant.components.media_player import (
+    ATTR_MEDIA_VOLUME_LEVEL,
+    ATTR_MEDIA_VOLUME_MUTED,
     MediaPlayerEntity,
     MediaPlayerEntityFeature,
     MediaPlayerState,
@@ -148,17 +151,47 @@ class HAIRMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
         state from the entity's state before this restart -- the power
         monitor's STARTUP SEED (power_monitor.py, commit 2) corrects it
         immediately after if a sensor is configured, so restore only
-        has to get close. Clamped to plain ON/OFF like the verdict
+        has to get close.
+
+        PLAYBACK STATE STAYS CLAMPED to plain ON/OFF, like the verdict
         handler: HAIR has no way to know whether a restored PLAYING/
-        PAUSED/IDLE state still holds, so it isn't restored.
+        PAUSED/IDLE state still holds, so it isn't restored. That part
+        is deliberate and correct and is not what changed here.
+
+        VOLUME AND MUTE ADDED 2026-08-23 (state-restore-audit.md, GH
+        #115). They were dropped by the same 0.9.8 scoping rule that
+        caught fan's percentage -- "on/off platforms restore is_on" --
+        without a comment naming it here.
+
+        The reasoning is not the same as playback's, which is why they
+        move and playback does not. A stepped IR volume is a guess
+        either way, but 0.5 is a WORSE guess than the last value this
+        entity actually held: the default is a number nobody chose,
+        while the stored one is at least where the user left it. Mute
+        is worse still -- flipping silently to false across a restart
+        is the kind of thing that gets blamed on the TV.
+
+        Same type tolerance as fan: a missing, None or unconvertible
+        value falls back to __init__'s default rather than raising, so
+        a pre-fix stored state behaves exactly as it does today.
         """
         last_state = await self.async_get_last_state()
-        if last_state is not None:
-            self._state = (
-                MediaPlayerState.ON
-                if last_state.state == STATE_ON
-                else MediaPlayerState.OFF
-            )
+        if last_state is None:
+            return
+        self._state = (
+            MediaPlayerState.ON
+            if last_state.state == STATE_ON
+            else MediaPlayerState.OFF
+        )
+
+        volume = last_state.attributes.get(ATTR_MEDIA_VOLUME_LEVEL)
+        if volume is not None:
+            with contextlib.suppress(TypeError, ValueError):
+                self._volume_level = max(0.0, min(1.0, float(volume)))
+
+        muted = last_state.attributes.get(ATTR_MEDIA_VOLUME_MUTED)
+        if muted is not None:
+            self._is_muted = bool(muted)
 
     @callback
     def _handle_power_verdict(self, device_id: str, verdict: PowerVerdict) -> None:

--- a/custom_components/hair/remote.py
+++ b/custom_components/hair/remote.py
@@ -75,6 +75,22 @@ class HAIRRemoteEntity(RemoteEntity):
         self._manager = device_manager
         self._attr_unique_id = f"hair_{device.id}_remote"
         self._attr_name = "Remote"
+        # ALWAYS ON, and that is a decision (owner ruling 2026-08-23,
+        # state-restore-audit.md section 2e / GH #115).
+        #
+        # The audit found this platform has no restore path at all and
+        # asked the question the code could not answer: is a HAIR
+        # remote's is_on a claim about the APPLIANCE, which should
+        # survive a restart, or about the SENDER, which is always
+        # available? Ruled: the sender. The toggle says this remote is
+        # ready to use, not that the thing it points at is powered.
+        #
+        # So there is deliberately no RestoreEntity here and nothing to
+        # restore. A remote comes back on after every restart because
+        # it IS on -- HAIR can always send through it. Read as an
+        # omission before the ruling; recorded now so a future
+        # RestoreEntity sweep has to argue with the decision instead of
+        # quietly reversing it.
         self._is_on = True
 
     @property

--- a/custom_components/hair/tests/test_restore_completeness.py
+++ b/custom_components/hair/tests/test_restore_completeness.py
@@ -1,0 +1,280 @@
+"""Restore completeness: the invariants that hold across all platforms.
+
+`test_restore_state_reboot.py` pins what each platform restores.
+This file pins the three things that must be true of every restore
+block at once, and that no per-platform test can see:
+
+- **NO RESTORE PATH TRANSMITS.** GH #115's closing requirement, and the
+  one thing HAIR was already clean on. The audit verified it three ways
+  on the live box (store row count, log grep, timestamp ordering); this
+  is the version that runs in CI and keeps it true. Restore is
+  bookkeeping by construction -- every block writes `self._is_on` /
+  `self._hvac_mode` / etc. and none reaches a send. A future block that
+  did reach one would be a silent regression on a promise made to a
+  reporter.
+- **Every platform tolerates no stored state.** A fresh install, a new
+  entity, a snapshot HA never wrote: `async_get_last_state()` returns
+  None and the entity keeps `__init__`'s defaults without raising.
+- **A pre-fix stored state behaves exactly as today.** The 2026-08-23
+  additions all read attributes that a v0.11.1 state does not carry.
+  Every one of them has to fall back rather than raise, or upgrading
+  breaks every entity at once on the first boot.
+
+The device fixtures mirror the audit's own instrument: action keys
+mapped to command names that do not exist on the device, so the entity
+advertises every feature and accepts every setter while `_send` finds
+nothing to send. Fully exercisable and provably unable to transmit,
+which is the right shape for a test whose job is proving nothing
+transmits.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.components.climate import (
+    ATTR_FAN_MODE,
+    ATTR_PRESET_MODE,
+    ATTR_SWING_MODE,
+    ATTR_TEMPERATURE,
+    HVACMode,
+)
+from homeassistant.components.fan import ATTR_OSCILLATING, ATTR_PERCENTAGE
+from homeassistant.components.media_player import (
+    ATTR_MEDIA_VOLUME_LEVEL,
+    ATTR_MEDIA_VOLUME_MUTED,
+    MediaPlayerState,
+)
+from homeassistant.core import State
+
+from custom_components.hair.climate import HAIRClimateEntity
+from custom_components.hair.const import DeviceType
+from custom_components.hair.cover import HAIRCoverEntity
+from custom_components.hair.fan import HAIRFanEntity
+from custom_components.hair.light import HAIRLightEntity
+from custom_components.hair.media_player import HAIRMediaPlayerEntity
+from custom_components.hair.models import EntityConfig, IRDevice
+from custom_components.hair.switch import HAIRSwitchEntity
+from custom_components.hair.wig_format import ClimateCell, ClimateMatrix
+
+# Every action key any of these platforms reads, pointed at command
+# names the device does not have -- the audit's instrument. The entity
+# advertises the feature and accepts the setter; _send finds nothing.
+_PHANTOM_MAPPING = {
+    key: f"No Such Command ({key})"
+    for key in (
+        "turn_on", "turn_off", "power_toggle",
+        "volume_up", "volume_down", "mute", "select_source",
+        "play", "pause", "stop",
+        "speed_up", "speed_down", "oscillate",
+        "open_cover", "close_cover", "stop_cover",
+        "mode_cool", "mode_heat", "fan_low", "fan_high",
+    )
+}
+
+
+def _device(device_type: DeviceType, **overrides) -> IRDevice:
+    return IRDevice(
+        id="dev-restore",
+        name="Restore Probe",
+        device_type=device_type,
+        emitter_entity_ids=["infrared.test"],
+        entity_config=EntityConfig(command_mapping=dict(_PHANTOM_MAPPING)),
+        **overrides,
+    )
+
+
+def _matrix() -> ClimateMatrix:
+    return ClimateMatrix(
+        min_temp=16.0, max_temp=30.0, precision=1.0,
+        modes=["cool"], fan_modes=["auto"], swing_modes=[],
+        off="P-OFF", on=None,
+        cells=[ClimateCell(mode="cool", fan="auto", temp=22.0,
+                           pronto="P-C-A-22")],
+    )
+
+
+def _spy_manager() -> MagicMock:
+    """A manager that records any attempt to put IR on the wire.
+
+    Every door out of an entity, not just the one each platform
+    happens to use today: if a restore block ever calls any of them
+    the count moves and the test fails.
+    """
+    mgr = MagicMock()
+    mgr.async_send_command = AsyncMock()
+    mgr.async_send_matrix_cell = AsyncMock()
+    mgr.async_send_pronto = AsyncMock()
+    return mgr
+
+
+def _sends(mgr: MagicMock) -> int:
+    return (
+        mgr.async_send_command.call_count
+        + mgr.async_send_matrix_cell.call_count
+        + mgr.async_send_pronto.call_count
+    )
+
+
+def _build(entity_cls, device, last_state, matrix=None):
+    mgr = _spy_manager()
+    entity = entity_cls(device, mgr)
+    entity.async_write_ha_state = MagicMock()
+    entity.hass = MagicMock()
+    entity.hass.config.units.temperature_unit = "°C"
+    if matrix is not None:
+        entity._matrix = matrix
+    entity.async_get_last_state = AsyncMock(return_value=last_state)
+    entity.async_get_last_extra_data = AsyncMock(return_value=None)
+    return entity, mgr
+
+
+# A rich stored state per platform: every attribute the 2026-08-23 work
+# added, set to something a restore block would have to act on. If any
+# block reaches a send, it will be while handling one of these.
+_RICH: list[tuple] = [
+    (HAIRSwitchEntity, DeviceType.SWITCH, State("switch.x", "on", {}), None),
+    (HAIRLightEntity, DeviceType.LIGHT, State("light.x", "on", {}), None),
+    (
+        HAIRFanEntity, DeviceType.FAN,
+        State("fan.x", "on",
+              {ATTR_PERCENTAGE: 60, ATTR_OSCILLATING: True}),
+        None,
+    ),
+    (
+        HAIRMediaPlayerEntity, DeviceType.MEDIA_PLAYER,
+        State("media_player.x", "on",
+              {ATTR_MEDIA_VOLUME_LEVEL: 0.55, ATTR_MEDIA_VOLUME_MUTED: True}),
+        None,
+    ),
+    (
+        HAIRCoverEntity, DeviceType.SCREEN,
+        State("cover.x", "closed", {}),
+        None,
+    ),
+    (
+        HAIRClimateEntity, DeviceType.AC,
+        State("climate.x", HVACMode.COOL,
+              {ATTR_TEMPERATURE: 22.0, ATTR_FAN_MODE: "auto"}),
+        None,
+    ),
+    (
+        HAIRClimateEntity, DeviceType.AC,
+        State("climate.x", HVACMode.COOL,
+              {ATTR_TEMPERATURE: 22.0, ATTR_FAN_MODE: "auto",
+               ATTR_SWING_MODE: None, ATTR_PRESET_MODE: "anything"}),
+        _matrix(),
+    ),
+]
+
+_IDS = [
+    "switch", "light", "fan", "media_player", "cover",
+    "climate-preset-mode", "climate-matrix-mode",
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("entity_cls,device_type,last_state,matrix", _RICH, ids=_IDS)
+async def test_restore_never_transmits(entity_cls, device_type, last_state, matrix):
+    """#115: "restored values should not send IR commands automatically
+    during startup". They do not, and this is what keeps it that way."""
+    device = _device(device_type, climate_matrix=matrix is not None)
+    entity, mgr = _build(entity_cls, device, last_state, matrix)
+    await entity._async_restore_state()
+    assert _sends(mgr) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("entity_cls,device_type,last_state,matrix", _RICH, ids=_IDS)
+async def test_no_stored_state_is_survivable(entity_cls, device_type, last_state, matrix):
+    """A fresh install, a new entity, or a snapshot HA never wrote."""
+    device = _device(device_type, climate_matrix=matrix is not None)
+    entity, mgr = _build(entity_cls, device, None, matrix)
+    await entity._async_restore_state()
+    assert _sends(mgr) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("entity_cls,device_type,last_state,matrix", _RICH, ids=_IDS)
+async def test_v0111_shaped_state_restores_without_error(
+    entity_cls, device_type, last_state, matrix
+):
+    """The shape a v0.11.1 install actually wrote: the state string and
+    the attributes that release restored, and NONE of the ones this
+    ticket added.
+
+    Every new read has to fall back rather than raise. Getting this
+    wrong breaks every entity at once on the first boot after upgrade,
+    which is the worst failure mode available to a restore change.
+    """
+    legacy = State(
+        last_state.entity_id,
+        last_state.state,
+        {
+            key: value for key, value in last_state.attributes.items()
+            if key in (ATTR_TEMPERATURE, ATTR_FAN_MODE, ATTR_SWING_MODE)
+        },
+    )
+    device = _device(device_type, climate_matrix=matrix is not None)
+    entity, mgr = _build(entity_cls, device, legacy, matrix)
+    await entity._async_restore_state()
+    assert _sends(mgr) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("entity_cls,device_type,last_state,matrix", _RICH, ids=_IDS)
+async def test_v0111_shaped_state_leaves_the_new_attributes_at_defaults(
+    entity_cls, device_type, last_state, matrix
+):
+    """Same states, checked from the other side: a pre-fix snapshot
+    must produce EXACTLY today's behaviour, not a partial apply."""
+    legacy = State(last_state.entity_id, last_state.state, {})
+    device = _device(device_type, climate_matrix=matrix is not None)
+    entity, _ = _build(entity_cls, device, legacy, matrix)
+    fresh, _ = _build(entity_cls, _device(
+        device_type, climate_matrix=matrix is not None), None, matrix)
+    await entity._async_restore_state()
+    await fresh._async_restore_state()
+
+    if isinstance(entity, HAIRFanEntity):
+        assert entity.percentage == fresh.percentage
+        assert entity.oscillating == fresh.oscillating
+    elif isinstance(entity, HAIRMediaPlayerEntity):
+        assert entity.volume_level == fresh.volume_level
+        assert entity.is_volume_muted == fresh.is_volume_muted
+    elif isinstance(entity, HAIRClimateEntity):
+        assert entity.preset_mode == fresh.preset_mode is None
+
+
+@pytest.mark.asyncio
+async def test_every_platform_that_restores_says_so_the_same_way():
+    """One shape, six platforms. Restore lives in
+    `_async_restore_state` and is reached from `async_added_to_hass`,
+    so a reader who learns one platform has learned all of them -- and
+    the cross-cutting tests above can find every block by name.
+
+    Remote is the deliberate exception and is asserted as such in
+    test_restore_state_reboot.py: it restores nothing, by ruling.
+    """
+    for cls in (
+        HAIRSwitchEntity, HAIRLightEntity, HAIRFanEntity,
+        HAIRMediaPlayerEntity, HAIRCoverEntity, HAIRClimateEntity,
+    ):
+        assert hasattr(cls, "_async_restore_state"), cls.__name__
+        assert hasattr(cls, "async_added_to_hass"), cls.__name__
+
+
+@pytest.mark.asyncio
+async def test_media_player_restore_never_lands_on_a_transient_state():
+    """The one clamp this ticket deliberately did NOT widen. Every
+    stored playback state has to come back as plain ON or OFF, because
+    one-way IR cannot know whether a TV is still playing after a
+    reboot."""
+    for stored in ("playing", "paused", "idle", "buffering", "on", "off"):
+        entity, mgr = _build(
+            HAIRMediaPlayerEntity, _device(DeviceType.MEDIA_PLAYER),
+            State("media_player.x", stored, {ATTR_MEDIA_VOLUME_LEVEL: 0.4}),
+        )
+        await entity._async_restore_state()
+        assert entity.state in (MediaPlayerState.ON, MediaPlayerState.OFF)
+        assert _sends(mgr) == 0

--- a/custom_components/hair/tests/test_restore_state_reboot.py
+++ b/custom_components/hair/tests/test_restore_state_reboot.py
@@ -33,7 +33,11 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.components.fan import ATTR_OSCILLATING, ATTR_PERCENTAGE
-from homeassistant.components.media_player import MediaPlayerState
+from homeassistant.components.media_player import (
+    ATTR_MEDIA_VOLUME_LEVEL,
+    ATTR_MEDIA_VOLUME_MUTED,
+    MediaPlayerState,
+)
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import State
 
@@ -624,3 +628,75 @@ async def test_fan_off_still_carries_its_speed_back():
     assert entity.is_on is False
     assert entity.percentage == 40
     assert entity.oscillating is True
+
+
+# ---------------------------------------------------------------------------
+# media_player: volume and mute (restore completeness, 2026-08-23).
+# Dropped by the same 0.9.8 rule as fan's percentage, with no comment here
+# naming it. Playback state stays clamped, which is a different argument.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("volume,muted", [(0.55, True), (0.2, False)])
+async def test_media_restores_volume_and_mute(volume, muted):
+    last = State(
+        "media_player.x", "on",
+        {ATTR_MEDIA_VOLUME_LEVEL: volume, ATTR_MEDIA_VOLUME_MUTED: muted},
+    )
+    entity, mgr = await _restored_entity(
+        HAIRMediaPlayerEntity, _device(DeviceType.MEDIA_PLAYER), last
+    )
+    assert entity.state == MediaPlayerState.ON
+    assert entity.volume_level == pytest.approx(volume)
+    assert entity.is_volume_muted is muted
+    mgr.async_send_command.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_media_playing_still_clamps_to_on_while_volume_restores():
+    """The two rules coexist. Playback is not knowable after a reboot
+    and stays clamped; the volume the user last set is knowable and
+    comes back. A stored PLAYING must still land on ON."""
+    last = State(
+        "media_player.x", "playing",
+        {ATTR_MEDIA_VOLUME_LEVEL: 0.7, ATTR_MEDIA_VOLUME_MUTED: True},
+    )
+    entity, _ = await _restored_entity(
+        HAIRMediaPlayerEntity, _device(DeviceType.MEDIA_PLAYER), last
+    )
+    assert entity.state == MediaPlayerState.OFF
+    assert entity.volume_level == pytest.approx(0.7)
+    assert entity.is_volume_muted is True
+
+
+@pytest.mark.asyncio
+async def test_media_legacy_stored_state_behaves_exactly_as_today():
+    last = State("media_player.x", "on", {})
+    entity, _ = await _restored_entity(
+        HAIRMediaPlayerEntity, _device(DeviceType.MEDIA_PLAYER), last
+    )
+    assert entity.state == MediaPlayerState.ON
+    assert entity.volume_level == pytest.approx(0.5)
+    assert entity.is_volume_muted is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad", ["loud", [], {}])
+async def test_media_malformed_volume_falls_back(bad):
+    last = State("media_player.x", "on", {ATTR_MEDIA_VOLUME_LEVEL: bad})
+    entity, _ = await _restored_entity(
+        HAIRMediaPlayerEntity, _device(DeviceType.MEDIA_PLAYER), last
+    )
+    assert entity.volume_level == pytest.approx(0.5)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stored,expected", [(-1.0, 0.0), (4.2, 1.0)])
+async def test_media_out_of_range_volume_clamps(stored, expected):
+    """volume_level is a 0..1 contract with HA."""
+    last = State("media_player.x", "on", {ATTR_MEDIA_VOLUME_LEVEL: stored})
+    entity, _ = await _restored_entity(
+        HAIRMediaPlayerEntity, _device(DeviceType.MEDIA_PLAYER), last
+    )
+    assert entity.volume_level == pytest.approx(expected)

--- a/custom_components/hair/tests/test_restore_state_reboot.py
+++ b/custom_components/hair/tests/test_restore_state_reboot.py
@@ -41,6 +41,7 @@ from homeassistant.components.media_player import (
 )
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import State
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from custom_components.hair.climate import HAIRClimateEntity, _ClimateExtraStoredData
 from custom_components.hair.const import CommandSource, DeviceType
@@ -49,6 +50,7 @@ from custom_components.hair.fan import HAIRFanEntity
 from custom_components.hair.light import HAIRLightEntity
 from custom_components.hair.media_player import HAIRMediaPlayerEntity
 from custom_components.hair.models import EntityConfig, IRCommand, IRDevice
+from custom_components.hair.remote import HAIRRemoteEntity
 from custom_components.hair.switch import HAIRSwitchEntity
 from custom_components.hair.wig_format import ClimateCell, ClimateMatrix
 
@@ -899,3 +901,41 @@ async def test_preset_mode_climate_is_untouched_by_all_of_this():
     )
     assert entity.hvac_mode == HVACMode.COOL
     assert entity.preset_mode is None
+
+
+# ---------------------------------------------------------------------------
+# remote: always on, by ruling (restore completeness, 2026-08-23)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_remote_is_always_on_after_a_restart():
+    """Ruled 2026-08-23: a remote's is_on is a claim about the SENDER,
+    not the appliance. It comes back on because it IS on -- HAIR can
+    always send through it.
+
+    Pinned so a future RestoreEntity sweep has to argue with the
+    decision rather than quietly reversing it: a fresh entity is on,
+    a stored OFF does not change that, and no restore hook exists to
+    make it change.
+    """
+    entity = HAIRRemoteEntity(_device(DeviceType.MEDIA_PLAYER), _manager())
+    assert entity.is_on is True
+    assert not hasattr(entity, "_async_restore_state")
+    assert not isinstance(entity, RestoreEntity)
+
+
+@pytest.mark.asyncio
+async def test_remote_off_then_simulated_restart_comes_back_on():
+    """The audit set it off before both restarts and got on back both
+    times. That is now the specified behaviour, so the test asserts it
+    on purpose rather than the audit reporting it as a gap."""
+    device = _device(DeviceType.MEDIA_PLAYER)
+    entity = HAIRRemoteEntity(device, _manager())
+    entity.async_write_ha_state = MagicMock()
+    entity.hass = MagicMock()
+    entity._is_on = False
+    assert entity.is_on is False
+    # A restart is a fresh construction from the same stored device.
+    reborn = HAIRRemoteEntity(device, _manager())
+    assert reborn.is_on is True

--- a/custom_components/hair/tests/test_restore_state_reboot.py
+++ b/custom_components/hair/tests/test_restore_state_reboot.py
@@ -32,6 +32,7 @@ from homeassistant.components.climate import (
     ATTR_TEMPERATURE,
     HVACMode,
 )
+from homeassistant.components.fan import ATTR_OSCILLATING, ATTR_PERCENTAGE
 from homeassistant.components.media_player import MediaPlayerState
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import State
@@ -554,3 +555,72 @@ async def test_cover_has_no_power_verdict_subscription():
     entity.async_get_last_state = AsyncMock(return_value=None)
     await entity.async_added_to_hass()
     assert not hasattr(entity, "_power_verdict_unsub")
+
+
+# ---------------------------------------------------------------------------
+# fan: percentage and oscillating (restore completeness, 2026-08-23).
+# GH #115's actual report. The 0.9.8 scope was a real decision; it is stale.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("percentage,oscillating", [(60, True), (80, False)])
+async def test_fan_restores_percentage_and_oscillating(percentage, oscillating):
+    """Two distinct values, the way the audit ran it: a result that
+    only holds for one particular value is an artefact, not a fix."""
+    last = State(
+        "fan.x", "on",
+        {ATTR_PERCENTAGE: percentage, ATTR_OSCILLATING: oscillating},
+    )
+    entity, mgr = await _restored_entity(HAIRFanEntity, _device(DeviceType.FAN), last)
+    assert entity.is_on is True
+    assert entity.percentage == percentage
+    assert entity.oscillating is oscillating
+    mgr.async_send_command.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fan_legacy_stored_state_behaves_exactly_as_today():
+    """A state written before this fix carries neither attribute. It
+    must restore is_on and leave the other two at __init__'s defaults,
+    which is precisely what today's code does -- no crash, no guess."""
+    last = State("fan.x", "on", {})
+    entity, _ = await _restored_entity(HAIRFanEntity, _device(DeviceType.FAN), last)
+    assert entity.is_on is True
+    assert entity.percentage is None
+    assert entity.oscillating is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad", ["not-a-number", None, [], {}])
+async def test_fan_malformed_percentage_falls_back(bad):
+    """A restore block that raises on a stale snapshot takes the whole
+    entity down with it. Anything unconvertible is treated as absent."""
+    last = State("fan.x", "on", {ATTR_PERCENTAGE: bad})
+    entity, _ = await _restored_entity(HAIRFanEntity, _device(DeviceType.FAN), last)
+    assert entity.percentage is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stored,expected", [(-20, 0), (250, 100)])
+async def test_fan_out_of_range_percentage_clamps(stored, expected):
+    """Percentage is a 0..100 contract with HA. A corrupted snapshot
+    self-heals to a legal value rather than resurrecting forever, the
+    same reasoning 098-final-review applied to the climate setpoint."""
+    last = State("fan.x", "on", {ATTR_PERCENTAGE: stored})
+    entity, _ = await _restored_entity(HAIRFanEntity, _device(DeviceType.FAN), last)
+    assert entity.percentage == expected
+
+
+@pytest.mark.asyncio
+async def test_fan_off_still_carries_its_speed_back():
+    """The power-verdict handler says an "on" verdict restores speed
+    and oscillation for free, because neither is cleared on off. That
+    is only true if a stored OFF state keeps them, so it does."""
+    last = State(
+        "fan.x", "off", {ATTR_PERCENTAGE: 40, ATTR_OSCILLATING: True}
+    )
+    entity, _ = await _restored_entity(HAIRFanEntity, _device(DeviceType.FAN), last)
+    assert entity.is_on is False
+    assert entity.percentage == 40
+    assert entity.oscillating is True

--- a/custom_components/hair/tests/test_restore_state_reboot.py
+++ b/custom_components/hair/tests/test_restore_state_reboot.py
@@ -28,6 +28,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from homeassistant.components.climate import (
     ATTR_FAN_MODE,
+    ATTR_PRESET_MODE,
     ATTR_SWING_MODE,
     ATTR_TEMPERATURE,
     HVACMode,
@@ -42,12 +43,12 @@ from homeassistant.const import UnitOfTemperature
 from homeassistant.core import State
 
 from custom_components.hair.climate import HAIRClimateEntity, _ClimateExtraStoredData
-from custom_components.hair.const import DeviceType
+from custom_components.hair.const import CommandSource, DeviceType
 from custom_components.hair.cover import HAIRCoverEntity
 from custom_components.hair.fan import HAIRFanEntity
 from custom_components.hair.light import HAIRLightEntity
 from custom_components.hair.media_player import HAIRMediaPlayerEntity
-from custom_components.hair.models import EntityConfig, IRDevice
+from custom_components.hair.models import EntityConfig, IRCommand, IRDevice
 from custom_components.hair.switch import HAIRSwitchEntity
 from custom_components.hair.wig_format import ClimateCell, ClimateMatrix
 
@@ -700,3 +701,201 @@ async def test_media_out_of_range_volume_clamps(stored, expected):
         HAIRMediaPlayerEntity, _device(DeviceType.MEDIA_PLAYER), last
     )
     assert entity.volume_level == pytest.approx(expected)
+
+
+# ---------------------------------------------------------------------------
+# climate: matrix_cell and the ruled preset match check (restore
+# completeness, 2026-08-23). The preset reversal is the one item in this
+# ticket that overturns a documented decision rather than closing a gap.
+# ---------------------------------------------------------------------------
+
+PRESET_NAME = "cool / fan: auto / swing: swing / 22"
+
+
+def _starred_matrix_device(
+    sent_state: dict | None = None,
+    starred: tuple[str, ...] = (PRESET_NAME,),
+    command_name: str = PRESET_NAME,
+) -> IRDevice:
+    """A matrix AC carrying one starred STATE row.
+
+    The default row's coordinates are exactly _matrix()'s only cell, so
+    a restored cool/auto/22/swing lands on the same cell the star does
+    -- the match the ruling requires.
+    """
+    command = IRCommand(
+        id="cmd-preset",
+        name=command_name,
+        source=CommandSource.MATRIX,
+        protocol="PRONTO",
+        code="P-C-A-22-S",
+        sent_state=(
+            {"mode": "cool", "fan": "auto", "swing": "swing", "temp": 22.0}
+            if sent_state is None else (sent_state or None)
+        ),
+    )
+    return _device(
+        DeviceType.AC,
+        climate_matrix=True,
+        commands=[command],
+        entity_config=EntityConfig(starred=list(starred)),
+    )
+
+
+async def _restored_starred_entity(last_state, device=None, matrix=None):
+    mgr = _manager()
+    entity = HAIRClimateEntity(device or _starred_matrix_device(), mgr)
+    entity.async_write_ha_state = MagicMock()
+    entity.hass = MagicMock()
+    entity.hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
+    entity._matrix = matrix if matrix is not None else _matrix()
+    entity.async_get_last_state = AsyncMock(return_value=last_state)
+    entity.async_get_last_extra_data = AsyncMock(return_value=None)
+    await entity._async_restore_state()
+    return entity, mgr
+
+
+def _stored(preset: str | None = PRESET_NAME, **overrides) -> State:
+    attrs = {
+        ATTR_TEMPERATURE: 22.0,
+        ATTR_FAN_MODE: "auto",
+        ATTR_SWING_MODE: "swing",
+    }
+    if preset is not None:
+        attrs[ATTR_PRESET_MODE] = preset
+    attrs.update(overrides)
+    return State("climate.x", HVACMode.COOL, attrs)
+
+
+@pytest.mark.asyncio
+async def test_matrix_cell_is_rederived_after_restore():
+    """The device page's current-cell readout went blank after every
+    restart. It was never scoped out -- the readout postdates the 0.9.8
+    restore list and nobody added it when the feature landed."""
+    entity, mgr = await _restored_starred_entity(_stored())
+    assert entity.extra_state_attributes["matrix_cell"] == PRESET_NAME
+    mgr.async_send_command.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_matrix_cell_matches_what_the_live_setter_produces():
+    """Re-derived rather than read back, so the two doors cannot drift.
+    Whatever the live send path would name this cell, restore names it
+    the same way -- including the display-unit conversion."""
+    entity, _ = await _restored_starred_entity(_stored())
+    live = entity._cell_display_name(entity._matrix.cells[0])
+    assert entity.extra_state_attributes["matrix_cell"] == live
+
+
+@pytest.mark.asyncio
+async def test_restored_off_names_the_off_cell():
+    """The live async_turn_off writes exactly this, so the readout
+    agrees with itself whichever way the entity got here."""
+    entity, _ = await _restored_starred_entity(
+        State("climate.x", HVACMode.OFF, {})
+    )
+    assert entity.extra_state_attributes["matrix_cell"] == "Off"
+    assert entity.preset_mode is None
+
+
+@pytest.mark.asyncio
+async def test_preset_survives_when_the_triple_resolves_to_its_cell():
+    """The ruling, in its intended case. The restored mode/fan/temp
+    resolve to the same cell the starred command does, so naming it
+    claims nothing the restored state does not already claim."""
+    entity, mgr = await _restored_starred_entity(_stored())
+    assert entity.preset_mode == PRESET_NAME
+    assert entity.hvac_mode == HVACMode.COOL
+    mgr.async_send_command.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_preset_stays_none_when_the_command_was_deleted():
+    device = _device(
+        DeviceType.AC, climate_matrix=True, commands=[],
+        entity_config=EntityConfig(starred=[PRESET_NAME]),
+    )
+    entity, _ = await _restored_starred_entity(_stored(), device=device)
+    assert entity.preset_mode is None
+    assert entity.hvac_mode == HVACMode.COOL  # everything else still restores
+
+
+@pytest.mark.asyncio
+async def test_preset_stays_none_when_the_command_is_no_longer_starred():
+    entity, _ = await _restored_starred_entity(
+        _stored(), device=_starred_matrix_device(starred=())
+    )
+    assert entity.preset_mode is None
+
+
+@pytest.mark.asyncio
+async def test_preset_stays_none_when_the_stored_triple_resolves_elsewhere():
+    """The honesty case the original refusal was protecting. The stored
+    preset names one cell; the restored attributes land on another; the
+    attribute must not claim the first."""
+    matrix = _matrix()
+    matrix.cells.append(
+        ClimateCell(mode="heat", fan="low", temp=28.0, swing="fixed",
+                    pronto="P-H-L-28-F")
+    )
+    stored = State("climate.x", HVACMode.HEAT, {
+        ATTR_TEMPERATURE: 28.0,
+        ATTR_FAN_MODE: "low",
+        ATTR_SWING_MODE: "fixed",
+        ATTR_PRESET_MODE: PRESET_NAME,
+    })
+    entity, _ = await _restored_starred_entity(stored, matrix=matrix)
+    assert entity.hvac_mode == HVACMode.HEAT
+    assert entity.preset_mode is None
+
+
+@pytest.mark.asyncio
+async def test_preset_stays_none_when_the_lattice_changed_under_it():
+    """The starred row still exists and is still starred, but its
+    coordinates no longer resolve in the current matrix -- a re-fit or
+    a re-adopt moved the lattice."""
+    entity, _ = await _restored_starred_entity(
+        _stored(),
+        device=_starred_matrix_device(
+            sent_state={"mode": "dry", "fan": "turbo", "swing": "none",
+                        "temp": 99.0}
+        ),
+    )
+    assert entity.preset_mode is None
+
+
+@pytest.mark.asyncio
+async def test_preset_stays_none_for_a_row_with_no_coordinates():
+    """A STATE row minted before 0.10.1 item 7 and never matched by the
+    setup backfill carries no coordinates. The live setter refuses to
+    parse display grammar to recover them and so does restore: there is
+    no re-validating a preset whose cell cannot be named."""
+    entity, _ = await _restored_starred_entity(
+        _stored(), device=_starred_matrix_device(sent_state={})
+    )
+    assert entity.preset_mode is None
+    assert entity.extra_state_attributes["matrix_cell"] == PRESET_NAME
+
+
+@pytest.mark.asyncio
+async def test_legacy_stored_state_with_no_preset_attribute():
+    """A state written before this fix carries no preset_mode key at
+    all. Nothing to restore, nothing to raise about."""
+    entity, _ = await _restored_starred_entity(_stored(preset=None))
+    assert entity.preset_mode is None
+    assert entity.hvac_mode == HVACMode.COOL
+
+
+@pytest.mark.asyncio
+async def test_preset_mode_climate_is_untouched_by_all_of_this():
+    """Non-matrix climate has no cells to match against, so it keeps
+    the original refusal by construction: the whole block is inside the
+    matrix branch."""
+    last = State("climate.x", HVACMode.COOL, {
+        ATTR_TEMPERATURE: 22.0, ATTR_PRESET_MODE: "whatever",
+    })
+    entity, _ = await _restored_entity(
+        HAIRClimateEntity, _preset_climate_device(), last
+    )
+    assert entity.hvac_mode == HVACMode.COOL
+    assert entity.preset_mode is None

--- a/custom_components/hair/tests/test_restore_state_reboot.py
+++ b/custom_components/hair/tests/test_restore_state_reboot.py
@@ -38,6 +38,7 @@ from homeassistant.core import State
 
 from custom_components.hair.climate import HAIRClimateEntity, _ClimateExtraStoredData
 from custom_components.hair.const import DeviceType
+from custom_components.hair.cover import HAIRCoverEntity
 from custom_components.hair.fan import HAIRFanEntity
 from custom_components.hair.light import HAIRLightEntity
 from custom_components.hair.media_player import HAIRMediaPlayerEntity
@@ -481,3 +482,75 @@ async def test_added_to_hass_restores_before_dispatcher_connects(monkeypatch):
 
     assert calls == ["restore", "dispatcher_connect"]
     assert entity.is_on is True
+
+
+# ---------------------------------------------------------------------------
+# cover: the platform the 0.9.8 scoping rule missed (restore completeness,
+# 2026-08-23). Not "on/off" and not climate, so the rule's sentence read as
+# though it covered the field while nothing actually did.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cover_no_last_state_stays_unknown():
+    """No stored state is the ONLY case that may still read unknown.
+
+    A fresh install has no evidence about the screen and should say so.
+    The bug was that a restart also produced this, which is a different
+    thing wearing the same face.
+    """
+    entity, mgr = await _restored_entity(
+        HAIRCoverEntity, _device(DeviceType.SCREEN), None
+    )
+    assert entity.is_closed is None
+    mgr.async_send_command.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cover_restores_closed():
+    last = State("cover.x", "closed", {})
+    entity, mgr = await _restored_entity(
+        HAIRCoverEntity, _device(DeviceType.SCREEN), last
+    )
+    assert entity.is_closed is True
+    mgr.async_send_command.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cover_restores_open():
+    """Both directions, because the audit set closed before restart A
+    and OPEN before restart B and got `unknown` back from both -- which
+    is what proved the attribute was being dropped rather than one
+    particular value being mishandled."""
+    last = State("cover.x", "open", {})
+    entity, _ = await _restored_entity(
+        HAIRCoverEntity, _device(DeviceType.SCREEN), last
+    )
+    assert entity.is_closed is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("state", ["unknown", "unavailable", "opening", "garbage"])
+async def test_cover_unusable_state_stays_unknown(state):
+    """Anything that is not one of this platform's two real states is
+    no evidence, and no evidence stays None rather than guessing a
+    direction."""
+    entity, _ = await _restored_entity(
+        HAIRCoverEntity, _device(DeviceType.SCREEN), State("cover.x", state, {})
+    )
+    assert entity.is_closed is None
+
+
+@pytest.mark.asyncio
+async def test_cover_has_no_power_verdict_subscription():
+    """Ruled 2026-08-23: cover deliberately does not subscribe, so the
+    asymmetry against the other five platforms is a decision rather
+    than the same oversight repeating. Pinned so a later sweep adding
+    it has to change this test and read the ruling.
+    """
+    entity = HAIRCoverEntity(_device(DeviceType.SCREEN), _manager())
+    entity.async_write_ha_state = MagicMock()
+    entity.hass = MagicMock()
+    entity.async_get_last_state = AsyncMock(return_value=None)
+    await entity.async_added_to_hass()
+    assert not hasattr(entity, "_power_verdict_unsub")


### PR DESCRIPTION
Closes the state-restore audit (GH 115). Cover gains RestoreEntity and remembers whether the screen is closed; fan restores speed and oscillation; media player restores volume and mute; climate restores its matrix cell readout and restores the preset only when the restored mode, fan and temperature still resolve to that presets own cell; remote is deliberately always on with the reasoning recorded. Restoration transmits nothing, pinned by test across every platform, and legacy stored states behave exactly as before. Benched with Home Assistant native restarts, two per platform, every audited gap now restoring.