### PR TITLE
Pronto identity: end the hash walks at the last real pulse

### DIFF
--- a/custom_components/hair/event_parser.py
+++ b/custom_components/hair/event_parser.py
@@ -369,7 +369,15 @@ class EventParser:
             return None
         try:
             words = [int(w, 16) for w in code.strip().split()]
-        except (ValueError, TypeError):
+        except (AttributeError, TypeError, ValueError):
+            # AttributeError: a .storage row whose ``code`` is not a
+            # string at all reaches ``code.strip()``. This function is
+            # the bottom of the identity layer and every walk above it
+            # is documented as answering None for a code it cannot
+            # read, so it answers None here rather than raising up
+            # through six callers -- one of which is the legacy
+            # byte-hash backfill inside the executor job that loads the
+            # whole Sniffer catalog.
             return None
         # Pronto header is 4 words: type, freq, burst1_count, burst2_count.
         if len(words) < 5:

--- a/custom_components/hair/event_parser.py
+++ b/custom_components/hair/event_parser.py
@@ -357,8 +357,13 @@ class EventParser:
 
         Returns ``None`` if the string is malformed or too short
         (needs at least 4 header words + 1 timing word). Accepts ``None``
-        so the ``str | None`` callers (``_pronto_sl_pattern``,
-        ``pronto_byte_hash``) pass through without a separate guard.
+        so the ``str | None`` callers (``_pronto_identity_timings``,
+        ``device_fingerprint``) pass through without a separate guard.
+
+        The WHOLE word list, header included, and no strip:
+        ``device_fingerprint`` reads ``words[1]`` and ``words[4:]`` from
+        here directly and needs to see all of it. The identity strip
+        lives in ``_pronto_identity_timings`` instead.
         """
         if not code:
             return None
@@ -372,39 +377,74 @@ class EventParser:
         return words
 
     @staticmethod
-    def _pronto_sl_pattern(code: str | None) -> str | None:
-        """Convert a Pronto hex code to an S/L pulse-duration pattern.
+    def _pronto_identity_timings(code: str | None) -> list[int] | None:
+        """The timing words identity hashes: everything up to the last pulse.
 
-        Parses the timing words (after the 4-word header) and classifies
-        each as S(hort), L(ong), or ignores gaps (end-of-signal markers).
+        THE TAIL RULE, expressed over Pronto words. ``identity.canonical_edges``
+        is the definition of that rule (identity.py); the two pops below are
+        that function's strip written against a word list instead of signed
+        microseconds, so the two layers cannot drift apart again.
 
-        This mirrors how real IR receiver ICs decode signals: they apply
-        a threshold to distinguish short from long pulses, ignoring exact
-        microsecond timing.  The resulting pattern string (e.g. "SSLLSSSS")
-        is deterministic for a given button regardless of timing jitter.
+        WHY A STRIP AT ALL (GH #125). One waveform reaches HAIR wearing three
+        different tails. A file writes the inter-frame gap it was authored
+        with; a receiver writes its own measure of the trailing silence;
+        ``raw_to_pronto`` pads the missing final space with a zero. Hashing
+        the rendered text gave the same button up to three identities, and
+        the load-time migration kept moving stored rows onto a form the air
+        could never reproduce. Identity must not depend on which tail the
+        path produced, so the walk ends at the last real pulse and no tail
+        is hashed at all.
 
-        Returns ``None`` if the code is malformed.
+        Returns ``None`` for a code that cannot be read, and for one with
+        nothing left after the strip -- an all-zero code carries no identity
+        (GH #108), which is the answer ``identity.canonical_byte_hash``
+        already gives for it.
         """
         words = EventParser._parse_pronto_words(code)
         if words is None:
             return None
 
-        # Skip 4-word header; classify timing words.
-        timings = words[4:]
-        pattern = []
-        for t in timings:
+        # Skip the 4-word header; stop at the first end-of-signal gap.
+        timings: list[int] = []
+        for t in words[4:]:
             if t >= PRONTO_GAP_THRESHOLD:
-                # End-of-signal gap -- stop here.
                 break
-            if t < PRONTO_SL_THRESHOLD:
-                pattern.append("S")
-            else:
-                pattern.append("L")
+            timings.append(t)
 
-        if not pattern:
+        # Drop a padded tail, then leave the list ending on a MARK. Position,
+        # not sign, is what says mark or space in a Pronto word list, so an
+        # even length means it ends on a space.
+        while timings and timings[-1] == 0:
+            timings.pop()
+        if timings and len(timings) % 2 == 0:
+            timings.pop()
+
+        return timings or None
+
+    @staticmethod
+    def _pronto_sl_pattern(code: str | None) -> str | None:
+        """Convert a Pronto hex code to an S/L pulse-duration pattern.
+
+        Classifies each identity timing word (``_pronto_identity_timings``,
+        which skips the header, stops at the end-of-signal gap and strips
+        the tail) as S(hort) or L(ong).
+
+        This mirrors how real IR receiver ICs decode signals: they apply
+        a threshold to distinguish short from long pulses, ignoring exact
+        microsecond timing.  The resulting pattern string (e.g. "SSLLSSSS")
+        is deterministic for a given button regardless of timing jitter,
+        and since GH #125 regardless of which tail the code was written
+        with.
+
+        Returns ``None`` if the code is malformed or carries no pulse.
+        """
+        timings = EventParser._pronto_identity_timings(code)
+        if timings is None:
             return None
 
-        return "".join(pattern)
+        return "".join(
+            "S" if t < PRONTO_SL_THRESHOLD else "L" for t in timings
+        )
 
     @staticmethod
     def pronto_byte_hash(code: str | None) -> str | None:
@@ -418,7 +458,7 @@ class EventParser:
         classifies short and all buttons on the remote share one S/L
         pattern). This hash preserves the distinction without
         over-fragmenting jittered captures of the same physical button:
-        each pre-gap timing word is rounded to the nearest
+        each identity timing word is rounded to the nearest
         ``PRONTO_BYTE_HASH_BIN`` carrier cycles, and the comma-joined
         sequence is SHA-256 hashed (first 16 hex).
 
@@ -426,27 +466,17 @@ class EventParser:
         triggers, the known-command matcher, and repeat suppression all key
         on ``(signal_fingerprint, byte_hash)``.
 
-        Uses the same parse and gap-break point as ``_pronto_sl_pattern``
-        so the two layers of the composite key stay consistent. Returns
-        ``None`` if the code is malformed.
+        Reads ``_pronto_identity_timings``, the same source as
+        ``_pronto_sl_pattern``, so the two layers of the composite key see
+        exactly the same pulses. Returns ``None`` if the code is malformed
+        or carries no pulse.
         """
-        words = EventParser._parse_pronto_words(code)
-        if words is None:
+        timings = EventParser._pronto_identity_timings(code)
+        if timings is None:
             return None
 
         n = PRONTO_BYTE_HASH_BIN
-        # Skip the 4-word header; quantize timing words, break at the
-        # first end-of-signal gap (same truncation as the S/L pattern).
-        quantized: list[str] = []
-        for t in words[4:]:
-            if t >= PRONTO_GAP_THRESHOLD:
-                break
-            quantized.append(str(round(t / n) * n))
-
-        if not quantized:
-            return None
-
-        payload = ",".join(quantized)
+        payload = ",".join(str(round(t / n) * n) for t in timings)
         return hashlib.sha256(payload.encode()).hexdigest()[:16]
 
     # -----------------------------------------------------------------

--- a/custom_components/hair/identity.py
+++ b/custom_components/hair/identity.py
@@ -285,6 +285,17 @@ def canonical_fingerprint(
         # class). Hash it AS PRONTO rather than falling through, or an
         # unstamped one lands on the empty-raw constant after all.
         return EventParser.signal_fingerprint("PRONTO", code, raw_timings)
+
+    # THE SAME COLLAPSE, ONE STEP FURTHER OUT. A row with no protocol
+    # stamp, a code that is not Pronto at all, and no raw timings to
+    # fall back on has nothing to hash: signal_fingerprint would hand
+    # back the fingerprint of an EMPTY timing list, one constant shared
+    # by every such row, and the load-time migration would write it in.
+    # No identity is the honest answer and every caller already skips
+    # the empty string (GH #108 set that convention). A row that HAS
+    # timings still gets their fingerprint, which is real.
+    if not protocol and code and not raw_timings:
+        return ""
     return EventParser.signal_fingerprint(protocol, code, raw_timings)
 
 

--- a/custom_components/hair/identity.py
+++ b/custom_components/hair/identity.py
@@ -257,7 +257,21 @@ def canonical_fingerprint(
     """
     from .event_parser import EventParser
 
-    if protocol and protocol.upper() == "PRONTO":
+    # A CODE THAT PARSES AS PRONTO WORDS IS PRONTO, stamp or no stamp
+    # (GH #125). ``protocol`` defaults to None on UnknownSignal,
+    # IRCommand and IRTrigger, and both load-time migrations call this
+    # with raw_timings=None. Without this widening such a row fell to
+    # ``signal_fingerprint(None, code, None)``, which hashes an EMPTY
+    # raw timing list and hands back one constant for every caller --
+    # so every protocol-less Pronto row in a store was rewritten onto a
+    # single shared fingerprint at load, and they all matched each
+    # other. Pre-existing since the 2026-08-17 backfill rather than new
+    # here; in scope because that same migration is its vehicle.
+    is_pronto = bool(protocol and protocol.upper() == "PRONTO")
+    if not protocol and code:
+        is_pronto = EventParser._parse_pronto_words(code) is not None
+
+    if is_pronto:
         # No burst, no identity (GH #108). Hashing the text of an
         # all-zero code would mint a fingerprint that matches nothing on
         # the air and collides with every other empty code; the empty
@@ -267,6 +281,10 @@ def canonical_fingerprint(
         wire = canonical_pronto(code)
         if wire is not None:
             return EventParser.signal_fingerprint("PRONTO", wire, raw_timings)
+        # Hashable but not canonicalizable (the over-declared-header
+        # class). Hash it AS PRONTO rather than falling through, or an
+        # unstamped one lands on the empty-raw constant after all.
+        return EventParser.signal_fingerprint("PRONTO", code, raw_timings)
     return EventParser.signal_fingerprint(protocol, code, raw_timings)
 
 

--- a/custom_components/hair/ir_command.py
+++ b/custom_components/hair/ir_command.py
@@ -112,6 +112,13 @@ class ProntoCommand(Command):
         *,
         repeat_count: int = 0,
     ) -> None:
+        if not isinstance(pronto_hex, str):
+            # The signature says str and a .storage row can still hand
+            # us an int. Raising the family every caller already catches
+            # keeps a corrupt row costing itself rather than raising an
+            # AttributeError out of split() and through the identity
+            # layer into the catalog load.
+            raise ValueError("Pronto hex must be a string")
         words = [int(w, 16) for w in pronto_hex.split()]
         if len(words) < 4:
             raise ValueError("Pronto hex too short (need at least 4 words)")

--- a/custom_components/hair/matrix_listener.py
+++ b/custom_components/hair/matrix_listener.py
@@ -869,10 +869,20 @@ class MatrixListener:
 # module level, beside the builder they wrap, so the on-disk shape and
 # the in-memory one cannot drift apart in a refactor.
 
-# Bumped to /2 for the receiver-tolerant tier (2026-08-18). A stored /1
-# index is simply not read, so every lattice rebuilds once and gains the
-# new map; the rebuild is the same seconds-of-work the first build was.
-INDEX_FORMAT = "hair-cell-index/2"
+# Bumped to /2 for the receiver-tolerant tier (2026-08-18) and to /3 for
+# the unified strip (GH #125). A stored index of an older format is
+# simply not read, so every lattice rebuilds once and gains the new map;
+# the rebuild is the same seconds-of-work the first build was.
+#
+# WHY THE VERSION IS THE ONLY LEVER HERE. ``_load_stored_index`` checks
+# three things: this string, the matrix file's content hash, and the
+# display unit. A change to the identity ALGORITHM moves none of them --
+# the migration never touches the matrix file, so its content hash is
+# unchanged -- and the stored index would go on answering with
+# pre-migration hashes while captures arrived carrying post-migration
+# ones. Every climate lattice would silently stop recognizing its own
+# cells, with nothing in any log to say so.
+INDEX_FORMAT = "hair-cell-index/3"
 
 
 def _hit_to_row(hit: CellHit) -> list:

--- a/custom_components/hair/signal_monitor.py
+++ b/custom_components/hair/signal_monitor.py
@@ -3096,8 +3096,17 @@ class SignalMonitor:
                     skipped += 1
                     continue
                 code = result.normalized
-                sig_fp = EventParser.signal_fingerprint("PRONTO", code, [])
-                byte_hash = EventParser.pronto_byte_hash(code)
+                # THE LAST DOOR ON THE RAW WALK (GH #125). Every sibling
+                # mint door -- the Clipper paste, the Plucker place, the
+                # capture path, every websocket create -- goes through
+                # the canonical pair; this one still called the raw
+                # EventParser one. After the unified strip the two agree
+                # for every code, which is exactly why this is the
+                # moment to route it: the repair is provably a no-op
+                # today, and the door stops being the one place a second
+                # identity form could come back in later.
+                sig_fp = canonical_fingerprint("PRONTO", code, [])
+                byte_hash = canonical_byte_hash(code)
                 # Tiered in-batch duplicate guard: codebook entries carry a
                 # decoded identity, so two encodings of the same command
                 # dedupe here instead of surviving until the load-time heal.

--- a/custom_components/hair/signal_store.py
+++ b/custom_components/hair/signal_store.py
@@ -755,11 +755,39 @@ def _transform_loaded(
     # of v0.3.4 keys on the composite (fingerprint, byte_hash).
     from .event_parser import EventParser
 
-    legacy_signals = any(
-        not s.get("id") or s.get("byte_hash") is None
-        for d in (raw.get("devices") or [])
-        for s in (d.get("signals") or [])
-    )
+    # DIRTY MEANS "MEMORY DIFFERS FROM DISK", NEVER "WORK REMAINS"
+    # (GH #125). A row whose code cannot be read can never gain a
+    # byte_hash. It is FOUND on every load and CHANGED by none, so
+    # counting it as pending legacy work kept the store permanently
+    # dirty -- harmless while nothing acted on the flag, and a rewrite
+    # of the entire catalog on every boot once the load-time save
+    # landed. Measured on the bench: ONE Mirror row with a code of None
+    # did that to a 1.4 MB store, with byte-identical content each time.
+    #
+    # Classified here at load and never branded onto the row. A future
+    # version that CAN read such a code simply repairs it then, with no
+    # stale marker to unlearn first.
+    unrepairable: list[str] = []
+    legacy_signals = False
+    for _d in raw.get("devices") or []:
+        for _s in _d.get("signals") or []:
+            if not _s.get("id"):
+                legacy_signals = True  # an id is always mintable
+                continue
+            if _s.get("byte_hash") is not None:
+                continue
+            if EventParser.pronto_byte_hash(_s.get("code")) is not None:
+                legacy_signals = True  # a hash this load can fill in
+            else:
+                unrepairable.append(_s.get("id"))
+    if unrepairable:
+        _LOGGER.debug(
+            "%d catalog row(s) carry a code no hash can be computed "
+            "from. They are re-read on every load and changed by none, "
+            "so they do not mark the store dirty: %s",
+            len(unrepairable),
+            ", ".join(unrepairable[:20]),
+        )
     for device in devices.values():
         for sig in device.signals:
             if sig.byte_hash is None and sig.code:

--- a/custom_components/hair/signal_store.py
+++ b/custom_components/hair/signal_store.py
@@ -795,25 +795,53 @@ def _transform_loaded(
     # reads and copies (and what a wig's claim digest hashes once the
     # row is saved to the closet). Runs BEFORE the duplicate heal below,
     # which keys on exactly these values.
-    from .identity import (
-        canonical_byte_hash,
-        canonical_fingerprint,
-        canonical_pronto,
-    )
+    from .identity import canonical_byte_hash, canonical_fingerprint
 
     canon_moved = 0
     for device in devices.values():
         for sig in device.signals:
-            # Only rows whose code is readable Pronto have a wire form.
-            # Manual and legacy rows keep the identity they have.
-            if not sig.code or canonical_pronto(sig.code) is None:
+            # HASHABLE IS THE BAR, NOT CANONICALIZABLE (GH #125). Same
+            # widening as storage._backfill_canonical_identity: a code
+            # can hash without canonicalizing (the over-declared-header
+            # class), and those are exactly the rows whose hash the
+            # unified strip moves.
+            if not sig.code:
+                continue
+            # A .storage row can lie about its own type. Named here so
+            # the one bad row is visible in the log rather than just
+            # quietly identity-less, and skipped so the walks below are
+            # only ever handed a string.
+            if not isinstance(sig.code, str):
+                _LOGGER.warning(
+                    "Signal %s on remote %s stores a non-string code "
+                    "(%s); leaving its identity alone",
+                    sig.id,
+                    device.label or device.id,
+                    type(sig.code).__name__,
+                )
+                continue
+            # ONE BAD ROW COSTS ITSELF, NOT THE CATALOG (GH #108's
+            # lesson, applied here). This runs inside the single
+            # executor job that loads every remote the user has, and
+            # canonical_pronto on a non-string code raises
+            # AttributeError out of pronto_hex.split() rather than the
+            # ValueError family the helpers catch. Unguarded, one such
+            # row in .storage took the whole Sniffer catalog with it.
+            try:
+                fresh_hash = canonical_byte_hash(sig.code)
+                fresh_fp = canonical_fingerprint(sig.protocol, sig.code, None)
+            except Exception:
+                _LOGGER.warning(
+                    "Skipped signal %s on remote %s in the canonical "
+                    "identity backfill: its code could not be read",
+                    sig.id,
+                    device.label or device.id,
+                )
                 continue
             moved = False
-            fresh_hash = canonical_byte_hash(sig.code)
             if fresh_hash is not None and fresh_hash != sig.byte_hash:
                 sig.byte_hash = fresh_hash
                 moved = True
-            fresh_fp = canonical_fingerprint(sig.protocol, sig.code, None)
             if fresh_fp and fresh_fp != sig.fingerprint:
                 sig.fingerprint = fresh_fp
                 moved = True

--- a/custom_components/hair/signal_store.py
+++ b/custom_components/hair/signal_store.py
@@ -153,13 +153,34 @@ class SignalStore:
             for record in (raw.get("plucked_stores") or [])
             if isinstance(record, dict)
         ]
-        if dirty:
-            self._dirty = True
         # The sticky index is in-memory only, so it is built here from
         # what was just loaded. A restart therefore files a re-press onto
         # the same row it landed on before the restart.
         self.rebuild_signal_index()
         self._loaded = True
+        if dirty:
+            # PERSIST THE MIGRATION (GH #125), the way
+            # ``HAIRStore.async_load`` already does for the device side.
+            #
+            # This used to set the dirty FLAG and stop there, which arms
+            # nothing: ``schedule_save`` is what starts the debounce and
+            # the ceiling, and nothing called it. So the catalog's
+            # load-time migration has never reached disk under its own
+            # power. It waited for the next unrelated write -- a
+            # capture, an alias, a delete, a reorder -- and until one
+            # came, every boot re-ran and re-reported the whole thing.
+            #
+            # That was invisible while the canonical block had almost
+            # nothing to move on a captured-row store. It stops being
+            # invisible here: on the bench store this release moves 495
+            # of 552 catalog rows.
+            #
+            # Last, deliberately. ``_serialize`` reads
+            # ``_plucked_stores``, which is populated above, so a save
+            # from any earlier point would write a half-built payload
+            # and drop the Plucker's records. A clean boot leaves
+            # ``dirty`` False and writes nothing at all.
+            await self.async_save()
 
     async def async_save(self) -> None:
         """Persist current state to disk immediately.

--- a/custom_components/hair/storage.py
+++ b/custom_components/hair/storage.py
@@ -593,20 +593,29 @@ class HAIRStore:
         no-op from the second boot on and folds into the one load-time
         save when it does change something.
         """
-        from .identity import (
-            canonical_byte_hash,
-            canonical_fingerprint,
-            canonical_pronto,
-        )
+        from .identity import canonical_byte_hash, canonical_fingerprint
 
         changed = commands = triggers = 0
         for device in self._data.values():
             for cmd in device.commands:
-                # Only rows whose code is readable Pronto have a wire
-                # form at all. A legacy protocol/code pair or a
-                # hand-written record keeps exactly the identity it has.
+                # HASHABLE IS THE BAR, NOT CANONICALIZABLE (GH #125).
+                # This used to skip any row whose code did not
+                # canonicalize, which sounds conservative and is not: a
+                # code can hash perfectly well without canonicalizing.
+                # An IRDB or Girr NEC entry whose burst-2 repeat
+                # sequence was truncated declares more pairs than its
+                # body carries, so ProntoCommand refuses it and
+                # canonical_pronto answers None, while pronto_byte_hash
+                # reads it happily. Those are exactly the rows whose
+                # hash the unified strip moves, so skipping them left
+                # the stored identity behind and the trigger silent.
+                #
+                # Dropping the precondition is safe because both helpers
+                # already degrade: canonical_byte_hash returns None for
+                # anything the word parser cannot read at all, and the
+                # "is not None" test below leaves such a row alone.
                 try:
-                    if not cmd.code or canonical_pronto(cmd.code) is None:
+                    if not cmd.code:
                         continue
                     fresh = canonical_byte_hash(cmd.code)
                 except Exception:
@@ -619,7 +628,11 @@ class HAIRStore:
                     commands += 1
                     changed += 1
         for trigger in self._triggers.values():
-            if not trigger.code or canonical_pronto(trigger.code) is None:
+            # Same widening as the command loop above, and the reason it
+            # matters more here: a skipped command is a button that does
+            # not light up, a skipped trigger is an automation that
+            # stops running.
+            if not trigger.code:
                 continue
             moved = False
             # REPOINT an existing hash; never ADD one. A trigger that

--- a/custom_components/hair/tests/fixtures/air-path/arris-power-clip.json
+++ b/custom_components/hair/tests/fixtures/air-path/arris-power-clip.json
@@ -2,8 +2,8 @@
  "note": "Arris Vip 2952 V2 (1) Power, the regression bench 1.2 failure of 2026-08-17. The file side is the trigger as the Clipper pasted it; the air side is what infrared.athom_rx actually handed back when the same Pronto was transmitted three times through an ESPHome blaster (19:03:58.257, 19:04:02.398, 19:04:08.554). Zero triggers fired: the byte hash moved, the bare-fingerprint tier is withheld from hash-bearing rows since v0.5.8, and the normalized tier that did match was never offered because the row was stamped origin=remote.",
  "file": {
   "pronto": "0000 004A 0012 0000 0012 0024 0024 0024 0012 0012 0024 0024 0024 0024 0012 0012 0012 0012 0012 0012 0012 0012 0012 0012 0012 0012 0012 0012 0012 0012 0012 0012 0024 0024 0024 0012 0012 0024 0012 0000",
-  "signal_fingerprint": "49b80b5e33c2cec8",
-  "byte_hash": "4457e79c2bdf1eca",
+  "signal_fingerprint": "34972b8f876e2593",
+  "byte_hash": "f1f2a27ac764219f",
   "decoded_fingerprint": null,
   "origin_as_shipped": "remote",
   "catalog_source": "manual"

--- a/custom_components/hair/tests/fixtures/grouping/arris-power-air.json
+++ b/custom_components/hair/tests/fixtures/grouping/arris-power-air.json
@@ -1,7 +1,7 @@
 {
  "id": "ea2fcfb3-0b0e-4635-af51-26b9ae5adcd6",
- "fingerprint": "4c4a0ad5ad41a5b2",
- "byte_hash": "bdd7fe8d947a2289",
+ "fingerprint": "34972b8f876e2593",
+ "byte_hash": "97b78dd1f60b2172",
  "protocol": "PRONTO",
  "code": "0000 006D 0012 0000 000D 0017 001A 0017 000C 000D 001A 0017 0018 0018 000C 000D 000D 000B 000C 000D 000E 000B 000D 000B 000C 000D 000D 000B 000C 000D 000D 000C 0018 001A 0018 000C 000D 0018 000C 017C",
  "raw_timings": [
@@ -43,7 +43,7 @@
   -10000
  ],
  "frequency": 38000,
- "sl_pattern": "SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSL",
+ "sl_pattern": "SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
  "alias": "",
  "first_seen": "2026-08-18T02:03:58.258554+00:00",
  "last_seen": "2026-08-18T02:04:08.555330+00:00",

--- a/custom_components/hair/tests/test_canonical_identity.py
+++ b/custom_components/hair/tests/test_canonical_identity.py
@@ -30,6 +30,10 @@ from custom_components.hair.identity import (
 )
 from custom_components.hair.ir_command import ProntoCommand, raw_to_pronto
 from custom_components.hair.models import IRCommand, IRDevice, IRTrigger
+from custom_components.hair.tests.test_identity_tail_strip import (
+    _legacy_byte_hash,
+    _legacy_fingerprint,
+)
 
 # A code whose trailing word is a real inter-frame gap: the shape every
 # AC frame and half the closet has.
@@ -50,13 +54,33 @@ def _off_the_air(code: str) -> tuple[str, str | None]:
 
 
 def test_the_trailing_gap_really_does_move_the_identity():
-    """The premise. If this ever stops being true the rest is moot."""
+    """The premise, and GH #125 inverted it on purpose.
+
+    Until v0.12.1 this asserted the opposite: that the trailing gap word
+    DID move the identity. That was true, and it was the whole reason
+    the canonical form existed -- hash the file text and a real press
+    could never match it. The unified strip took the tail out of both
+    hash walks, so the file's gap word, a receiver's own silence and
+    ``raw_to_pronto``'s padded zero now hash identically and the
+    divergence is gone at the source rather than worked around.
+
+    Kept rather than deleted, because it is still the first assertion
+    that fails if the strip is ever removed. The old behaviour is
+    asserted underneath, against the pre-strip walk, so the history is
+    not just a docstring claim.
+    """
     naive_fp = EventParser.signal_fingerprint("PRONTO", FILED, None)
     naive_hash = EventParser.pronto_byte_hash(FILED)
     heard_fp, heard_hash = _off_the_air(FILED)
 
-    assert naive_fp != heard_fp
-    assert naive_hash != heard_hash
+    assert naive_fp == heard_fp
+    assert naive_hash == heard_hash
+
+    # And it really did move before: the pre-strip walk still says so.
+    assert _legacy_byte_hash(FILED) != _legacy_byte_hash(canonical_pronto(FILED))
+    assert _legacy_fingerprint(FILED) != _legacy_fingerprint(
+        canonical_pronto(FILED)
+    )
 
 
 def test_canonical_identity_matches_what_comes_off_the_air():
@@ -130,24 +154,36 @@ def test_claim_digests_do_not_move():
 
 @pytest.mark.asyncio
 async def test_backfill_repoints_stored_commands_and_triggers(hass_store):
+    """A pre-0.12.1 store, moved onto the wire form on the first load.
+
+    Seeded with WIRED and its PRE-STRIP hash, which is what an install
+    upgrading into this release actually carries. Note the code: FILED
+    ends on a real inter-frame gap, and the gap break already excluded
+    that word, so a gap-tailed row is one of the twelve-in-853 whose
+    identity GH #125 does not move. It would seed nothing stale and the
+    test would pass vacuously. The zero tail is the class that moves,
+    and it is 838 of the 853.
+    """
     store = hass_store
-    heard_fp, heard_hash = _off_the_air(FILED)
+    heard_fp, heard_hash = _off_the_air(WIRED)
+    stale_hash = _legacy_byte_hash(WIRED)
+    stale_fp = _legacy_fingerprint(WIRED)
+    assert stale_hash != heard_hash
+    assert stale_fp != heard_fp
 
     device = IRDevice(id="dev-1", name="Adopted")
     device.commands = [
         IRCommand(
-            id="c1", name="Power", protocol="PRONTO", code=FILED,
-            byte_hash=EventParser.pronto_byte_hash(FILED),
+            id="c1", name="Power", protocol="PRONTO", code=WIRED,
+            byte_hash=stale_hash,
         )
     ]
     store._data = {"dev-1": device}
     store._triggers = {
         "t1": IRTrigger(
-            id="t1", name="Power", protocol="PRONTO", code=FILED,
-            signal_fingerprint=EventParser.signal_fingerprint(
-                "PRONTO", FILED, None
-            ),
-            byte_hash=EventParser.pronto_byte_hash(FILED),
+            id="t1", name="Power", protocol="PRONTO", code=WIRED,
+            signal_fingerprint=stale_fp,
+            byte_hash=stale_hash,
         )
     }
 
@@ -156,8 +192,8 @@ async def test_backfill_repoints_stored_commands_and_triggers(hass_store):
     assert store._triggers["t1"].byte_hash == heard_hash
     assert store._triggers["t1"].signal_fingerprint == heard_fp
     # The stored code text is untouched.
-    assert device.commands[0].code == FILED
-    assert store._triggers["t1"].code == FILED
+    assert device.commands[0].code == WIRED
+    assert store._triggers["t1"].code == WIRED
     # Idempotent: a second boot changes nothing.
     assert store._backfill_canonical_identity() is False
 
@@ -186,17 +222,22 @@ async def test_backfill_makes_the_matcher_recognize_a_real_press(hass_store):
 
 
 def test_catalog_rows_are_repointed_at_load():
-    """Clipper and Plucker rows, hashed from the code as pasted."""
+    """Clipper and Plucker rows, hashed from the code as pasted.
+
+    Zero-tailed and seeded pre-strip, for the reason given on the
+    command backfill above: the row has to be genuinely stale for the
+    migration to have work to do.
+    """
     from custom_components.hair.models import UnknownDevice, UnknownSignal
     from custom_components.hair.signal_store import _transform_loaded
 
-    heard_fp, heard_hash = _off_the_air(FILED)
+    heard_fp, heard_hash = _off_the_air(WIRED)
     device = UnknownDevice(label="Clipped")
     device.signals = [
         UnknownSignal(
-            id="s1", protocol="PRONTO", code=FILED,
-            fingerprint=EventParser.signal_fingerprint("PRONTO", FILED, None),
-            byte_hash=EventParser.pronto_byte_hash(FILED),
+            id="s1", protocol="PRONTO", code=WIRED,
+            fingerprint=_legacy_fingerprint(WIRED),
+            byte_hash=_legacy_byte_hash(WIRED),
         )
     ]
     raw = {"devices": [device.to_dict()], "dismissed": []}
@@ -206,10 +247,8 @@ def test_catalog_rows_are_repointed_at_load():
     signal = next(iter(devices.values())).signals[0]
     assert signal.fingerprint == heard_fp
     assert signal.byte_hash == heard_hash
-    assert signal.code == FILED
+    assert signal.code == WIRED
     assert dirty is True
-
-
 @pytest.fixture
 def hass_store():
     from custom_components.hair.storage import HAIRStore

--- a/custom_components/hair/tests/test_event_parser.py
+++ b/custom_components/hair/tests/test_event_parser.py
@@ -461,10 +461,15 @@ class TestProntoHelpers:
         assert sl == "LLL"
 
     def test_pronto_sl_pattern_threshold_boundary(self):
-        """Value exactly at threshold (0x30) is classified as L."""
-        code = "0000 006D 0002 0000 002F 0030"
+        """Value exactly at threshold (0x30) is classified as L.
+
+        The boundary word sits in a MARK slot. Since GH #125 the walk
+        ends on a mark, so a code whose LAST word is the one under test
+        would have it stripped before classification and prove nothing.
+        """
+        code = "0000 006D 0002 0000 0030 002F 0030 0010"
         sl = EventParser._pronto_sl_pattern(code)
-        assert sl == "SL"
+        assert sl == "LSL"
 
     def test_pronto_sl_pattern_malformed(self):
         assert EventParser._pronto_sl_pattern("0000 006D") is None

--- a/custom_components/hair/tests/test_identity_tail_strip.py
+++ b/custom_components/hair/tests/test_identity_tail_strip.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import gzip
 import hashlib
 import json
+import logging
 import re
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
@@ -793,15 +794,81 @@ def test_an_unstamped_class_e_row_is_still_hashed_as_pronto():
     )
 
 
-def test_a_protocolless_row_that_is_not_pronto_is_untouched():
-    """The widening only catches what actually parses as Pronto words."""
-    for code in ("not a pronto code", "0000 006D", ""):
-        assert canonical_fingerprint(None, code, None) == (
-            EventParser.signal_fingerprint(None, code, None)
-        )
+def test_an_unreadable_code_with_no_timings_gets_no_fingerprint():
+    """The collapse, one step further out than the Pronto widening.
+
+    A row with no protocol stamp, a code that is not Pronto at all, and
+    no raw timings has nothing to hash. signal_fingerprint would hand
+    back the empty-raw constant and the migration would write it onto
+    every such row in the store, which is how three junk rows collapse
+    into one. The empty string is the honest answer and every caller
+    already skips it.
+    """
+    empty_raw = EventParser.signal_fingerprint(None, None, None)
+    for code in ("not a pronto code", "0000 006D", "AAAA"):
+        assert canonical_fingerprint(None, code, None) == ""
+        assert canonical_fingerprint(None, code, None) != empty_raw
+    # An empty code was never the problem: there is no row to collapse.
+    assert canonical_fingerprint(None, "", None) == (
+        EventParser.signal_fingerprint(None, "", None)
+    )
+
+
+def test_an_unreadable_code_with_timings_still_hashes_them():
+    """Only the nothing-to-hash case answers empty. Real timings are
+    real identity, whatever the code field says."""
+    raw = [500, -500, 1000, -1000]
+    assert canonical_fingerprint(None, "AAAA", raw) == (
+        EventParser.signal_fingerprint(None, "AAAA", raw)
+    )
+    assert canonical_fingerprint(None, "AAAA", raw) != ""
 
 
 def test_a_stamped_non_pronto_protocol_still_passes_through():
     assert canonical_fingerprint("NEC", "0x20DF10EF", None) == (
         EventParser.signal_fingerprint("NEC", "0x20DF10EF", None)
     )
+
+
+def test_a_non_string_code_costs_one_row_not_the_catalog(caplog):
+    """One unreadable row must not take the whole Sniffer catalog.
+
+    The canonical block runs inside the single executor job that loads
+    every remote the user has, and canonical_pronto on a non-string code
+    raises AttributeError out of pronto_hex.split(), which is not in the
+    ValueError family the identity helpers catch. GH #108's lesson,
+    applied to the row that GH #125's widening now lets through.
+    """
+    from custom_components.hair.models import UnknownDevice, UnknownSignal
+    from custom_components.hair.signal_store import _transform_loaded
+
+    device = UnknownDevice(label="Clipped")
+    device.signals = [
+        UnknownSignal(
+            id="ok", protocol="PRONTO", code=FILE_FORM,
+            fingerprint=_legacy_fingerprint(FILE_FORM),
+            byte_hash=_legacy_byte_hash(FILE_FORM),
+        )
+    ]
+    raw = {"devices": [device.to_dict()], "dismissed": []}
+    rows = raw["devices"][0]["signals"]
+    rows.append(
+        {**rows[0], "id": "bad", "code": 123, "fingerprint": "",
+         "byte_hash": None}
+    )
+
+    with caplog.at_level(logging.WARNING):
+        devices, _dismissed, _dirty = _transform_loaded(raw)
+
+    loaded = {s.id: s for s in next(iter(devices.values())).signals}
+    # The catalog came back, and the good row was repointed as normal.
+    assert "ok" in loaded
+    assert loaded["ok"].byte_hash == EventParser.pronto_byte_hash(FILE_FORM)
+    assert loaded["ok"].fingerprint == (
+        EventParser.signal_fingerprint("PRONTO", FILE_FORM, None)
+    )
+    # The bad row survives untouched, and says so once.
+    assert "bad" in loaded
+    assert any(
+        "bad" in record.getMessage() for record in caplog.records
+    ), [r.getMessage() for r in caplog.records]

--- a/custom_components/hair/tests/test_identity_tail_strip.py
+++ b/custom_components/hair/tests/test_identity_tail_strip.py
@@ -1036,7 +1036,16 @@ async def test_a_migrating_load_saves_once_and_a_clean_one_never_saves():
             id="s1", protocol="PRONTO", code=FILE_FORM,
             fingerprint=_legacy_fingerprint(FILE_FORM),
             byte_hash=_legacy_byte_hash(FILE_FORM),
-        )
+        ),
+        # A row no load can ever repair, beside the ones this load
+        # moves. Found on every boot, changed by none. It must not keep
+        # the store dirty, or the second boot rewrites the whole catalog
+        # to say nothing -- which is what one such row did to the bench
+        # store, at 1.4 MB a time.
+        UnknownSignal(
+            id="unrepairable", protocol="PRONTO", code=None,
+            fingerprint="", byte_hash=None,
+        ),
     ]
     stale = {
         "devices": [device.to_dict()],
@@ -1054,7 +1063,8 @@ async def test_a_migrating_load_saves_once_and_a_clean_one_never_saves():
         await store.async_load()
 
     assert mock_store.async_save.await_count == 1, "a stale catalog must persist"
-    row = written["devices"][0]["signals"][0]
+    rows = {s["id"]: s for s in written["devices"][0]["signals"]}
+    row = rows["s1"]
     assert row["byte_hash"] == EventParser.pronto_byte_hash(FILE_FORM)
     assert row["fingerprint"] == (
         EventParser.signal_fingerprint("PRONTO", FILE_FORM, None)
@@ -1075,3 +1085,10 @@ async def test_a_migrating_load_saves_once_and_a_clean_one_never_saves():
 
     assert mock_again.async_save.await_count == 0, "a clean boot writes nothing"
     assert again._dirty is False
+    # The unrepairable row is still there on the second boot. Its
+    # silence is the acceptance: present, re-read, and not a reason to
+    # write.
+    kept = {s.id: s for s in next(iter(again._devices.values())).signals}
+    assert "unrepairable" in kept
+    assert kept["unrepairable"].byte_hash is None
+    assert "s1" in kept

--- a/custom_components/hair/tests/test_identity_tail_strip.py
+++ b/custom_components/hair/tests/test_identity_tail_strip.py
@@ -754,3 +754,54 @@ def test_pin_bindings_rederive_across_the_move(store):
     store._rebuild_command_index()
 
     assert derive_bindings(store, remote) == {"dev-1": {"t1": "c1"}}
+
+
+def test_protocolless_pronto_rows_do_not_collapse():
+    """Two different unstamped codes must get two fingerprints.
+
+    ``protocol`` defaults to None on UnknownSignal, IRCommand and
+    IRTrigger, and both load-time migrations call canonical_fingerprint
+    with raw_timings=None. Before the widening, such a row fell through
+    to the fingerprint of an EMPTY raw timing list: one constant, shared
+    by every protocol-less row in the store, written in at load.
+    """
+    a = "0000 006D 0002 0000 0020 0040 0020 0000"
+    b = "0000 006D 0002 0000 0040 0020 0040 0000"
+    empty_raw = EventParser.signal_fingerprint(None, None, None)
+
+    fp_a = canonical_fingerprint(None, a, None)
+    fp_b = canonical_fingerprint(None, b, None)
+
+    assert fp_a != fp_b
+    assert fp_a != empty_raw
+    assert fp_b != empty_raw
+    # And an unstamped row now agrees with the stamped answer, which is
+    # the whole point: one code, one identity, whichever door minted it.
+    assert fp_a == canonical_fingerprint("PRONTO", a, None)
+    assert fp_b == canonical_fingerprint("PRONTO", b, None)
+
+
+def test_an_unstamped_class_e_row_is_still_hashed_as_pronto():
+    """Hashable but not canonicalizable, and unstamped: the case that
+    would otherwise slip past the widening and onto the constant."""
+    empty_raw = EventParser.signal_fingerprint(None, None, None)
+
+    assert canonical_pronto(CLASS_E) is None
+    assert canonical_fingerprint(None, CLASS_E, None) != empty_raw
+    assert canonical_fingerprint(None, CLASS_E, None) == (
+        EventParser.signal_fingerprint("PRONTO", CLASS_E, None)
+    )
+
+
+def test_a_protocolless_row_that_is_not_pronto_is_untouched():
+    """The widening only catches what actually parses as Pronto words."""
+    for code in ("not a pronto code", "0000 006D", ""):
+        assert canonical_fingerprint(None, code, None) == (
+            EventParser.signal_fingerprint(None, code, None)
+        )
+
+
+def test_a_stamped_non_pronto_protocol_still_passes_through():
+    assert canonical_fingerprint("NEC", "0x20DF10EF", None) == (
+        EventParser.signal_fingerprint("NEC", "0x20DF10EF", None)
+    )

--- a/custom_components/hair/tests/test_identity_tail_strip.py
+++ b/custom_components/hair/tests/test_identity_tail_strip.py
@@ -872,3 +872,131 @@ def test_a_non_string_code_costs_one_row_not_the_catalog(caplog):
     assert any(
         "bad" in record.getMessage() for record in caplog.records
     ), [r.getMessage() for r in caplog.records]
+
+
+# ---------------------------------------------------------------------------
+# Nothing that leaves the install carries an identity
+# ---------------------------------------------------------------------------
+#
+# The RM4 Pro question, asked of this fix. The 0.9.8 trailing-pause trim
+# broke a Broadlink RM4 Pro because something downstream consumed the
+# thing that was removed. The hashed tail is a constant and carries no
+# information, so the equivalent blind spot here is not a CONSUMER but a
+# HOLDER: an artifact that leaves the install carrying an old identity
+# value and is later read back against a new one. These prove there is
+# no such holder, rather than asserting it in a comment.
+
+
+WIGS = FIXTURES / "wigs"
+
+
+def test_claim_digests_do_not_move():
+    """A wig's claims bind the code TEXT, over the whole corpus.
+
+    row_digest is what every signed fitting is signed over, so if it
+    moved with identity, this release would invalidate every signature
+    ever written. It hashes normalized_pronto plus the ditto count and
+    the bypass flag, and identity is not in it. Asserted here across the
+    fixture tree rather than on the single code test_canonical_identity
+    uses, and asserted as a property: computing every identity a code
+    has leaves its digest byte-identical.
+    """
+    from custom_components.hair.wig_format import row_digest
+
+    before = {code: row_digest(code, 0, False) for code in UNION_CORPUS}
+    for code in UNION_CORPUS:
+        canonical_byte_hash(code)
+        canonical_fingerprint("PRONTO", code, None)
+        EventParser.pronto_byte_hash(code)
+        EventParser.signal_fingerprint("PRONTO", code, None)
+    after = {code: row_digest(code, 0, False) for code in UNION_CORPUS}
+
+    assert before == after
+    # And the digest does move when the TEXT moves, so the assertion
+    # above is not passing because row_digest ignores its argument.
+    a, b = UNION_CORPUS[0], UNION_CORPUS[1]
+    assert row_digest(a, 0, False) != row_digest(b, 0, False)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "dreo-fan-dr-haf004s-perfect-fit.wig.json",
+        "komeco-airconditioner-kos-09qc-3hx-perfect-fit.wig.json",
+    ],
+)
+def test_an_existing_signed_fitting_still_verifies(name: str):
+    """No ed25519 signature covers an identity value.
+
+    Both certified fixtures were signed before this release. If any
+    signature bound a byte_hash or a fingerprint, moving 841 of them
+    would show up right here.
+    """
+    pytest.importorskip("cryptography")
+    from custom_components.hair.fitting_signing import verify_fitting
+
+    wig = json.loads((WIGS / name).read_text())
+    fittings = wig.get("fittings") or []
+    assert fittings, "the fixture is supposed to be a signed one"
+    for entry in fittings:
+        assert verify_fitting(entry) == "valid"
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "dreo-fan-dr-haf004s-perfect-fit.wig.json",
+        "komeco-airconditioner-kos-09qc-3hx-perfect-fit.wig.json",
+    ],
+)
+def test_no_wig_format_field_carries_an_identity(name: str):
+    """A structural guard, so a future field cannot quietly re-couple
+    the file format to identity.
+
+    The wig format cannot carry this defect because it cannot carry an
+    identity at all. The only ``fingerprint`` anywhere in the wig layer
+    is a signing key digest, which is a property of the signer and not
+    of any signal.
+    """
+    from custom_components.hair.wig_format import parse_wig, serialize_wig
+
+    parsed = parse_wig((WIGS / name).read_text())
+    assert parsed.wig is not None, parsed.errors
+    out = json.loads(serialize_wig(parsed.wig))
+
+    found: list[str] = []
+
+    def walk(node, path=""):
+        if isinstance(node, dict):
+            for key, value in node.items():
+                here = f"{path}.{key}"
+                if key == "byte_hash" or key.endswith("fingerprint"):
+                    found.append(here)
+                walk(value, here)
+        elif isinstance(node, list):
+            for index, item in enumerate(node):
+                walk(item, f"{path}[{index}]")
+
+    walk(out)
+    assert found == [], found
+
+
+def test_comb_receipt_holds_no_identity():
+    """The comb's receipt keys on cell and row keys, deliberately
+    outside every canonical hash. Nothing in it moves with identity."""
+    from custom_components.hair.wig_format import parse_wig, serialize_wig
+
+    parsed = parse_wig(
+        (WIGS / "komeco-airconditioner-kos-09qc-3hx-perfect-fit.wig.json")
+        .read_text()
+    )
+    assert parsed.wig is not None, parsed.errors
+    out = json.loads(serialize_wig(parsed.wig))
+    receipt = out.get("comb")
+    assert receipt is not None, "the fixture is supposed to carry a comb"
+
+    text = json.dumps(receipt)
+    assert "byte_hash" not in text
+    assert "fingerprint" not in text
+    # And no bare 16-hex identity value rode along under another name.
+    assert not re.search(r'"[0-9a-f]{16}"', text), text[:400]

--- a/custom_components/hair/tests/test_identity_tail_strip.py
+++ b/custom_components/hair/tests/test_identity_tail_strip.py
@@ -32,7 +32,7 @@ import json
 import logging
 import re
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -1000,3 +1000,78 @@ def test_comb_receipt_holds_no_identity():
     assert "fingerprint" not in text
     # And no bare 16-hex identity value rode along under another name.
     assert not re.search(r'"[0-9a-f]{16}"', text), text[:400]
+
+
+@pytest.mark.asyncio
+async def test_a_migrating_load_saves_once_and_a_clean_one_never_saves():
+    """The load-time catalog migration has to reach disk.
+
+    Setting the dirty flag arms nothing -- schedule_save is what starts
+    the debounce -- so before this the migration lived in memory until
+    some unrelated write flushed it, and every boot re-ran it. Measured
+    on the bench box before the fix: 495 of 552 rows moved in memory, 0
+    reached the file, and the file's mtime never changed across the
+    restart.
+
+    Both halves are asserted, because a save at every boot would be its
+    own defect on a flooded store: a stale catalog saves exactly once,
+    and the payload it wrote loads back clean with no save at all.
+    """
+    from custom_components.hair.models import UnknownDevice, UnknownSignal
+    from custom_components.hair.signal_store import SignalStore
+
+    def _hass():
+        hass = MagicMock()
+        hass.loop = MagicMock()
+        hass.loop.call_later = MagicMock(return_value=MagicMock())
+        hass.async_create_task = MagicMock()
+        hass.async_add_executor_job = AsyncMock(
+            side_effect=lambda func, *args: func(*args)
+        )
+        return hass
+
+    device = UnknownDevice(label="Clipped")
+    device.signals = [
+        UnknownSignal(
+            id="s1", protocol="PRONTO", code=FILE_FORM,
+            fingerprint=_legacy_fingerprint(FILE_FORM),
+            byte_hash=_legacy_byte_hash(FILE_FORM),
+        )
+    ]
+    stale = {
+        "devices": [device.to_dict()],
+        "dismissed": [],
+        "plucked_stores": [{"integration": "broadlink", "store_id": "x"}],
+    }
+
+    written: dict = {}
+    store = SignalStore(_hass())
+    with patch.object(store, "_store") as mock_store:
+        mock_store.async_load = AsyncMock(return_value=stale)
+        mock_store.async_save = AsyncMock(
+            side_effect=lambda payload: written.update(payload)
+        )
+        await store.async_load()
+
+    assert mock_store.async_save.await_count == 1, "a stale catalog must persist"
+    row = written["devices"][0]["signals"][0]
+    assert row["byte_hash"] == EventParser.pronto_byte_hash(FILE_FORM)
+    assert row["fingerprint"] == (
+        EventParser.signal_fingerprint("PRONTO", FILE_FORM, None)
+    )
+    assert row["code"] == FILE_FORM, "the stored code text is never rewritten"
+    # The Plucker's records survive the save: _serialize reads them, so a
+    # save placed any earlier in async_load would have dropped them.
+    assert written["plucked_stores"] == stale["plucked_stores"]
+
+    # Second boot, on exactly what the first one wrote.
+    again = SignalStore(_hass())
+    with patch.object(again, "_store") as mock_again:
+        mock_again.async_load = AsyncMock(
+            return_value=json.loads(json.dumps(written))
+        )
+        mock_again.async_save = AsyncMock()
+        await again.async_load()
+
+    assert mock_again.async_save.await_count == 0, "a clean boot writes nothing"
+    assert again._dirty is False

--- a/custom_components/hair/tests/test_identity_tail_strip.py
+++ b/custom_components/hair/tests/test_identity_tail_strip.py
@@ -31,6 +31,7 @@ import hashlib
 import json
 import re
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -438,3 +439,318 @@ def test_the_walk_ends_on_a_mark(code: str):
     timings = EventParser._pronto_identity_timings(code)
     assert timings is not None
     assert len(timings) % 2 == 1
+
+
+# ---------------------------------------------------------------------------
+# The migration: every holder of an identity re-keys on the same load
+# ---------------------------------------------------------------------------
+
+
+FILE_FORM = "0000 006D 0002 0000 0020 0040 0020 0000"
+"""How a file writes it: raw_to_pronto padded the final space with zero."""
+
+AIR_FORM = "0000 006D 0002 0000 0020 0040 0020 017C"
+"""How philippegu56's receiver writes it: its own measure of the silence.
+
+Sub-threshold, so the gap break never saw it and the old walk hashed it
+as a timing. 380 carrier cycles is about 10 ms; the gap threshold is
+1024 cycles, about 27 ms, which is why a real trailing silence can sit
+either side of the cliff depending on the receiver.
+"""
+
+CLASS_E = (
+    "0000 006C 0022 0002 015B 00AD 0016 0016 0016 0041 0016 0016 "
+    "0016 0041 0016 0041"
+)
+"""A code that hashes but does not canonicalize.
+
+The header declares 34 intro pairs plus 2 repeat pairs, so 72 timing
+words, while the body carries 12: the burst-2 repeat sequence was
+truncated somewhere upstream, as a copy out of an IRDB or Girr entry
+easily does. ``ProntoCommand`` refuses it and ``canonical_pronto``
+answers None, while both hash walks read it without complaint. This is
+the class the migration used to skip, and its hash moves like any
+other, so skipping it left the row behind.
+"""
+
+
+def _capture(code: str):
+    """One capture of ``code``, normalized as the Sniffer normalizes it.
+
+    Rebuilt from raw timings, which is what every receive path does, so
+    the identity is the wire form rather than the text.
+    """
+    from custom_components.hair.models import CaptureResult
+    from custom_components.hair.signal_monitor import normalize
+
+    command = ProntoCommand(code)
+    raw = command.get_raw_timings()
+    return normalize(
+        CaptureResult(
+            protocol="PRONTO",
+            code=raw_to_pronto(raw, frequency=command.modulation),
+            raw_timings=raw,
+            frequency=command.modulation,
+        )
+    )
+
+
+@pytest.fixture
+def store():
+    from custom_components.hair.storage import HAIRStore
+
+    hass = MagicMock()
+    hass.async_add_executor_job = AsyncMock(
+        side_effect=lambda func, *args: func(*args)
+    )
+    built = HAIRStore(hass)
+    built._data = {}
+    built._triggers = {}
+    built._trigger_remotes = {}
+    return built
+
+
+def test_the_two_tails_were_two_identities_and_are_now_one():
+    """The premise of every test below, stated once."""
+    assert _legacy_byte_hash(FILE_FORM) != _legacy_byte_hash(AIR_FORM)
+    assert _legacy_fingerprint(FILE_FORM) != _legacy_fingerprint(AIR_FORM)
+    assert EventParser.pronto_byte_hash(FILE_FORM) == (
+        EventParser.pronto_byte_hash(AIR_FORM)
+    )
+    assert EventParser.signal_fingerprint("PRONTO", FILE_FORM, None) == (
+        EventParser.signal_fingerprint("PRONTO", AIR_FORM, None)
+    )
+
+
+def test_trigger_rekeys_and_fires_on_the_surviving_row(store):
+    """The mandatory acceptance surface: the fragment pair collapses and
+    the trigger lands on what is left.
+
+    A remote holding a pasted row and its own capture of the same
+    button. Two rows, because the tails gave them two identities. One
+    load collapses them, re-keys the trigger, and a fresh press of the
+    same button matches the row that survived.
+    """
+    from custom_components.hair.models import (
+        IRTrigger,
+        UnknownDevice,
+        UnknownSignal,
+    )
+    from custom_components.hair.signal_store import _transform_loaded
+
+    device = UnknownDevice(label="Arris")
+    device.signals = [
+        UnknownSignal(
+            id="pasted", protocol="PRONTO", code=FILE_FORM, hit_count=3,
+            fingerprint=_legacy_fingerprint(FILE_FORM),
+            byte_hash=_legacy_byte_hash(FILE_FORM),
+            alias="Power", first_seen="2026-08-01T00:00:00+00:00",
+        ),
+        UnknownSignal(
+            id="heard", protocol="PRONTO", code=AIR_FORM, hit_count=5,
+            fingerprint=_legacy_fingerprint(AIR_FORM),
+            byte_hash=_legacy_byte_hash(AIR_FORM),
+            first_seen="2026-08-02T00:00:00+00:00",
+        ),
+    ]
+
+    devices, _dismissed, dirty = _transform_loaded(
+        {"devices": [device.to_dict()], "dismissed": []}
+    )
+
+    rows = next(iter(devices.values())).signals
+    assert dirty is True
+    assert len(rows) == 1
+    survivor = rows[0]
+    assert survivor.id == "pasted"
+    assert survivor.hit_count == 8
+    assert survivor.alias == "Power"
+
+    store._triggers = {
+        "t1": IRTrigger(
+            id="t1", name="Power", protocol="PRONTO", code=FILE_FORM,
+            signal_fingerprint=_legacy_fingerprint(FILE_FORM),
+            byte_hash=_legacy_byte_hash(FILE_FORM),
+        )
+    }
+    assert store._backfill_canonical_identity() is True
+    trigger = store._triggers["t1"]
+    assert trigger.signal_fingerprint == survivor.fingerprint
+    assert trigger.byte_hash == survivor.byte_hash
+
+    heard = _capture(AIR_FORM)
+    assert trigger.matches_signal(
+        heard.sig_fp, heard.byte_hash, heard.decoded_fingerprint
+    )
+
+
+def test_the_healed_row_still_carries_its_trigger_badge(store):
+    """The v0.6.1 orphan class, guarded.
+
+    Firing and the yellow badge are different questions: in v0.6.1 a
+    heal-merged row kept firing while the badge went dark, because the
+    survivor carried a different fingerprint from the trigger. Under
+    this migration both sides converge on the same load, so the badge
+    sits on the survivor.
+    """
+    from custom_components.hair.models import (
+        IRTrigger,
+        UnknownDevice,
+        UnknownSignal,
+    )
+    from custom_components.hair.signal_store import _transform_loaded
+
+    device = UnknownDevice(label="Arris")
+    device.signals = [
+        UnknownSignal(
+            id="pasted", protocol="PRONTO", code=FILE_FORM,
+            fingerprint=_legacy_fingerprint(FILE_FORM),
+            byte_hash=_legacy_byte_hash(FILE_FORM),
+        ),
+        UnknownSignal(
+            id="heard", protocol="PRONTO", code=AIR_FORM,
+            fingerprint=_legacy_fingerprint(AIR_FORM),
+            byte_hash=_legacy_byte_hash(AIR_FORM),
+        ),
+    ]
+    devices, _dismissed, _dirty = _transform_loaded(
+        {"devices": [device.to_dict()], "dismissed": []}
+    )
+    survivor = next(iter(devices.values())).signals[0]
+
+    store._triggers = {
+        "t1": IRTrigger(
+            id="t1", name="Power", protocol="PRONTO", code=AIR_FORM,
+            signal_fingerprint=_legacy_fingerprint(AIR_FORM),
+            byte_hash=_legacy_byte_hash(AIR_FORM),
+        )
+    }
+    store._backfill_canonical_identity()
+
+    assert store._triggers["t1"].matches_signal(
+        survivor.fingerprint, survivor.byte_hash, survivor.decoded_fingerprint
+    )
+
+
+def test_a_trigger_whose_code_does_not_canonicalize_is_still_rekeyed(store):
+    """The skip hole, closed.
+
+    The migration used to require ``canonical_pronto`` to succeed before
+    it would touch a row. A class-E code hashes and does not
+    canonicalize, so the guard skipped exactly the rows whose hash this
+    release moves, and the trigger would have gone quiet with no way to
+    tell why.
+    """
+    from custom_components.hair.models import IRTrigger
+
+    assert canonical_pronto(CLASS_E) is None
+    assert EventParser.pronto_byte_hash(CLASS_E) is not None
+    stale = _legacy_byte_hash(CLASS_E)
+    fresh = EventParser.pronto_byte_hash(CLASS_E)
+    assert stale != fresh
+
+    store._triggers = {
+        "t1": IRTrigger(
+            id="t1", name="Power", protocol="PRONTO", code=CLASS_E,
+            signal_fingerprint=_legacy_fingerprint(CLASS_E),
+            byte_hash=stale,
+        )
+    }
+
+    assert store._backfill_canonical_identity() is True
+    trigger = store._triggers["t1"]
+    assert trigger.byte_hash == fresh
+    assert trigger.signal_fingerprint == (
+        EventParser.signal_fingerprint("PRONTO", CLASS_E, None)
+    )
+
+
+def test_a_command_whose_code_does_not_canonicalize_is_still_rekeyed(store):
+    """The same hole on the command loop, which the matcher indexes."""
+    from custom_components.hair.models import IRCommand, IRDevice
+
+    device = IRDevice(id="dev-1", name="Adopted")
+    device.commands = [
+        IRCommand(
+            id="c1", name="Power", protocol="PRONTO", code=CLASS_E,
+            byte_hash=_legacy_byte_hash(CLASS_E),
+        )
+    ]
+    store._data = {"dev-1": device}
+
+    assert store._backfill_canonical_identity() is True
+    assert device.commands[0].byte_hash == (
+        EventParser.pronto_byte_hash(CLASS_E)
+    )
+
+
+def test_a_legacy_trigger_keeps_its_hashless_broad_match(store):
+    """The v0.5.8 rule, unchanged: repoint a hash, never add one.
+
+    A pre-0.5.8 trigger matches broadly on its fingerprint. Narrowing it
+    at load could mismatch a live capture and silence it, and a tier-2
+    miss is fatal, so the migration leaves the hash absent.
+    """
+    from custom_components.hair.models import IRTrigger
+
+    store._triggers = {
+        "t1": IRTrigger(
+            id="t1", name="Power", protocol="PRONTO", code=FILE_FORM,
+            signal_fingerprint=_legacy_fingerprint(FILE_FORM),
+            byte_hash=None,
+        )
+    }
+
+    store._backfill_canonical_identity()
+    trigger = store._triggers["t1"]
+    assert trigger.byte_hash is None
+    # The fingerprint still moves: that half was always recomputed.
+    assert trigger.signal_fingerprint == (
+        EventParser.signal_fingerprint("PRONTO", FILE_FORM, None)
+    )
+
+
+def test_pin_bindings_rederive_across_the_move(store):
+    """A pinned Remote drives the same command after the identities move.
+
+    Bindings hold ids, not identity values, and are rederived at every
+    load from whatever the identities currently are. This proves the
+    order holds: the identity backfill runs before the rederive, so the
+    map is built on the new values and not the old.
+    """
+    from custom_components.hair.models import (
+        IRCommand,
+        IRDevice,
+        IRTrigger,
+        TriggerRemote,
+    )
+    from custom_components.hair.pin_bindings import derive_bindings
+
+    device = IRDevice(id="dev-1", name="Adopted")
+    device.commands = [
+        IRCommand(
+            id="c1", name="Power", protocol="PRONTO", code=FILE_FORM,
+            byte_hash=_legacy_byte_hash(FILE_FORM),
+        )
+    ]
+    store._data = {"dev-1": device}
+
+    remote = TriggerRemote(
+        name="Arris", origin="closet", pinned_device_ids=["dev-1"]
+    )
+    store._trigger_remotes[remote.id] = remote
+    trigger = IRTrigger(
+        id="t1", name="Power", protocol="PRONTO", code=AIR_FORM,
+        signal_fingerprint=_legacy_fingerprint(AIR_FORM),
+        byte_hash=_legacy_byte_hash(AIR_FORM),
+        trigger_remote_id=remote.id, origin="closet",
+    )
+    store._triggers = {"t1": trigger}
+
+    # Before: the two tails gave the pair two identities and no binding.
+    assert derive_bindings(store, remote) == {"dev-1": {}}
+
+    store._backfill_canonical_identity()
+    store._rebuild_command_index()
+
+    assert derive_bindings(store, remote) == {"dev-1": {"t1": "c1"}}

--- a/custom_components/hair/tests/test_identity_tail_strip.py
+++ b/custom_components/hair/tests/test_identity_tail_strip.py
@@ -1,0 +1,440 @@
+"""Identity ends at the last real pulse: the unified strip (GH #125).
+
+THE DEFECT. One waveform reaches HAIR wearing three different tails. A
+file writes the inter-frame gap it was authored with; a receiver writes
+its own measure of the trailing silence; ``raw_to_pronto`` pads the
+missing final space with a zero. Both Pronto hash walks read the
+rendered text, so the same physical button could carry up to three
+identities, and the load-time migration kept moving stored rows onto a
+form the air would never reproduce -- philippegu56's rows re-minted on
+every reload, triggers going quiet with them.
+
+THE FIX. ``EventParser._pronto_identity_timings`` applies
+``identity.canonical_edges``'s rule inside both walks, so the tail is
+never hashed and the three forms converge by construction.
+
+WHAT THIS FILE PINS. The corpus invariant nobody pinned (wire and
+canonical agree on every fixture code), the blast radius as counts, and
+the edge classes the strip deliberately does not change. Every corpus
+test reads the fixture tree at run time: no baked code lists, so a
+fixture added tomorrow is measured tomorrow.
+
+The legacy helpers below are verbatim copies of the pre-strip walks.
+They are the only honest way to assert "this moved and that did not"
+without checking in 841 hashes, and they follow the parity-pin pattern
+``test_signal_flood.py`` uses for the GH #72 heal.
+"""
+from __future__ import annotations
+
+import gzip
+import hashlib
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from custom_components.hair.const import (
+    PRONTO_BYTE_HASH_BIN,
+    PRONTO_DEVICE_PREAMBLE_PAIRS,
+    PRONTO_GAP_THRESHOLD,
+    PRONTO_NEC_ADDRESS_PAIRS,
+    PRONTO_SL_THRESHOLD,
+)
+from custom_components.hair.event_parser import EventParser
+from custom_components.hair.identity import (
+    canonical_byte_hash,
+    canonical_fingerprint,
+    canonical_pronto,
+    is_multi_frame_code,
+)
+from custom_components.hair.ir_command import ProntoCommand, raw_to_pronto
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+_WORD = re.compile(r"^[0-9A-Fa-f]{4}$")
+
+
+# ---------------------------------------------------------------------------
+# The corpus, read from the fixture tree at run time
+# ---------------------------------------------------------------------------
+
+
+def _looks_pronto(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    parts = value.split()
+    return len(parts) >= 5 and all(_WORD.match(p) for p in parts)
+
+
+def _walk(node, sink: list[str]) -> None:
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if _looks_pronto(key):
+                sink.append(key)
+            _walk(value, sink)
+    elif isinstance(node, list):
+        for item in node:
+            _walk(item, sink)
+    elif _looks_pronto(node):
+        sink.append(node)
+
+
+def _dedupe(codes: list[str]) -> list[str]:
+    seen: dict[str, None] = {}
+    for code in codes:
+        seen.setdefault(" ".join(code.split()).upper(), None)
+    return list(seen)
+
+
+def _json_corpus() -> list[str]:
+    """Every Pronto in ``fixtures/**/*.json``. 853 unique as of v0.12.0."""
+    found: list[str] = []
+    for path in sorted(FIXTURES.rglob("*.json")):
+        try:
+            _walk(json.loads(path.read_text()), found)
+        except (ValueError, UnicodeDecodeError):
+            continue
+    return _dedupe(found)
+
+
+def _ext_corpus() -> list[str]:
+    """The Prontos that do not live in plain JSON.
+
+    ``.pronto`` files, the ``<ccf>`` elements of the Girr adapters (which
+    are line-wrapped in the source and must be whitespace-joined before
+    they parse), and the gzipped air-path captures. 79 unique, and mostly
+    gap-tailed where the JSON corpus is mostly zero-tailed -- which is
+    exactly why both are measured.
+    """
+    found: list[str] = []
+    for path in sorted(FIXTURES.rglob("*.pronto")):
+        text = " ".join(path.read_text().split())
+        if _looks_pronto(text):
+            found.append(text)
+    for path in sorted(FIXTURES.rglob("*.girr")):
+        for body in re.findall(
+            r"<ccf[^>]*>(.*?)</ccf>", path.read_text(), re.S
+        ):
+            joined = " ".join(body.split())
+            if _looks_pronto(joined):
+                found.append(joined)
+    for path in sorted(FIXTURES.rglob("*.json.gz")):
+        try:
+            with gzip.open(path, "rt") as handle:
+                _walk(json.load(handle), found)
+        except (OSError, ValueError, UnicodeDecodeError):
+            continue
+    seen = set(_json_corpus())
+    return [c for c in _dedupe(found) if c not in seen]
+
+
+JSON_CORPUS = _json_corpus()
+EXT_CORPUS = _ext_corpus()
+UNION_CORPUS = JSON_CORPUS + EXT_CORPUS
+
+
+def _tail_class(code: str) -> str:
+    """Which of the three tails this code was written with."""
+    words = EventParser._parse_pronto_words(code)
+    assert words is not None
+    last = words[-1]
+    if last == 0:
+        return "zero"
+    if last >= PRONTO_GAP_THRESHOLD:
+        return "gap"
+    return "sub"
+
+
+# ---------------------------------------------------------------------------
+# The pre-strip walks, copied verbatim so movement can be measured
+# ---------------------------------------------------------------------------
+
+
+def _legacy_sl_pattern(code: str | None) -> str | None:
+    words = EventParser._parse_pronto_words(code)
+    if words is None:
+        return None
+    pattern = []
+    for t in words[4:]:
+        if t >= PRONTO_GAP_THRESHOLD:
+            break
+        pattern.append("S" if t < PRONTO_SL_THRESHOLD else "L")
+    if not pattern:
+        return None
+    return "".join(pattern)
+
+
+def _legacy_byte_hash(code: str | None) -> str | None:
+    words = EventParser._parse_pronto_words(code)
+    if words is None:
+        return None
+    quantized: list[str] = []
+    for t in words[4:]:
+        if t >= PRONTO_GAP_THRESHOLD:
+            break
+        quantized.append(str(round(t / PRONTO_BYTE_HASH_BIN) * PRONTO_BYTE_HASH_BIN))
+    if not quantized:
+        return None
+    return hashlib.sha256(",".join(quantized).encode()).hexdigest()[:16]
+
+
+def _legacy_fingerprint(code: str | None) -> str | None:
+    sl = _legacy_sl_pattern(code)
+    if sl is None:
+        return None
+    return hashlib.sha256(f"PRONTO:{sl}".encode()).hexdigest()[:16]
+
+
+def _legacy_device_fingerprint(code: str) -> str | None:
+    words = EventParser._parse_pronto_words(code)
+    sl = _legacy_sl_pattern(code)
+    if words is None or sl is None:
+        return None
+    timings = words[4:]
+    if timings and timings[0] >= 0x100:
+        preamble = sl[2 : 2 + PRONTO_NEC_ADDRESS_PAIRS * 2]
+    else:
+        preamble = sl[: PRONTO_DEVICE_PREAMBLE_PAIRS * 2]
+    payload = f"DEV:PRONTO:{words[1]:04X}:{preamble}"
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# Idempotence, pinned corpus-wide (the invariant nobody pinned)
+# ---------------------------------------------------------------------------
+
+
+def test_the_corpus_is_the_one_the_measurement_was_taken_on():
+    """A guard on the guards: if extraction breaks, the counts below
+    would pass vacuously. 853 + 79 as measured at v0.12.0."""
+    assert len(JSON_CORPUS) == 853
+    assert len(EXT_CORPUS) == 79
+
+
+def test_every_fixture_pronto_hashes_the_same_wire_or_canonical():
+    """A1 and A2. The invariant the store's comment asserted and nothing
+    checked, which is why the suite stayed green on a broken store."""
+    bad_hash = [
+        c for c in JSON_CORPUS
+        if canonical_byte_hash(c) != EventParser.pronto_byte_hash(c)
+    ]
+    bad_fp = [
+        c for c in JSON_CORPUS
+        if canonical_fingerprint("PRONTO", c, None)
+        != EventParser.signal_fingerprint("PRONTO", c, None)
+    ]
+    assert bad_hash == []
+    assert bad_fp == []
+
+
+def test_the_extended_corpus_agrees_too():
+    """A3. The gap-tailed half of the fixture tree, where the JSON
+    corpus is almost entirely zero-tailed."""
+    for code in EXT_CORPUS:
+        assert canonical_byte_hash(code) == EventParser.pronto_byte_hash(code)
+        assert canonical_fingerprint("PRONTO", code, None) == (
+            EventParser.signal_fingerprint("PRONTO", code, None)
+        )
+
+
+def test_the_three_tail_shapes_of_one_code_share_one_identity():
+    """The test that would have caught the bug, and the first one to
+    fail if the strip is ever removed.
+
+    One waveform, three tails: the inter-frame gap a file writes, the
+    zero ``raw_to_pronto`` pads, and the sub-threshold silence a
+    receiver measures.
+    """
+    body = "0000 006D 0002 0000 0020 0040 0020"
+    gap, padded, heard = f"{body} 09BC", f"{body} 0000", f"{body} 017C"
+
+    hashes = {EventParser.pronto_byte_hash(c) for c in (gap, padded, heard)}
+    prints = {
+        EventParser.signal_fingerprint("PRONTO", c, None)
+        for c in (gap, padded, heard)
+    }
+    canon = {canonical_byte_hash(c) for c in (gap, padded, heard)}
+
+    assert len(hashes) == 1
+    assert len(prints) == 1
+    assert len(canon) == 1
+    assert hashes == canon
+    # The surviving value is the one the gap tail already had: the other
+    # two move onto it, not the other way round.
+    assert hashes == {_legacy_byte_hash(gap)}
+
+
+def test_canonicalization_is_idempotent_on_identity_not_only_text():
+    """The existing ``test_canonicalization_is_idempotent`` pins TEXT
+    idempotence, which was true all along. This pins the identity kind,
+    which was not, and whose name is why the false store comment stood.
+    """
+    for code in JSON_CORPUS[:50] + EXT_CORPUS[:20]:
+        once = canonical_pronto(code)
+        if once is None:
+            continue
+        assert canonical_byte_hash(once) == canonical_byte_hash(code)
+        assert canonical_fingerprint("PRONTO", once, None) == (
+            canonical_fingerprint("PRONTO", code, None)
+        )
+
+
+def test_a_real_receiver_tail_is_not_simulated_by_raw_to_pronto():
+    """``test_canonical_identity._off_the_air`` renders through
+    ``raw_to_pronto``, which zero-pads -- so the suite never saw the
+    shape philippegu56's hardware actually produces. A genuine
+    sub-threshold tail must now agree with it."""
+    filed = "0000 006D 0002 0000 0020 0040 0020 09BC"
+    command = ProntoCommand(filed)
+    simulated = raw_to_pronto(
+        command.get_raw_timings(), frequency=command.modulation
+    )
+    genuine = "0000 006D 0002 0000 0020 0040 0020 017C"
+
+    assert EventParser.pronto_byte_hash(simulated) == (
+        EventParser.pronto_byte_hash(genuine)
+    )
+    assert EventParser.signal_fingerprint("PRONTO", simulated, None) == (
+        EventParser.signal_fingerprint("PRONTO", genuine, None)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Blast radius, pinned as counts
+# ---------------------------------------------------------------------------
+
+
+def test_only_the_tail_class_moves():
+    """A4 and A5. Exactly 841 of the 853 move; the 12 that do not are
+    exactly the gap-tailed ones, whose tails the gap break already
+    excluded. A moved value on a gap-tail code means the strip is
+    reaching past the tail and is wrong."""
+    moved = [
+        c for c in JSON_CORPUS
+        if _legacy_byte_hash(c) != EventParser.pronto_byte_hash(c)
+    ]
+    still = [
+        c for c in JSON_CORPUS
+        if _legacy_byte_hash(c) == EventParser.pronto_byte_hash(c)
+    ]
+
+    assert len(moved) == 841
+    assert len(still) == 12
+    assert {_tail_class(c) for c in still} == {"gap"}
+    assert sorted(_tail_class(c) for c in set(moved)) == (
+        sorted(["zero"] * 838 + ["sub"] * 3)
+    )
+    # Every mover lands on the value canonicalization already computed:
+    # the two layers converge, they do not both drift somewhere new.
+    for code in moved:
+        assert EventParser.pronto_byte_hash(code) == canonical_byte_hash(code)
+
+
+def test_the_extended_corpus_moves_seven():
+    """The mirror of A4/A5 on the gap-tailed corpus: 7 move, 72 hold."""
+    moved = [
+        c for c in EXT_CORPUS
+        if _legacy_byte_hash(c) != EventParser.pronto_byte_hash(c)
+    ]
+    assert len(moved) == 7
+    assert {_tail_class(c) for c in moved} == {"sub", "zero"}
+
+
+def test_device_fingerprint_does_not_move():
+    """A6. The grouping key is persisted and never recomputed at load,
+    so if it moved, every catalog remote would split in two. The strip
+    removes at most one S/L character and the preamble slice is 18
+    characters at most, so it cannot reach: measured 0 of 932."""
+    for code in UNION_CORPUS:
+        assert _legacy_device_fingerprint(code) == (
+            EventParser.device_fingerprint("PRONTO", None, None, code)
+        )
+
+
+def test_the_strip_removes_at_most_one_character():
+    """Why A6 holds rather than happening to hold. One tail word, so one
+    S/L character, against a shortest corpus pattern of 23."""
+    deltas = set()
+    shortest = min(
+        len(EventParser._pronto_sl_pattern(c) or "") for c in UNION_CORPUS
+    )
+    for code in UNION_CORPUS:
+        before = len(_legacy_sl_pattern(code) or "")
+        after = len(EventParser._pronto_sl_pattern(code) or "")
+        deltas.add(before - after)
+    assert deltas <= {0, 1}
+    assert shortest > PRONTO_NEC_ADDRESS_PAIRS * 2 + 2
+
+
+# ---------------------------------------------------------------------------
+# Edge classes
+# ---------------------------------------------------------------------------
+
+
+def test_degenerate_code_has_no_byte_hash_on_either_layer():
+    """GH #108, converged for free. An all-zero code strips away to
+    nothing, so the wire walk now answers ``None`` -- which is what
+    ``canonical_byte_hash`` has answered since GH #108 shipped. This is
+    a CHANGE in the wire walk: it used to return a hash of a signal that
+    transmits nothing and can match nothing."""
+    degenerate = "0000 006D 0002 0000 0000 0000 0000 0000"
+
+    assert _legacy_byte_hash(degenerate) is not None
+    assert EventParser.pronto_byte_hash(degenerate) is None
+    assert EventParser._pronto_sl_pattern(degenerate) is None
+    assert canonical_byte_hash(degenerate) is None
+
+
+def test_a_burst2_repeat_frame_never_reaches_the_hash():
+    """A ditto sequence sits behind a gap word, so both walks stop
+    before it -- before this change and after. Its identity does not
+    move, which is why the Girr Onkyo class is in the unchanged 72."""
+    onkyo = next(
+        (c for c in UNION_CORPUS
+         if _tail_class(c) == "gap" and is_multi_frame_code(c)),
+        None,
+    )
+    assert onkyo is not None
+    assert _legacy_byte_hash(onkyo) == EventParser.pronto_byte_hash(onkyo)
+
+
+def test_a_multi_frame_code_with_a_sub_threshold_gap_still_hashes_all_frames():
+    """THE KNOWN LIMIT, pinned so nobody reads more into the strip than
+    is there. An AC state code's inter-frame gaps sit below the
+    threshold, so both walks hash every frame while a receiver delivers
+    one frame per capture. The strip does not close that; the
+    receiver-tolerant tier is the designed answer and stays necessary.
+    """
+    multi = [c for c in JSON_CORPUS if is_multi_frame_code(c)]
+    assert multi, "the corpus is supposed to be mostly multi-frame"
+    code = multi[0]
+    words = EventParser._parse_pronto_words(code)
+    assert words is not None
+    hashed = EventParser._pronto_identity_timings(code)
+    assert hashed is not None
+    # Everything but the header and the stripped tail reaches the hash.
+    assert len(hashed) >= len(words) - 4 - 1
+
+
+def test_an_unreadable_code_still_answers_none():
+    assert EventParser._pronto_identity_timings(None) is None
+    assert EventParser._pronto_identity_timings("not a pronto") is None
+    assert EventParser._pronto_identity_timings("0000 006D") is None
+    assert EventParser.pronto_byte_hash("0000 006D") is None
+    assert EventParser._pronto_sl_pattern("0000 006D") is None
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        "0000 006D 0002 0000 0020 0040 0020 0000",
+        "0000 006D 0002 0000 0020 0040 0020 09BC",
+    ],
+)
+def test_the_walk_ends_on_a_mark(code: str):
+    """The whole rule in one assertion: odd length means the last word
+    is a mark, whatever tail the code was written with."""
+    timings = EventParser._pronto_identity_timings(code)
+    assert timings is not None
+    assert len(timings) % 2 == 1

--- a/custom_components/hair/tests/test_matrix_listener.py
+++ b/custom_components/hair/tests/test_matrix_listener.py
@@ -1066,7 +1066,10 @@ def test_the_stored_index_carries_the_lowest_tier(tmp_path):
 
     index = build_cell_index(_air_matrix(), display_unit="C")
     payload = _index_to_payload(index, "h1", "C")
-    assert payload["format"] == "hair-cell-index/2"
+    # The literal lives in test_a_stale_cell_index_is_refused, which is
+    # what pins the version. Here it only has to be the current one, so
+    # a bump does not need this test edited to stay honest.
+    assert payload["format"] == _ml.INDEX_FORMAT
     restored = _payload_to_index(payload)
     assert restored is not None
     heard = _heard(_air_captures("C1", "esphome")[0])
@@ -1349,3 +1352,76 @@ async def test_a_remote_minted_at_runtime_is_warmed_by_its_mint_door():
     listener.warm_index.assert_called_once_with("r9")
     # A caller assembled without a listener must not raise.
     _warm_remote_matrix({}, "r9")
+
+
+def test_a_stale_cell_index_is_refused(tmp_path):
+    """The INDEX_FORMAT bump, pinned against being reverted as noise.
+
+    GH #125 moved the identity algorithm and nothing else. The matrix
+    file is untouched, so its content hash is unchanged, and the display
+    unit is unchanged, so an index written under the old hashes passes
+    both of the other freshness checks. The format version is the only
+    thing that can refuse it.
+    """
+    from custom_components.hair.matrix_listener import (
+        INDEX_FORMAT,
+        _build_and_store_index,
+        _load_stored_index,
+    )
+    from custom_components.hair.matrix_store import index_path, write_matrix
+
+    write_matrix(tmp_path, "r1", _matrix())
+    _build_and_store_index(str(tmp_path), "r1", _matrix(), "C")
+    assert INDEX_FORMAT == "hair-cell-index/3"
+    assert _load_stored_index(str(tmp_path), "r1", "C") is not None
+
+    path = index_path(tmp_path, "r1")
+    payload = _json.loads(path.read_text())
+    # The other two freshness keys are intact: only the format is old.
+    assert payload["unit"] == "C"
+    assert payload["matrix"]
+    payload["format"] = "hair-cell-index/2"
+    path.write_text(_json.dumps(payload))
+
+    assert _load_stored_index(str(tmp_path), "r1", "C") is None
+
+
+def test_a_rebuilt_index_matches_a_capture_after_the_identity_move(tmp_path):
+    """The other half of the bump: once rebuilt, the index answers a
+    real capture of the cell it indexes.
+
+    The capture is reconstructed from raw timings the way every receive
+    path reconstructs one, so this is the wire form and not the file
+    text. Since GH #125 the two hash alike, which is what lets a lattice
+    recognize its own cell off the air.
+    """
+    from custom_components.hair.ir_command import ProntoCommand, raw_to_pronto
+    from custom_components.hair.matrix_listener import (
+        _build_and_store_index,
+        _load_stored_index,
+    )
+    from custom_components.hair.matrix_store import write_matrix
+    from custom_components.hair.models import CaptureResult
+    from custom_components.hair.signal_monitor import normalize
+
+    write_matrix(tmp_path, "r1", _matrix())
+    _build_and_store_index(str(tmp_path), "r1", _matrix(), "C")
+    index = _load_stored_index(str(tmp_path), "r1", "C")
+    assert index is not None
+
+    command = ProntoCommand(PRONTO_COOL_23)
+    raw = command.get_raw_timings()
+    heard = normalize(
+        CaptureResult(
+            protocol="PRONTO",
+            code=raw_to_pronto(raw, frequency=command.modulation),
+            raw_timings=raw,
+            frequency=command.modulation,
+        )
+    )
+
+    hit, tier = index.match(
+        heard.decoded_fingerprint, heard.sig_fp, heard.byte_hash
+    )
+    assert hit.cell_key == "cool/auto/23"
+    assert tier == TIER_BYTE_HASH

--- a/custom_components/hair/tests/test_pin_bindings.py
+++ b/custom_components/hair/tests/test_pin_bindings.py
@@ -13,7 +13,7 @@ import logging
 
 import pytest
 
-from custom_components.hair.event_parser import EventParser
+from custom_components.hair.identity import canonical_fingerprint
 from custom_components.hair.models import (
     IRCommand,
     IRDevice,
@@ -42,7 +42,18 @@ _OTHER_PRONTO = (
 
 
 def _fp(code: str) -> str:
-    return EventParser.signal_fingerprint(None, code, None)
+    """The fingerprint a stored row actually carries for this code.
+
+    NOT ``signal_fingerprint(None, code, None)``, which is what this
+    helper used to be. With no protocol stamp that hashes an EMPTY raw
+    timing list and hands back one constant for every code, so both
+    sides of the bare-fingerprint tests below met on a shared constant
+    rather than on the code's own identity. GH #125 closed that in
+    ``canonical_fingerprint``, which now reads an unstamped Pronto code
+    as Pronto; this mirrors it, and is what the load-time backfill
+    writes onto a legacy row.
+    """
+    return canonical_fingerprint(None, code, None)
 
 
 class _FakeStore:

--- a/custom_components/hair/tests/test_signal_monitor.py
+++ b/custom_components/hair/tests/test_signal_monitor.py
@@ -2201,3 +2201,59 @@ async def test_copy_signals_to_trigger_remote_names_order_and_provenance():
     )
     assert no_target["success"] is False
     assert no_target["code"] == "target_not_found"
+
+
+@pytest.mark.asyncio
+async def test_import_manual_remote_mints_canonical_identity():
+    """A codebook import is heard by the Sniffer when the button is hit.
+
+    import_manual_remote was the last mint door still calling the raw
+    EventParser pair while every sibling used the canonical one (GH
+    #125). Two things are pinned: the door mints the canonical values,
+    which is the routing contract; and those values are what a real
+    capture of the same code produces, which is what the user actually
+    experiences. The code below is gap-tailed the way a codebook entry
+    is, while a capture arrives zero-tailed, so before the unified strip
+    the two hashed differently and an imported row could never hear
+    itself.
+    """
+    from custom_components.hair.identity import (
+        canonical_byte_hash,
+        canonical_fingerprint,
+    )
+    from custom_components.hair.ir_command import ProntoCommand, raw_to_pronto
+    from custom_components.hair.models import CaptureResult
+    from custom_components.hair.signal_monitor import normalize
+
+    hass = _make_hass()
+    store = _make_signal_store(hass)
+    monitor = SignalMonitor(hass, store, _make_hair_store())
+    code = (
+        "0000 006D 0006 0000 00E0 0070 0014 000D 0014 002E "
+        "0014 000D 0014 000D 0014 0400"
+    )
+
+    result = await monitor.import_manual_remote(
+        "Codebook TV", [{"name": "Power", "code": code}]
+    )
+    assert result["imported"] == 1
+    sig = store.get_all_devices()[0].signals[0]
+
+    # The routing contract.
+    assert sig.fingerprint == canonical_fingerprint("PRONTO", sig.code, [])
+    assert sig.byte_hash == canonical_byte_hash(sig.code)
+
+    # And what it buys: the same button, off the air, lands here.
+    command = ProntoCommand(sig.code)
+    raw = command.get_raw_timings()
+    heard = normalize(
+        CaptureResult(
+            protocol="PRONTO",
+            code=raw_to_pronto(raw, frequency=command.modulation),
+            raw_timings=raw,
+            frequency=command.modulation,
+        )
+    )
+    assert heard.code != sig.code, "the tails should still differ"
+    assert heard.sig_fp == sig.fingerprint
+    assert heard.byte_hash == sig.byte_hash

--- a/custom_components/hair/tests/test_signal_store.py
+++ b/custom_components/hair/tests/test_signal_store.py
@@ -185,6 +185,7 @@ class TestLoadSave:
         }
         with patch.object(store, "_store") as mock_store:
             mock_store.async_load = AsyncMock(return_value=raw)
+            mock_store.async_save = AsyncMock()
             await store.async_load()
 
         # Live fingerprint stays dismissed.
@@ -192,9 +193,12 @@ class TestLoadSave:
         # Orphan was pruned.
         assert not store.is_dismissed("orphan_fp")
         assert store.dismissed_count == 1
-        # Self-heal flags the store as dirty so the cleanup persists on
-        # next save.
-        assert store._dirty
+        # The self-heal PERSISTS. This used to assert the dirty flag,
+        # which armed nothing: a load-time repair sat in memory until an
+        # unrelated write flushed it (GH #125). The save is the real
+        # contract, and the flag is clear afterwards because of it.
+        assert mock_store.async_save.await_count == 1
+        assert store._dirty is False
 
     @pytest.mark.asyncio
     async def test_load_with_no_orphans_does_not_mark_dirty(self):
@@ -703,11 +707,14 @@ class TestManualOrder:
         }
         with patch.object(store, "_store") as mock_store:
             mock_store.async_load = AsyncMock(return_value=raw)
+            mock_store.async_save = AsyncMock()
             await store.async_load()
         sigs = store.get_device("m1").signals
         assert [s.fingerprint for s in sigs] == ["dup", "uniq"]
-        # A change was made, so the cleaned list will be persisted.
-        assert store._dirty is True
+        # A change was made, so the cleaned list IS persisted, not merely
+        # flagged for a later write (GH #125).
+        assert mock_store.async_save.await_count == 1
+        assert store._dirty is False
 
     @pytest.mark.asyncio
     async def test_load_v0_3_4_assigns_ids_and_keeps_distinct_byte_hash(self):
@@ -732,15 +739,18 @@ class TestManualOrder:
         }
         with patch.object(store, "_store") as mock_store:
             mock_store.async_load = AsyncMock(return_value=raw)
+            mock_store.async_save = AsyncMock()
             await store.async_load()
         sigs = store.get_device("B").signals
         # Distinct codes sharing a fingerprint stay as two separate signals.
         assert len(sigs) == 2
         assert sigs[0].fingerprint == sigs[1].fingerprint
         assert sigs[0].byte_hash != sigs[1].byte_hash
-        # Each legacy signal received a stable id and a computed byte_hash,
-        # and the store is dirty so those persist on the next save.
+        # Each legacy signal received a stable id and a computed
+        # byte_hash, and the load PERSISTED them rather than flagging
+        # them for a write that might never come (GH #125).
         for sig in sigs:
             assert sig.id
             assert sig.byte_hash is not None
-        assert store._dirty is True
+        assert mock_store.async_save.await_count == 1
+        assert store._dirty is False

--- a/custom_components/hair/tests/test_tolerant_identity.py
+++ b/custom_components/hair/tests/test_tolerant_identity.py
@@ -106,14 +106,22 @@ def test_a_wig_minted_trigger_fires_on_a_real_press(store):
     byte hash is not what a receiver hands back: every capture below
     misses the trigger on the tiers above, and lands on it through the
     normalized one.
+
+    The captures moved from F1 to C1 with GH #125. F1's divergence was
+    partly the trailing gap word, which the unified strip removed from
+    identity, so one of its four captures is now answered at tier 2 and
+    the premise no longer holds for it. C1's is receiver distortion --
+    marks short, spaces long, on every transmitter -- which no identity
+    rule can strip, so it remains the honest case for this tier. The
+    promotion itself is pinned at the bottom of this file.
     """
-    remote = TriggerRemote(name="ACER", origin="closet")
+    remote = TriggerRemote(name="Bench Handset", origin="closet")
     store._trigger_remotes[remote.id] = remote
-    trigger = wig_trigger(air_code("F1"), "Power", remote.id)
+    trigger = wig_trigger(air_code("C1"), "Cool 23", remote.id)
     store._triggers[trigger.id] = trigger
 
-    rows = air_captures("F1")
-    assert len(rows) == 4
+    rows = air_captures("C1")
+    assert len(rows) == 16
     for row in rows:
         signal = heard(row)
         if row["transmitter"] != "inject":
@@ -133,12 +141,12 @@ def test_the_tier_is_not_reached_without_it(store):
     The tier is opt-in per call site, so a caller that has not been
     threaded through cannot start matching by accident.
     """
-    remote = TriggerRemote(name="ACER", origin="closet")
+    remote = TriggerRemote(name="Bench Handset", origin="closet")
     store._trigger_remotes[remote.id] = remote
-    trigger = wig_trigger(air_code("F1"), "Power", remote.id)
+    trigger = wig_trigger(air_code("C1"), "Cool 23", remote.id)
     store._triggers[trigger.id] = trigger
 
-    signal = heard(air_captures("F1", "esphome")[0])
+    signal = heard(air_captures("C1", "esphome")[0])
     assert store.get_triggers_for_signal(
         "PRONTO", signal.code, signal.sig_fp, signal.byte_hash,
         signal.decoded_fingerprint,
@@ -147,17 +155,19 @@ def test_the_tier_is_not_reached_without_it(store):
 
 def test_two_file_sourced_triggers_of_one_shape_fire_neither(store):
     """One press must not run two buttons' automations."""
-    remote = TriggerRemote(name="ACER", origin="closet")
+    remote = TriggerRemote(name="Bench Handset", origin="closet")
     store._trigger_remotes[remote.id] = remote
-    first = wig_trigger(air_code("F1"), "Power", remote.id)
-    second = wig_trigger(stretched(air_code("F1")), "Power (twin)", remote.id)
+    first = wig_trigger(air_code("C1"), "Cool 23", remote.id)
+    second = wig_trigger(
+        stretched(air_code("C1")), "Cool 23 (twin)", remote.id
+    )
     store._triggers[first.id] = first
     store._triggers[second.id] = second
     assert norm_fingerprint_of_code(first.code) == norm_fingerprint_of_code(
         second.code
     )
 
-    signal = heard(air_captures("F1", "esphome")[0])
+    signal = heard(air_captures("C1", "esphome")[0])
     assert store.get_triggers_for_signal(
         "PRONTO", signal.code, signal.sig_fp, signal.byte_hash,
         signal.decoded_fingerprint, signal.norm_fp,
@@ -165,12 +175,12 @@ def test_two_file_sourced_triggers_of_one_shape_fire_neither(store):
 
 
 def test_a_capture_that_decoded_never_reaches_the_trigger_tier(store):
-    remote = TriggerRemote(name="ACER", origin="closet")
+    remote = TriggerRemote(name="Bench Handset", origin="closet")
     store._trigger_remotes[remote.id] = remote
-    trigger = wig_trigger(air_code("F1"), "Power", remote.id)
+    trigger = wig_trigger(air_code("C1"), "Cool 23", remote.id)
     store._triggers[trigger.id] = trigger
 
-    signal = heard(air_captures("F1", "esphome")[0])
+    signal = heard(air_captures("C1", "esphome")[0])
     assert store.get_triggers_for_signal(
         "PRONTO", signal.code, signal.sig_fp, signal.byte_hash,
         "NEC:0x0007:0x02", signal.norm_fp,
@@ -322,12 +332,12 @@ def adopted_device(code: str, name: str = "Power") -> IRDevice:
 
 def test_a_wig_adopted_command_is_recognized_on_a_real_press(store):
     """A device adopted from a wig, and the real remote in someone's hand."""
-    device = adopted_device(air_code("F1"))
+    device = adopted_device(air_code("C1"), name="Cool 23")
     store._data[device.id] = device
     store._rebuild_command_index()
     ref = (device.id, device.commands[0].id)
 
-    for row in air_captures("F1", "esphome") + air_captures("F1", "broadlink"):
+    for row in air_captures("C1", "esphome") + air_captures("C1", "broadlink"):
         signal = heard(row)
         assert store.match_command(
             signal.decoded_fingerprint, signal.sig_fp, signal.byte_hash
@@ -340,13 +350,13 @@ def test_a_wig_adopted_command_is_recognized_on_a_real_press(store):
 
 def test_a_learned_command_is_not_offered_the_tier(store):
     """The same code on a device nobody adopted from a file."""
-    device = adopted_device(air_code("F1"))
+    device = adopted_device(air_code("C1"), name="Cool 23")
     device.source_wig_id = None
     device.commands[0].source = CommandSource.CAPTURED
     store._data[device.id] = device
     store._rebuild_command_index()
 
-    signal = heard(air_captures("F1", "esphome")[0])
+    signal = heard(air_captures("C1", "esphome")[0])
     assert store.match_command(
         signal.decoded_fingerprint, signal.sig_fp, signal.byte_hash,
         signal.norm_fp,
@@ -354,13 +364,13 @@ def test_a_learned_command_is_not_offered_the_tier(store):
 
 
 def test_two_file_commands_of_one_shape_match_neither(store):
-    device = adopted_device(air_code("F1"))
-    twin = adopted_device(stretched(air_code("F1")), name="Power (twin)")
+    device = adopted_device(air_code("C1"), name="Cool 23")
+    twin = adopted_device(stretched(air_code("C1")), name="Cool 23 (twin)")
     device.commands.append(twin.commands[0])
     store._data[device.id] = device
     store._rebuild_command_index()
 
-    signal = heard(air_captures("F1", "esphome")[0])
+    signal = heard(air_captures("C1", "esphome")[0])
     assert store.match_command(
         signal.decoded_fingerprint, signal.sig_fp, signal.byte_hash,
         signal.norm_fp,
@@ -423,18 +433,18 @@ def test_a_receiver_learned_trigger_never_matches_on_the_tier_alone(store):
     """
     remote = TriggerRemote(name="Sniffed remote", origin="remote")
     store._trigger_remotes[remote.id] = remote
-    trigger = wig_trigger(air_code("F1"), "Power", remote.id, origin="remote")
+    trigger = wig_trigger(
+        air_code("C1"), "Cool 23", remote.id, origin="remote"
+    )
     store._triggers[trigger.id] = trigger
 
-    for row in air_captures("F1", "esphome"):
+    for row in air_captures("C1", "esphome"):
         signal = heard(row)
         assert signal.norm_fp == norm_fingerprint_of_code(trigger.code)
         assert store.get_triggers_for_signal(
             "PRONTO", signal.code, signal.sig_fp, signal.byte_hash,
             signal.decoded_fingerprint, signal.norm_fp,
         ) == []
-
-
 def test_two_sony_buttons_still_separate_through_the_decoded_tier(store):
     """The collision the tier would cause if it were ever reached.
 
@@ -586,3 +596,65 @@ def test_a_single_frame_file_row_keeps_the_tighter_window(store):
 
     assert not is_multi_frame_code(trigger.code)
     assert not manager._is_multi_frame_file_row(trigger)
+
+
+# --- what GH #125 took off this tier ---------------------------------------
+
+
+def test_the_tail_class_was_promoted_out_of_the_tier(store):
+    """The unified strip answers one class here, and only one.
+
+    F1 is a short single-frame code whose file form and its ESPHome
+    capture differed by the trailing gap word alone. GH #125 made
+    identity end at the last real pulse, so that capture is now settled
+    at tier 2 and never consults this one -- a precision gain, since the
+    tolerant tier refuses ambiguous shapes and the byte hash does not.
+
+    Recorded rather than celebrated: it is ONE capture of fifty-one. The
+    same remote's Broadlink captures of the same button still arrive with
+    a different byte hash, because that difference is receiver
+    distortion and not a tail, and forty-five of the fifty-one air-path
+    captures still reach their file row through the normalized tier
+    alone. This tier is not on its way out.
+    """
+    remote = TriggerRemote(name="ACER", origin="closet")
+    store._trigger_remotes[remote.id] = remote
+    trigger = wig_trigger(air_code("F1"), "Power", remote.id)
+    store._triggers[trigger.id] = trigger
+
+    promoted = [
+        row for row in air_captures("F1")
+        if trigger.matches_signal(
+            heard(row).sig_fp,
+            heard(row).byte_hash,
+            heard(row).decoded_fingerprint,
+        )
+    ]
+    still_tolerant = [
+        row for row in air_captures("F1") if row not in promoted
+    ]
+
+    assert {r["transmitter"] for r in promoted} == {"esphome", "inject"}
+    assert {r["transmitter"] for r in still_tolerant} == {"broadlink"}
+
+    # The promoted capture is answered WITHOUT being handed the tier.
+    esphome = next(r for r in promoted if r["transmitter"] == "esphome")
+    signal = heard(esphome)
+    matched = store.get_triggers_for_signal(
+        "PRONTO", signal.code, signal.sig_fp, signal.byte_hash,
+        signal.decoded_fingerprint,
+    )
+    assert [t.id for t in matched] == [trigger.id]
+
+    # The others are unchanged, and still need it.
+    for row in still_tolerant:
+        signal = heard(row)
+        assert store.get_triggers_for_signal(
+            "PRONTO", signal.code, signal.sig_fp, signal.byte_hash,
+            signal.decoded_fingerprint,
+        ) == []
+        matched = store.get_triggers_for_signal(
+            "PRONTO", signal.code, signal.sig_fp, signal.byte_hash,
+            signal.decoded_fingerprint, signal.norm_fp,
+        )
+        assert [t.id for t in matched] == [trigger.id]


### PR DESCRIPTION
Raw PRONTO signals re-minted as new rows on every reload because canonical and wire identity hashed the trailing gap differently. Identity now ends at the last real pulse; stored identities recompute once at first load and the migration persists. Independently reviewed; benched on VM999 including a field reproduction on real hardware.

Reported by @philippegu56. Closes #125.