### PR TITLE
Tangles backend: findings to fixes through one guarded door

### DIFF
--- a/custom_components/hair/climate.py
+++ b/custom_components/hair/climate.py
@@ -43,6 +43,7 @@ from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
 from homeassistant.util.unit_conversion import TemperatureConverter
 
 from .const import DOMAIN, CommandSource, DeviceType
+from .matrix_store import SIGNAL_MATRIX_CHANGED
 from .models import IRDevice
 from .power_monitor import SIGNAL_POWER_VERDICT, PowerVerdict
 from .send_signal import (
@@ -185,6 +186,7 @@ class HAIRClimateEntity(RestoreEntity, ClimateEntity):
         # file I/O never runs in a constructor called on the loop).
         self._swing_mode: str | None = None
         self._matrix: ClimateMatrix | None = None
+        self._matrix_changed_unsub = None
         # Display name of the last transmitted cell ("Off"/"On" for
         # the power codes): the device page's current-cell readout
         # (owner ruling Q2). Display grammar since the second half
@@ -262,6 +264,12 @@ class HAIRClimateEntity(RestoreEntity, ClimateEntity):
         self._device_sent_unsub = async_dispatcher_connect(
             self.hass, SIGNAL_DEVICE_SENT, self._handle_device_sent
         )
+        # A repair can rewrite one cell of a live device. Without this
+        # the entity would keep transmitting the bytes it loaded at
+        # startup, which are the broken ones.
+        self._matrix_changed_unsub = async_dispatcher_connect(
+            self.hass, SIGNAL_MATRIX_CHANGED, self._handle_matrix_changed
+        )
         self._subscribe_sensors()
 
     async def async_will_remove_from_hass(self) -> None:
@@ -271,6 +279,9 @@ class HAIRClimateEntity(RestoreEntity, ClimateEntity):
         if self._device_sent_unsub is not None:
             self._device_sent_unsub()
             self._device_sent_unsub = None
+        if self._matrix_changed_unsub is not None:
+            self._matrix_changed_unsub()
+            self._matrix_changed_unsub = None
         self._unsubscribe_sensors()
 
     async def _async_restore_state(self) -> None:
@@ -728,6 +739,14 @@ class HAIRClimateEntity(RestoreEntity, ClimateEntity):
             self._target_temperature = (
                 m.min_temp + round((mid - m.min_temp) / step) * step
             )
+
+    @callback
+    def _handle_matrix_changed(self, owner_id: str) -> None:
+        """Re-read the lattice a repair just rewrote."""
+        if owner_id != self._device.id or not self._matrix_mode:
+            return
+        if self.hass is not None:
+            self.hass.async_create_task(self._async_refresh_matrix())
 
     async def _async_refresh_matrix(self) -> None:
         await self._async_load_matrix()

--- a/custom_components/hair/device_manager.py
+++ b/custom_components/hair/device_manager.py
@@ -642,6 +642,41 @@ class DeviceManager:
             origin=origin,
         )
 
+    async def async_test_send(
+        self,
+        device_id: str,
+        pronto: str,
+        *,
+        send_count: int = 1,
+        label: str = "Test",
+    ) -> set[str]:
+        """Transmit candidate bytes once, saving nothing.
+
+        The fix flow has to let somebody point a candidate at the real
+        unit BEFORE it is written anywhere -- that press is the whole
+        gate on the write. So this takes raw Pronto rather than a stored
+        command id, and there is deliberately no path from here to the
+        store: it rides the same all-emitters resilience machinery every
+        other send uses (``_async_broadcast``) and then forgets.
+
+        Raw ALWAYS, never the canonical re-encode. A candidate is being
+        judged on what it will actually transmit once written, and
+        re-encoding it from a decoded identity would test bytes the
+        device is not about to store.
+        """
+        device = self._store.get_device(device_id)
+        if device is None:
+            raise KeyError(f"Unknown device {device_id}")
+        if not device.emitter_entity_ids:
+            raise RuntimeError(f"Device {device_id} has no emitters configured")
+
+        from .ir_command import build_command
+
+        ir_cmd = build_command(protocol="PRONTO", code=pronto)
+        return await self._async_broadcast(
+            device, ir_cmd, label, send_count=max(1, min(int(send_count), 10)),
+        )
+
     async def async_send_command(
         self,
         device_id: str,

--- a/custom_components/hair/field_readers.py
+++ b/custom_components/hair/field_readers.py
@@ -421,6 +421,29 @@ def read_frames(
     the header space is longer than the frame gap, so testing the gap
     first would end the frame before it began.
     """
+    frames, _positions, unreadable = read_frames_positioned(timing, timings)
+    return frames, unreadable
+
+
+def read_frames_positioned(
+    timing: FrameTiming, timings: list[int]
+) -> tuple[list[list[int]], list[list[int]], bool]:
+    """The same walk, also reporting WHERE each bit came from.
+
+    ``positions[f][i]`` is the index of the pulse pair, in the
+    trailing-zero-stripped train, that carried bit ``i`` of frame ``f``.
+
+    This exists so a caller that has to change one field can change the
+    pulses that field actually occupies, in the code's own timings,
+    instead of rendering a fresh waveform from the map's nominal
+    windows. Reporting where a bit came from is still READING: this
+    module has no encoder, imports no transmit path, and both are
+    asserted by test. Whoever builds something with these positions
+    does it somewhere else.
+
+    ``read_frames`` is this function with the positions dropped, so
+    there is one walk and it cannot drift from itself.
+    """
     # A zero at the end of the train is Pronto saying "nothing more", not
     # a pulse of no length. Leaving it in makes the last pair of every
     # code that carries one fall outside every window, which would fail
@@ -431,9 +454,11 @@ def read_frames(
     while train and train[-1] == 0:
         train.pop()
     frames: list[list[int]] = []
+    places: list[list[int]] = []
     bits: list[int] = []
+    where: list[int] = []
     pairs = zip(train[0::2], train[1::2], strict=False)
-    for mark, space in pairs:
+    for index, (mark, space) in enumerate(pairs):
         mark_us = abs(mark)
         space_us = abs(space)
         carrier = space_us if timing.classify == "space" else mark_us
@@ -443,22 +468,32 @@ def read_frames(
             continue  # the header carries no bit
         if space_us >= timing.gap_min:
             frames.append(bits)
+            places.append(where)
             bits = []
+            where = []
             continue
         if not timing.unit.holds(other):
-            return [], True
+            return [], [], True
         if timing.zero.holds(carrier):
             bits.append(0)
+            where.append(index)
         elif timing.one.holds(carrier):
             bits.append(1)
+            where.append(index)
         else:
             # Outside every window the map states. Guessing here would
             # be a reading nobody can check, and skipping would shift
             # every bit after it.
-            return [], True
+            return [], [], True
     if bits:
         frames.append(bits)
-    return [frame for frame in frames if frame], False
+        places.append(where)
+    kept = [i for i, frame in enumerate(frames) if frame]
+    return (
+        [frames[i] for i in kept],
+        [places[i] for i in kept],
+        False,
+    )
 
 
 def bits_to_bytes(bits: list[int], bit_order: str) -> tuple[int, ...]:
@@ -575,6 +610,12 @@ def _bit_selector(bits: str) -> tuple[int, int]:
         mask = ((1 << length) - 1) << start
         return mask, start
     raise ValueError(f"unknown bit selector {bits!r}")
+
+
+#: Public name for the selector, so a caller that has to WRITE a field
+#: addresses exactly the bits this module READS it from. Two selectors
+#: would be two answers to one question.
+bit_selector = _bit_selector
 
 
 def read_field(reading: Reading, spec: FieldSpec) -> int | None:

--- a/custom_components/hair/field_readers.py
+++ b/custom_components/hair/field_readers.py
@@ -176,6 +176,12 @@ class FieldMap:
     """One protocol family: how to read its frames and what they mean."""
 
     protocol_id: str
+    #: A content tag for the map itself, so anything that recorded
+    #: "this map justified that write" can tell later whether the map
+    #: it trusted is still the map on disk. Derived from the document
+    #: rather than declared in it, because a hand-maintained version
+    #: number is exactly the field that does not get bumped.
+    version: str
     frame_layout: list[int]
     payload_frame: int
     bit_order: str
@@ -295,6 +301,19 @@ def _rule(raw: dict[str, Any]) -> IntegrityRule | None:
     )
 
 
+def _map_version(raw: dict[str, Any]) -> str:
+    """A short content digest of one map document."""
+    import hashlib
+    import json
+
+    # Document order, not sorted keys: a map's vocabulary legitimately
+    # mixes key types (YAML reads `on:` as the boolean True beside
+    # `"cool"`), and sorting those against each other raises. Order is
+    # stable for a given file, which is all a content tag needs.
+    canonical = json.dumps(raw, default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+
+
 def parse_map(raw: dict[str, Any]) -> FieldMap | None:
     """One YAML document as a map, or None when it cannot be executed."""
     if not isinstance(raw, dict):
@@ -327,6 +346,7 @@ def parse_map(raw: dict[str, Any]) -> FieldMap | None:
     ]
     return FieldMap(
         protocol_id=protocol_id,
+        version=_map_version(raw),
         frame_layout=[int(bits) for bits in layout],
         payload_frame=int(frame.get("payload_frame", 0) or 0),
         bit_order=str(frame.get("bit_order", "msb_first")),

--- a/custom_components/hair/matrix_store.py
+++ b/custom_components/hair/matrix_store.py
@@ -37,6 +37,17 @@ from .wig_format import (
 
 _LOGGER = logging.getLogger(__name__)
 
+#: One device's lattice changed underneath a live entity.
+#:
+#: Until the fix flow, matrix files only changed when a device was
+#: created, so ``climate.py`` says in as many words that a loaded matrix
+#: is never re-read. A repair breaks that assumption: it writes one cell
+#: of a device that is running, and without this the entity would go on
+#: transmitting the bytes it loaded at startup -- the broken ones, which
+#: is the entire thing the repair was for. Dispatched with the owner id
+#: after any write that is not a creation.
+SIGNAL_MATRIX_CHANGED = "hair_matrix_changed"
+
 MATRICES_DIRNAME = "hair/matrices"
 MATRIX_SUFFIX = ".matrix.json"
 

--- a/custom_components/hair/models.py
+++ b/custom_components/hair/models.py
@@ -336,7 +336,7 @@ _KNOWN_DEVICE = frozenset({
     "humidity_sensor_entity_id", "capture_device_id",
     "capture_provider_type", "commands", "entity_config", "database_id",
     "climate_matrix", "source_wig_id", "source_file", "source_remote_id",
-    "origin", "created_at", "updated_at",
+    "origin", "created_at", "updated_at", "tangle_attestations",
 })
 
 
@@ -372,6 +372,16 @@ class IRDevice:
     temperature_sensor_entity_id: str | None = None
     humidity_sensor_entity_id: str | None = None
     capture_device_id: str | None = None
+    #: The KEEP outcome of the fix flow: findings a person looked at,
+    #: tested on their own hardware, and vouched for as working anyway.
+    #:
+    #: Device-side rather than in the wig, because it is a statement
+    #: about THIS installation's hardware and not about the file. Each
+    #: record is keyed by the target's bytes and the map version that
+    #: doubted them, so it expires STRUCTURALLY: change either and the
+    #: key stops matching, the attestation stops applying, and the
+    #: finding is open again. Nothing schedules that and nothing has to.
+    tangle_attestations: list[dict[str, Any]] = field(default_factory=list)
     capture_provider_type: CaptureProviderType = CaptureProviderType.ESPHOME
     commands: list[IRCommand] = field(default_factory=list)
     entity_config: EntityConfig = field(default_factory=EntityConfig)
@@ -628,6 +638,7 @@ class IRDevice:
             "temperature_sensor_entity_id": self.temperature_sensor_entity_id,
             "humidity_sensor_entity_id": self.humidity_sensor_entity_id,
             "capture_device_id": self.capture_device_id,
+            "tangle_attestations": [dict(a) for a in self.tangle_attestations],
             "capture_provider_type": str(self.capture_provider_type),
             "commands": [c.to_dict() for c in self.commands],
             "entity_config": self.entity_config.to_dict(),
@@ -671,6 +682,12 @@ class IRDevice:
                 data.get("humidity_sensor_entity_id") or None
             ),
             capture_device_id=data.get("capture_device_id"),
+            # Absent on every device made before the fix flow existed,
+            # which reads correctly as "nobody has vouched for anything".
+            tangle_attestations=[
+                a for a in (data.get("tangle_attestations") or [])
+                if isinstance(a, dict)
+            ],
             capture_provider_type=CaptureProviderType(
                 data.get("capture_provider_type", CaptureProviderType.ESPHOME)
             ),

--- a/custom_components/hair/tangles.py
+++ b/custom_components/hair/tangles.py
@@ -1,0 +1,331 @@
+"""Tangles: the fix-flow derivation tier.
+
+The comb says what is wrong with a wig. This module says what is wrong
+with a DEVICE somebody is holding, in a shape a repair surface can act
+on: one row per target that carries a finding, each with the finding's
+own vote, the bytes it currently sends, and (from P2) where a correct
+copy of those bytes already lives.
+
+THE ROWS ARE DERIVED, NEVER STORED. Nothing here writes, nothing here
+persists, and there is no tangle record to clean up when a device is
+deleted or a repair lands. The listing is recomputed from the device's
+live state on every call, which is what makes "apply a fix and watch
+the row leave" true rather than bookkeeping.
+
+WHERE THE FINDINGS COME FROM. Not from the source wig's stored receipt.
+That receipt describes the file in the closet, and the moment a repair
+writes a cell it describes something the device no longer is; a device
+built from scratch has no receipt at all. So the device is projected
+back into a wig (the shipped exporter, ``build_wig_from_device``) and
+combed live. The comb is pure and cheap enough to run per call -- the
+whole 82-wig closet combs in seconds -- and combing what is actually
+on the device is the only reading that cannot go stale.
+
+PORTHOLE ROWS ARE EXCLUDED FROM THE PROJECTION. ``_mint_cell_rows``
+gives every comb-flagged cell a coordinate-named command so the command
+toolset reaches it, which means a flagged cell appears twice in a device:
+once in the lattice and once as a depth-0 command holding a copy of the
+same bytes. A projection that kept both would comb the same code twice
+and offer the same repair under two ids. The lattice is the authority
+for a cell, so the porthole is dropped here and the cell stands for it.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field, replace
+from typing import Any
+
+from .models import IRCommand, IRDevice
+from .wig_comb import (
+    ADVISORY_CHECKS,
+    SEVERITY_ORDER,
+    Finding,
+    comb_wig,
+)
+from .wig_export import build_wig_from_device
+from .wig_format import ClimateMatrix, cell_key, row_digest
+
+_LOGGER = logging.getLogger(__name__)
+
+#: A row addressing one lattice cell, keyed by its coordinate string.
+TARGET_CELL = "cell"
+#: A row addressing one flat command, keyed by its command id.
+TARGET_COMMAND = "command"
+
+#: Why the field tier said nothing, when it said nothing. These ride
+#: the listing so an empty field tier reads as "nobody could look"
+#: rather than as a clean bill -- the same distinction the comb's own
+#: coverage block exists to draw.
+FIELD_TIER_UNMAPPED = "protocol-unmapped"
+FIELD_TIER_NO_LATTICE = "no-lattice"
+FIELD_TIER_READ = "read"
+
+
+@dataclass(frozen=True)
+class TangleTarget:
+    """What a row is about: one lattice cell, or one flat command."""
+
+    kind: str
+    #: The comb's own key for this target -- a cell coordinate string
+    #: (``heat_cool/medium/off/19``) or the command's alias. Never
+    #: invented here: it is what the receipt would address.
+    key: str
+    command_id: str | None = None
+    #: Cell coordinates, matrix targets only. The donor search and the
+    #: guarded write both address a cell by these, never by its key.
+    coordinates: dict[str, Any] | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {"kind": self.kind, "key": self.key}
+        if self.command_id is not None:
+            out["command_id"] = self.command_id
+        if self.coordinates is not None:
+            out["coordinates"] = dict(self.coordinates)
+        return out
+
+
+@dataclass(frozen=True)
+class TangleRow:
+    """One target the comb doubts, with everything a fix needs to open.
+
+    ``findings`` carries every finding that named this target, in the
+    comb's own severity order, each with its message key and params --
+    the vote, verbatim. A row that led with only its worst class would
+    hide the cell that is both short AND lying, which is exactly the
+    pair R2 went out of its way to keep side by side.
+    """
+
+    id: str
+    target: TangleTarget
+    classes: list[str]
+    findings: list[dict[str, Any]]
+    pronto: str
+    digest: str
+    #: P2 fills these in. False here means "not searched yet"; the
+    #: listing says which sources a row does have.
+    has_donor: bool = False
+    donor: dict[str, Any] | None = None
+    #: P5 fills this in: a standing attestation covering these bytes.
+    attested: dict[str, Any] | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "target": self.target.as_dict(),
+            "classes": list(self.classes),
+            "findings": [dict(f) for f in self.findings],
+            "pronto": self.pronto,
+            "digest": self.digest,
+            "has_donor": self.has_donor,
+            "donor": dict(self.donor) if self.donor else None,
+            "attested": dict(self.attested) if self.attested else None,
+        }
+
+
+@dataclass
+class TangleListing:
+    """Every open finding on one device, plus what was looked at."""
+
+    rows: list[TangleRow] = field(default_factory=list)
+    matrix: bool = False
+    #: The comb's coverage block for this projection, verbatim.
+    coverage: dict[str, Any] | None = None
+    #: Which family read the lattice, when one did.
+    protocol: str | None = None
+    field_tier: str = FIELD_TIER_READ
+    #: Candidate sources this device can offer at all. A flat device
+    #: never gets donors in this release (frame-vote reconstruction is
+    #: 3b), and saying so is better than an empty donor field.
+    candidate_sources: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "rows": [row.as_dict() for row in self.rows],
+            "matrix": self.matrix,
+            "coverage": self.coverage,
+            "protocol": self.protocol,
+            "field_tier": self.field_tier,
+            "candidate_sources": list(self.candidate_sources),
+        }
+
+
+def row_id(kind: str, key: str) -> str:
+    """The stable reference a fix quotes back at the server."""
+    return f"{kind}:{key}"
+
+
+def is_porthole(command: IRCommand) -> bool:
+    """A command that is a view of a lattice cell, not a code of its own."""
+    return bool(getattr(command, "matrix_cell", None))
+
+
+def project_device(
+    device: IRDevice, matrix: ClimateMatrix | None
+) -> tuple[Any, dict[str, str]]:
+    """The device as a wig, plus alias -> command id for its flat rows.
+
+    Uses the shipped exporter rather than a second serializer, so a
+    tangle listing reads exactly the bytes a Save to Closet would write.
+    Porthole rows are dropped first (see the module docstring).
+    """
+    flat = [c for c in device.commands if not is_porthole(c)]
+    build = build_wig_from_device(replace(device, commands=flat), matrix)
+    if build.wig is None:
+        return None, {}
+    sources: dict[str, str] = {}
+    for signal, command_id in zip(build.wig.signals, build.sources, strict=False):
+        sources.setdefault(signal.alias, command_id)
+    return build.wig, sources
+
+
+def _order(check: str) -> int:
+    try:
+        return SEVERITY_ORDER.index(check)
+    except ValueError:
+        return len(SEVERITY_ORDER)
+
+
+def _findings_by_key(report: Any) -> dict[str, list[Finding]]:
+    """Group non-advisory findings by every key they name, worst first.
+
+    A relationship finding (duplicated neighbours, duplicate labels)
+    names its whole group, and every member of that group has something
+    to answer for, so it lands on each of their rows.
+    """
+    grouped: dict[str, list[Finding]] = {}
+    for finding in report.findings:
+        if finding.check in ADVISORY_CHECKS:
+            continue
+        for key in finding.keys:
+            grouped.setdefault(key, []).append(finding)
+    for entries in grouped.values():
+        entries.sort(key=lambda f: _order(f.check))
+    return grouped
+
+
+def _cell_digest(pronto: str) -> str:
+    """A cell's current-bytes digest.
+
+    Cells carry no dittos and are never pinned to raw (plan 5.5), so
+    the recipe is the bytes alone -- but it is still built through
+    ``row_digest`` so a cell digest and a signal digest are the same
+    kind of thing and can never drift apart.
+    """
+    return row_digest(pronto, 0, False)
+
+
+def list_tangles(
+    device: IRDevice, matrix: ClimateMatrix | None
+) -> TangleListing:
+    """Every open finding on this device, derived from its live state."""
+    wig, sources = project_device(device, matrix)
+    listing = TangleListing(matrix=matrix is not None)
+    if wig is None:
+        return listing
+
+    report = comb_wig(wig)
+    grouped = _findings_by_key(report)
+    coverage = report.coverage.to_dict() if report.coverage else None
+    listing.coverage = coverage
+    protocol = None
+    if coverage and isinstance(coverage.get("protocol"), dict):
+        protocol = coverage["protocol"].get("id")
+    listing.protocol = protocol
+
+    if matrix is None:
+        listing.field_tier = FIELD_TIER_NO_LATTICE
+        listing.candidate_sources = ["capture", "paste"]
+    elif protocol is None:
+        listing.field_tier = FIELD_TIER_UNMAPPED
+        listing.candidate_sources = ["capture", "paste"]
+    else:
+        listing.candidate_sources = ["donor", "capture", "paste"]
+
+    rows: list[TangleRow] = []
+    if matrix is not None:
+        portholes = {
+            _coord_key(command.matrix_cell): command.id
+            for command in device.commands
+            if is_porthole(command)
+        }
+        for cell in matrix.cells:
+            key = cell_key(cell)
+            findings = grouped.pop(key, None)
+            if not findings:
+                continue
+            coordinates = {
+                "mode": cell.mode, "fan": cell.fan,
+                "swing": cell.swing, "temp": cell.temp,
+            }
+            rows.append(TangleRow(
+                id=row_id(TARGET_CELL, key),
+                target=TangleTarget(
+                    kind=TARGET_CELL, key=key,
+                    command_id=portholes.get(_coord_key(coordinates)),
+                    coordinates=coordinates,
+                ),
+                classes=[f.check for f in findings],
+                findings=[f.to_dict() for f in findings],
+                pronto=cell.pronto,
+                digest=_cell_digest(cell.pronto),
+            ))
+        for key in ("off", "on"):
+            findings = grouped.pop(key, None)
+            pronto = matrix.off if key == "off" else matrix.on
+            if not findings or pronto is None:
+                continue
+            rows.append(TangleRow(
+                id=row_id(TARGET_CELL, key),
+                target=TangleTarget(
+                    kind=TARGET_CELL, key=key,
+                    coordinates={"power": key},
+                ),
+                classes=[f.check for f in findings],
+                findings=[f.to_dict() for f in findings],
+                pronto=pronto,
+                digest=_cell_digest(pronto),
+            ))
+
+    by_id = {command.id: command for command in device.commands}
+    for signal in wig.signals:
+        findings = grouped.pop(signal.alias, None)
+        if not findings:
+            continue
+        command_id = sources.get(signal.alias)
+        command = by_id.get(command_id or "")
+        rows.append(TangleRow(
+            id=row_id(TARGET_COMMAND, command_id or signal.alias),
+            target=TangleTarget(
+                kind=TARGET_COMMAND, key=signal.alias,
+                command_id=command_id,
+            ),
+            classes=[f.check for f in findings],
+            findings=[f.to_dict() for f in findings],
+            pronto=signal.pronto,
+            digest=row_digest(
+                signal.pronto,
+                signal.ditto_count,
+                signal.bypass_protocol,
+            ),
+        ))
+        if command is None:
+            _LOGGER.debug(
+                "Tangle row for %r has no command on device %s",
+                signal.alias, device.id,
+            )
+
+    listing.rows = rows
+    return listing
+
+
+def _coord_key(coordinates: Any) -> tuple:
+    """A hashable coordinate tuple, tolerant of a porthole's dict."""
+    if not isinstance(coordinates, dict):
+        return ()
+    temp = coordinates.get("temp")
+    return (
+        coordinates.get("mode"),
+        coordinates.get("fan"),
+        coordinates.get("swing"),
+        None if temp is None else float(temp),
+    )

--- a/custom_components/hair/tangles.py
+++ b/custom_components/hair/tangles.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field, replace
+from datetime import UTC
 from typing import Any
 
 from . import field_readers
@@ -705,6 +706,164 @@ def pre_read(
     if comparable:
         verdict.matches = not verdict.mismatches
     return verdict
+
+
+# ---------------------------------------------------------------------------
+# P4: the one door through the no-cell-editing wall
+# ---------------------------------------------------------------------------
+
+#: Where a repair's record lives, on the cell or on the command. Inside
+#: the object's own extras, so it rides the matrix file and the exported
+#: wig by the unknown-keys contract without a format change.
+PROVENANCE_KEY = "hair_repair"
+
+#: The write is honest about how much of it was proven on air.
+TIER_AIR_TESTED = "air-tested"
+TIER_RULE_DERIVED = "rule-derived"
+
+APPLY_NO_FINDING = "no_finding"
+APPLY_NOT_TESTED = "not_tested"
+APPLY_BAD_CANDIDATE = "bad_candidate"
+APPLY_DISAGREEMENT_UNDECLARED = "reading_disagreed_required"
+APPLY_NOTHING_TO_REVERT = "nothing_to_revert"
+
+
+def _now() -> str:
+    from datetime import datetime
+
+    return datetime.now(UTC).isoformat(timespec="seconds")
+
+
+def build_provenance(
+    *,
+    source: str,
+    prior_pronto: str,
+    lattice: LatticeReading,
+    row: TangleRow,
+    tested: bool,
+    tier: str = TIER_AIR_TESTED,
+    run: str | None = None,
+    tested_keys: list[str] | None = None,
+    detail: dict[str, Any] | None = None,
+    disagreed: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """The record a repair leaves behind, and the undo it leaves with it.
+
+    ``prior`` is the whole point: one step back lives in the record
+    rather than in a history, so a revert needs nothing but the thing it
+    is reverting.
+
+    ``tested`` is RECORDED, never verified. The server cannot see
+    somebody's air conditioner respond and must not pretend to; what it
+    can do is write down that the assertion was made, and let the
+    receipt carry it where anybody can read it.
+    """
+    record: dict[str, Any] = {
+        "origin": "fix",
+        "source": source,
+        "applied": _now(),
+        "tested": bool(tested),
+        "tier": tier,
+        "prior": {
+            "pronto": prior_pronto,
+            "digest": _cell_digest(prior_pronto),
+        },
+        "finding": {
+            "key": row.target.key,
+            "classes": list(row.classes),
+        },
+    }
+    if lattice.readable:
+        record["map"] = {
+            "id": lattice.field_map.protocol_id,
+            "version": lattice.field_map.version,
+        }
+    if run is not None:
+        record["run"] = run
+    if tested_keys:
+        record["tested_cells"] = list(tested_keys)
+    if detail:
+        record["detail"] = dict(detail)
+    if disagreed is not None:
+        # The escalation ladder's third rung. A consistent mismatch is
+        # evidence about OUR READING, not about the person pressing the
+        # button -- a remote sends what its display shows. So the write
+        # is allowed, and what it records is that a human overrode a
+        # reading and exactly what the reading said. Repeated
+        # same-family off-by-ones are how a field gets re-ratified, and
+        # they can only accumulate if they are written down.
+        record["reading_disagreed"] = {
+            "user_attested": True,
+            "reads_as": dict(disagreed.get("reads_as") or {}),
+            "claims": dict(disagreed.get("claims") or {}),
+            "mismatches": list(disagreed.get("mismatches") or []),
+        }
+    return record
+
+
+def _extras_of(holder: Any) -> dict[str, Any]:
+    if isinstance(holder, IRCommand):
+        return holder._extra
+    return holder.extra
+
+
+def write_repair(
+    holder: Any, pronto: str, provenance: dict[str, Any]
+) -> None:
+    """Put the bytes in and the record beside them."""
+    if isinstance(holder, IRCommand):
+        holder.code = pronto
+        holder.protocol = "PRONTO"
+        # The repaired bytes ARE the code. A stale raw_timings beside
+        # them would win at transmit on the raw path and quietly undo
+        # the repair.
+        holder.raw_timings = None
+    else:
+        holder.pronto = pronto
+    _extras_of(holder)[PROVENANCE_KEY] = provenance
+
+
+def read_repair(holder: Any) -> dict[str, Any] | None:
+    record = _extras_of(holder).get(PROVENANCE_KEY)
+    return record if isinstance(record, dict) else None
+
+
+def revert_repair(holder: Any) -> dict[str, Any] | None:
+    """One step back, then forget it happened.
+
+    Not a history. The record carries the bytes that were there before
+    this repair and nothing older, so reverting twice is not a thing
+    that can happen and does not need a guard that pretends otherwise.
+    """
+    record = read_repair(holder)
+    if record is None:
+        return None
+    prior = (record.get("prior") or {}).get("pronto")
+    if not isinstance(prior, str) or not prior:
+        return None
+    if isinstance(holder, IRCommand):
+        holder.code = prior
+        holder.protocol = "PRONTO"
+        holder.raw_timings = None
+    else:
+        holder.pronto = prior
+    _extras_of(holder).pop(PROVENANCE_KEY, None)
+    return record
+
+
+def portholes_for(device: IRDevice, coordinates: dict[str, Any]) -> list:
+    """Every porthole command standing for one lattice cell.
+
+    A repair has to reach these too. The porthole holds a COPY of the
+    cell's bytes taken at adopt, and it is what TEST sends and what the
+    command editor shows, so leaving it behind would give somebody a
+    button that still transmits the code they just repaired.
+    """
+    anchor = _coord_key(coordinates)
+    return [
+        command for command in device.commands
+        if is_porthole(command) and _coord_key(command.matrix_cell) == anchor
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/hair/tangles.py
+++ b/custom_components/hair/tangles.py
@@ -708,6 +708,448 @@ def pre_read(
 
 
 # ---------------------------------------------------------------------------
+# P7: witnessed-field synthesis
+# ---------------------------------------------------------------------------
+
+#: The map does not vouch for the field being rewritten.
+SYNTH_FIELD_PROVISIONAL = "field-not-ratified"
+#: The map declares an integrity rule it does not vouch for, so a
+#: recomputed frame could not be trusted even if the field could.
+SYNTH_RULE_PROVISIONAL = "integrity-rule-not-ratified"
+#: The capture does not read as the value the cluster needs. Nothing is
+#: witnessed, so nothing is synthesized.
+SYNTH_NO_WITNESS = "capture-does-not-read-as-needed"
+#: This cell has no healthy relative to build from.
+SYNTH_NO_SIBLING = "no-healthy-sibling"
+#: Nothing read the lattice, or the sibling's own bytes will not parse.
+SYNTH_UNREADABLE = "unreadable"
+
+#: Where a candidate came from, recorded in provenance and never
+#: guessed at afterwards.
+ORIGIN_DONOR = "donor"
+ORIGIN_SYNTHESIZED = "synthesized"
+ORIGIN_CAPTURE = "capture"
+ORIGIN_PASTE = "paste"
+
+
+class SynthesisBug(RuntimeError):
+    """A synthesized candidate did not read back as its own cell.
+
+    Raised, never returned. Every candidate this module builds is
+    checked against the same reader that judged the cell in the first
+    place, and a candidate that fails that check is a defect in the
+    synthesis, not a result to hand somebody.
+    """
+
+
+@dataclass
+class Synthesis:
+    """What one witnessed value could and could not build."""
+
+    candidates: dict[str, dict[str, Any]] = field(default_factory=dict)
+    declined: dict[str, str] = field(default_factory=dict)
+    #: Set when the whole run is refused before any cell is attempted.
+    refused: str | None = None
+    witness: dict[str, Any] | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "candidates": {k: dict(v) for k, v in self.candidates.items()},
+            "declined": dict(self.declined),
+            "refused": self.refused,
+            "witness": dict(self.witness) if self.witness else None,
+        }
+
+
+def _pronto_words(pronto: str) -> list[int] | None:
+    try:
+        words = [int(token, 16) for token in pronto.split()]
+    except ValueError:
+        return None
+    return words if len(words) >= 6 and words[1] > 0 else None
+
+
+def _words_to_pronto(words: list[int]) -> str:
+    return " ".join(f"{word:04X}" for word in words)
+
+
+def _carrier_index(field_map: Any, pair: int) -> int:
+    """Which word of a pulse pair carries the bit, per the map."""
+    return 5 + 2 * pair if field_map.timing.classify == "space" \
+        else 4 + 2 * pair
+
+
+def _byte_bits(value: int, bit_order: str) -> list[int]:
+    """One byte as eight bits in TRANSMISSION order.
+
+    The exact inverse of ``bits_to_bytes``'s packing, so a byte written
+    here reads back as the byte that was written.
+    """
+    if bit_order == "lsb_first":
+        return [(value >> index) & 1 for index in range(8)]
+    return [(value >> (7 - index)) & 1 for index in range(8)]
+
+
+def _exemplars(
+    field_map: Any, words: list[int], frames: list[list[int]],
+    positions: list[list[int]],
+) -> dict[int, int]:
+    """This code's OWN pulse widths for a zero and for a one.
+
+    Synthesis rewrites bits inside a real capture rather than rendering
+    a fresh waveform from the map's nominal windows, so the bits it
+    changes have to look like the bits it did not: same device, same
+    receiver, same jitter. The exemplar is the code's own median for
+    that bit value.
+
+    A code with no bit of one value falls back to the map's stated
+    window, because a value that never occurs has no exemplar to copy.
+    """
+    seen: dict[int, list[int]] = {0: [], 1: []}
+    for frame, place in zip(frames, positions, strict=True):
+        for bit, pair in zip(frame, place, strict=True):
+            index = _carrier_index(field_map, pair)
+            if index < len(words):
+                seen[bit].append(words[index])
+    out: dict[int, int] = {}
+    for bit, window in ((0, field_map.timing.zero), (1, field_map.timing.one)):
+        values = sorted(seen[bit])
+        if values:
+            out[bit] = values[len(values) // 2]
+        else:
+            nominal = window.nominal or (window.minimum + window.maximum) / 2
+            out[bit] = max(1, round(nominal / 0.241246 / words[1]))
+    return out
+
+
+def _repair_integrity(
+    field_map: Any, frames: list[list[int]]
+) -> list[list[int]]:
+    """Recompute every ratified rule the map declares, in place.
+
+    The arithmetic mirrors ``field_readers.check_integrity`` rather than
+    importing it, because that function ASKS and this one ANSWERS. The
+    coupling is pinned instead of assumed: a test recomputes and then
+    puts the result back through ``check_integrity``, so the day the two
+    drift, the suite says so.
+    """
+    out = [list(frame) for frame in frames]
+    for rule in field_map.integrity:
+        if not rule.ratified:
+            continue
+        params = rule.params
+        index = int(params.get("frame", 0) or 0)
+        if index >= len(out):
+            continue
+        frame = out[index]
+        if rule.type == "complement_pairs":
+            pairs = params.get("pairs")
+            if not pairs:
+                start = int(params.get("start", 0) or 0)
+                count = int(params.get("count", 0) or 0)
+                pairs = [
+                    [start + 2 * i, start + 2 * i + 1] for i in range(count)
+                ]
+            for low, high in pairs:
+                if max(low, high) < len(frame):
+                    frame[high] = (~frame[low]) & 0xFF
+        elif rule.type in ("checksum_sum", "nibble_sum"):
+            target = params.get("target_byte")
+            if not isinstance(target, int) or target >= len(frame):
+                continue
+            if rule.type == "checksum_sum":
+                span = params.get("range")
+                if not isinstance(span, list | tuple) or len(span) != 2:
+                    continue
+                first, last = int(span[0]), int(span[1])
+                if last >= len(frame):
+                    continue
+                modulus = int(params.get("mod", 256) or 256)
+                total = (
+                    sum(frame[first:last + 1])
+                    + int(params.get("offset", 0) or 0)
+                ) % modulus % 256
+            else:
+                nibbles = params.get("nibbles")
+                if not isinstance(nibbles, list):
+                    continue
+                total = 0
+                broken = False
+                for entry in nibbles:
+                    if not isinstance(entry, list | tuple) or len(entry) != 2:
+                        broken = True
+                        break
+                    byte_index, half = int(entry[0]), str(entry[1])
+                    if byte_index >= len(frame):
+                        broken = True
+                        break
+                    byte = frame[byte_index]
+                    total += (byte >> 4) if half in ("high", "hi") \
+                        else (byte & 0x0F)
+                if broken:
+                    continue
+                modulus = int(params.get("mod", 16) or 16)
+                total = (total + int(params.get("offset", 0) or 0)) % modulus
+            bits = params.get("bits")
+            if bits is None:
+                frame[target] = total & 0xFF
+            else:
+                try:
+                    mask, shift = field_readers.bit_selector(str(bits))
+                except ValueError:
+                    continue
+                frame[target] = (frame[target] & ~mask & 0xFF) | (
+                    (total << shift) & mask)
+        elif rule.type == "frame_repeat":
+            other = int(params.get("equals", 0) or 0)
+            if other < len(out):
+                out[index] = list(out[other])
+    return out
+
+
+def rewrite_field(
+    field_map: Any, pronto: str, spec: Any, value: int
+) -> str | None:
+    """One field rewritten inside a real capture's own timings.
+
+    NOT a rendering. The pulses this does not change are the bytes that
+    arrived from the device, untouched down to the Pronto word, and the
+    ones it does change take their width from this same code's own
+    median zero and one. That is what keeps a synthesized frame a
+    member of the family it came from rather than an idealised drawing
+    of one.
+
+    Returns None when the capture will not parse under the map.
+    """
+    words = _pronto_words(pronto)
+    if words is None:
+        return None
+    timings = field_readers.pronto_microseconds(pronto)
+    if timings is None:
+        return None
+    frames, positions, unreadable = field_readers.read_frames_positioned(
+        field_map.timing, timings
+    )
+    if unreadable or spec.frame >= len(frames):
+        return None
+    try:
+        mask, shift = field_readers.bit_selector(spec.bits)
+    except ValueError:
+        return None
+
+    before = [
+        list(field_readers.bits_to_bytes(frame, field_map.bit_order))
+        for frame in frames
+    ]
+    after = [list(frame) for frame in before]
+    if spec.byte >= len(after[spec.frame]):
+        return None
+    current = after[spec.frame][spec.byte]
+    after[spec.frame][spec.byte] = (current & ~mask & 0xFF) | (
+        (value << shift) & mask)
+    after = _repair_integrity(field_map, after)
+
+    exemplar = _exemplars(field_map, words, frames, positions)
+    for frame_index, (old_bytes, new_bytes) in enumerate(
+            zip(before, after, strict=False)):
+        place = positions[frame_index]
+        for byte_index, (old, new) in enumerate(
+                zip(old_bytes, new_bytes, strict=False)):
+            if old == new:
+                continue
+            old_bits = _byte_bits(old, field_map.bit_order)
+            new_bits = _byte_bits(new, field_map.bit_order)
+            for offset in range(8):
+                if old_bits[offset] == new_bits[offset]:
+                    continue
+                bit_index = byte_index * 8 + offset
+                if bit_index >= len(place):
+                    return None
+                word = _carrier_index(field_map, place[bit_index])
+                if word >= len(words):
+                    return None
+                words[word] = exemplar[new_bits[offset]]
+    return _words_to_pronto(words)
+
+
+def _healthy_siblings(
+    lattice: LatticeReading, target: ClimateCell, field_name: str
+) -> list[ClimateCell]:
+    """Cells identical to the target except on the rewritten axis, whose
+    own bytes agree with their own label.
+
+    A sibling that is itself lying would carry its lie into every cell
+    built from it, so the check is not "same coordinates" but "same
+    coordinates AND telling the truth".
+    """
+    axis = FIELD_COORDINATE.get(field_name)
+    if axis is None:
+        return []
+    anchor = _elsewhere(target, {field_name})
+    out = []
+    for key, candidate in lattice.cells.items():
+        if candidate is target or _elsewhere(candidate, {field_name}) != anchor:
+            continue
+        healthy = True
+        for spec in lattice.field_map.fields:
+            if not spec.ratified:
+                continue
+            claimed = _coordinate_of(candidate, spec.name)
+            if claimed is None:
+                continue
+            expected = field_readers.expected_value(spec, claimed)
+            read = lattice.reads(key, spec)
+            if expected is None or read is None:
+                continue
+            if expected != read:
+                healthy = False
+                break
+        if healthy:
+            out.append(candidate)
+    # Nearest on the rewritten axis first, then by key, so the choice is
+    # deterministic and a card built twice is built the same way.
+    target_value = _coordinate_of(target, field_name)
+
+    def _distance(cell: ClimateCell) -> tuple:
+        value = _coordinate_of(cell, field_name)
+        if isinstance(value, int | float) and isinstance(
+                target_value, int | float):
+            return (abs(float(value) - float(target_value)), cell_key(cell))
+        return (0.0, cell_key(cell))
+
+    return sorted(out, key=_distance)
+
+
+def synthesize(
+    lattice: LatticeReading,
+    rows: list[TangleRow],
+    witness_pronto: str,
+    field_name: str,
+    witness_target: str | None = None,
+) -> Synthesis:
+    """Build candidates for a cluster from ONE witnessed value.
+
+    The witness is a capture from the user's own hardware that reads as
+    the value the cluster needs. That press is what makes this legal:
+    the map could compute the same byte on its own, and deliberately is
+    not allowed to. A value nobody demonstrated is a value nobody
+    checked, and unreadable-never-guessed does not bend because the
+    arithmetic happens to be easy.
+
+    Each remaining cell is then built from its OWN healthy sibling --
+    same mode, fan and swing, a different value of the rewritten field
+    -- with only that field changed and the map's ratified rules
+    recomputed over the result.
+
+    ``witness_target`` is the row the capture was AIMED at, and only
+    that row receives the captured bytes verbatim. Matching on the
+    witnessed value alone is not enough and the first build got it
+    wrong: four cells needing 19 differ by swing, ZHLT01 marks swing
+    provisional, and handing all four the same frame produced four
+    candidates that passed their own read-back while three of them
+    carried the wrong swing. The read-back can only check what the map
+    ratifies, so the rule is structural instead -- every cell nobody
+    aimed at is built from its own sibling, which is right on every
+    axis by construction.
+    """
+    result = Synthesis()
+    if not lattice.readable:
+        result.refused = SYNTH_UNREADABLE
+        return result
+    field_map = lattice.field_map
+    spec = lattice.spec_for(field_name)
+    if spec is None or not spec.ratified:
+        result.refused = SYNTH_FIELD_PROVISIONAL
+        return result
+    if any(not rule.ratified for rule in field_map.integrity):
+        # A frame carries its own proof. If the map will not vouch for
+        # the rule that proves it, a recomputed frame is a guess wearing
+        # a checksum, and the Galanz class stays untouchable.
+        result.refused = SYNTH_RULE_PROVISIONAL
+        return result
+
+    reading = field_readers.read_code(
+        witness_pronto, [field_map], prefer=field_map.protocol_id
+    )
+    if not reading.identified:
+        result.refused = SYNTH_NO_WITNESS
+        return result
+    witnessed = field_readers.read_field(reading, spec)
+    if witnessed is None:
+        result.refused = SYNTH_NO_WITNESS
+        return result
+
+    needed = {
+        field_readers.expected_value(
+            spec, _coordinate_of(lattice.cells[row.target.key], field_name)
+        )
+        for row in rows
+        if row.target.key in lattice.cells
+    }
+    if witnessed not in needed:
+        result.refused = SYNTH_NO_WITNESS
+        return result
+
+    witness_digest = _cell_digest(witness_pronto)
+    result.witness = {
+        "digest": witness_digest,
+        "field": field_name,
+        "value": witnessed,
+        "reads_as": _label_for(
+            spec, _axis_domain(lattice, field_name), witnessed),
+    }
+
+    for row in rows:
+        cell = lattice.cells.get(row.target.key)
+        if cell is None:
+            result.declined[row.id] = SYNTH_UNREADABLE
+            continue
+        wanted = field_readers.expected_value(
+            spec, _coordinate_of(cell, field_name))
+        if wanted is None:
+            result.declined[row.id] = SYNTH_FIELD_PROVISIONAL
+            continue
+
+        if witness_target is not None and row.id == witness_target:
+            # The press was aimed here. The capture IS the candidate: a
+            # frame the user actually produced beats one derived from a
+            # sibling, and their aim is the attestation for the axes
+            # this map does not ratify and cannot check.
+            built = witness_pronto
+            origin = ORIGIN_CAPTURE
+            sibling_key = None
+        else:
+            siblings = _healthy_siblings(lattice, cell, field_name)
+            if not siblings:
+                result.declined[row.id] = SYNTH_NO_SIBLING
+                continue
+            sibling = siblings[0]  # sorted; nearest on the rewritten axis
+            sibling_key = cell_key(sibling)
+            built = rewrite_field(field_map, sibling.pronto, spec, wanted)
+            origin = ORIGIN_SYNTHESIZED
+            if built is None:
+                result.declined[row.id] = SYNTH_UNREADABLE
+                continue
+
+        verdict = pre_read(lattice, built, row.target.coordinates)
+        if verdict.matches is not True:
+            raise SynthesisBug(
+                f"synthesized candidate for {row.target.key} reads as "
+                f"{verdict.reads_as} against {verdict.claims}"
+            )
+        result.candidates[row.id] = {
+            "pronto": built,
+            "digest": _cell_digest(built),
+            "origin": origin,
+            "witness_digest": witness_digest,
+            "witness_field": field_name,
+            "sibling": sibling_key,
+            "verdict": verdict.as_dict(),
+        }
+    return result
+
+
+# ---------------------------------------------------------------------------
 # P6: causes, not findings
 # ---------------------------------------------------------------------------
 

--- a/custom_components/hair/tangles.py
+++ b/custom_components/hair/tangles.py
@@ -44,6 +44,7 @@ from .wig_comb import (
     FIELD_COORDINATE,
     POWER_FIELD,
     SEVERITY_ORDER,
+    Code,
     Coverage,
     Finding,
     comb_wig,
@@ -114,6 +115,10 @@ class TangleRow:
     #: Why the donor search came back empty, when it did. An abstention
     #: with a reason is a result; a silent None reads as "not looked at".
     donor_abstain: str | None = None
+    #: What this row's CURRENT bytes read as, against its own label.
+    #: The details view says "says Heat 18, will say Heat 19" from this
+    #: and the candidate's verdict side by side.
+    verdict: dict[str, Any] | None = None
     #: P5 fills this in: a standing attestation covering these bytes.
     attested: dict[str, Any] | None = None
 
@@ -128,6 +133,7 @@ class TangleRow:
             "has_donor": self.has_donor,
             "donor": dict(self.donor) if self.donor else None,
             "donor_abstain": self.donor_abstain,
+            "verdict": self.verdict,
             "attested": dict(self.attested) if self.attested else None,
         }
 
@@ -138,6 +144,13 @@ class TangleListing:
 
     rows: list[TangleRow] = field(default_factory=list)
     clusters: list[TangleCluster] = field(default_factory=list)
+    #: Findings the comb files as ADVISORY -- same code under two
+    #: names, and the two ditto advisories. They are not suspects and
+    #: never become rows or cards, because "these two buttons share a
+    #: code" is legitimate on a toggle remote. They are served beside
+    #: the rows so a surface that asks a person to decide has something
+    #: to show, without any of it counting as something wrong.
+    advisories: list[dict[str, Any]] = field(default_factory=list)
     matrix: bool = False
     #: The comb's coverage block for this projection, verbatim.
     coverage: dict[str, Any] | None = None
@@ -153,6 +166,7 @@ class TangleListing:
         return {
             "rows": [row.as_dict() for row in self.rows],
             "clusters": [c.as_dict() for c in self.clusters],
+            "advisories": [dict(a) for a in self.advisories],
             "matrix": self.matrix,
             "coverage": self.coverage,
             "protocol": self.protocol,
@@ -254,7 +268,11 @@ def list_tangles(
         listing.candidate_sources = ["donor", "capture", "paste"]
 
     rows: list[TangleRow] = []
-    lattice = read_lattice(matrix)
+    lattice = read_lattice(matrix, wig)
+    listing.advisories = [
+        finding.to_dict() for finding in report.findings
+        if finding.check in ADVISORY_CHECKS
+    ]
     if matrix is not None:
         portholes = {
             _coord_key(command.matrix_cell): command.id
@@ -286,6 +304,9 @@ def list_tangles(
                 has_donor=donor is not None,
                 donor=donor,
                 donor_abstain=abstain,
+                verdict=pre_read(
+                    lattice, cell.pronto, coordinates
+                ).as_dict(),
             ))
         for key in ("off", "on"):
             findings = grouped.pop(key, None)
@@ -325,6 +346,7 @@ def list_tangles(
                 signal.ditto_count,
                 signal.bypass_protocol,
             ),
+            verdict=pre_read(lattice, signal.pronto).as_dict(),
         ))
         if command is None:
             _LOGGER.debug(
@@ -385,16 +407,32 @@ class LatticeReading:
         return field_readers.read_field(reading, spec)
 
 
-def read_lattice(matrix: ClimateMatrix | None) -> LatticeReading:
-    """Decode every cell of a lattice once, under one family vote."""
-    if matrix is None:
+def read_lattice(
+    matrix: ClimateMatrix | None, wig: Any = None
+) -> LatticeReading:
+    """Decode a device's codes once, under one family vote.
+
+    A flat device is read too, and by the same vote. R2's rule five
+    stands -- integrity rules need no labels, so a flat wig whose codes
+    identify under a map gets them -- and the vote is what keeps a
+    single coincidental match from naming a family for a remote that
+    has nothing to do with it. Only the label comparison is
+    matrix-only, because a flat row carries a name, not a coordinate.
+    """
+    if matrix is not None:
+        codes = matrix_codes(matrix)
+        cells = {cell_key(cell): cell for cell in matrix.cells}
+    elif wig is not None and wig.signals:
+        codes = [
+            Code(key=signal.alias, pronto=signal.pronto)
+            for signal in wig.signals
+        ]
+        cells = {}
+    else:
         return LatticeReading()
-    codes = matrix_codes(matrix)
     field_map, readings = read_family(codes, Coverage())
     return LatticeReading(
-        field_map=field_map,
-        readings=readings,
-        cells={cell_key(cell): cell for cell in matrix.cells},
+        field_map=field_map, readings=readings, cells=cells,
     )
 
 
@@ -508,6 +546,168 @@ def find_donor(
 
 
 # ---------------------------------------------------------------------------
+# P3: reading a candidate before anything is written
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CandidateVerdict:
+    """What a candidate turns out to be, read against a target's label.
+
+    Pure. Nothing here sends, saves or decides -- it is the sentence a
+    surface shows before a person commits, and the same sentence the
+    guarded write records when they commit anyway.
+    """
+
+    #: Field name -> the label these bytes read as, in the wig's own
+    #: words. This is what "reads as: Heat / Fan High / 19" is built
+    #: from; a byte value is not something to show anybody.
+    reads_as: dict[str, Any] = field(default_factory=dict)
+    #: Field name -> the label the target CLAIMS.
+    claims: dict[str, Any] = field(default_factory=dict)
+    #: The same two, unrendered, for the record.
+    raw_read: dict[str, int] = field(default_factory=dict)
+    raw_expected: dict[str, int] = field(default_factory=dict)
+    #: Fields where the two disagree. Empty is a match.
+    mismatches: list[str] = field(default_factory=list)
+    #: None when there is no label to compare against (a flat command,
+    #: an unmapped lattice). NOT the same as False.
+    matches: bool | None = None
+    protocol: str | None = None
+    declined: str | None = None
+    #: Rule type -> True, False, or None for a rule that could not be
+    #: evaluated. A rule that cannot be evaluated is never a pass.
+    integrity: dict[str, bool | None] = field(default_factory=dict)
+    #: R1's frame check on the candidate itself, when it disagrees.
+    frame_vote: dict[str, Any] | None = None
+    #: Decoded identity, where a TX decoder recognises the capture. The
+    #: only read-back a flat command has.
+    decoded: dict[str, Any] | None = None
+
+    @property
+    def readable(self) -> bool:
+        return self.protocol is not None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "reads_as": dict(self.reads_as),
+            "claims": dict(self.claims),
+            "raw_read": dict(self.raw_read),
+            "raw_expected": dict(self.raw_expected),
+            "mismatches": list(self.mismatches),
+            "matches": self.matches,
+            "protocol": self.protocol,
+            "declined": self.declined,
+            "integrity": dict(self.integrity),
+            "frame_vote": self.frame_vote,
+            "decoded": dict(self.decoded) if self.decoded else None,
+        }
+
+
+def _frame_vote(pronto: str) -> dict[str, Any] | None:
+    """R1's own check, on the candidate itself.
+
+    A capture whose repeats disagree is a bad capture whatever it reads
+    as, and saying so while the remote is still in somebody's hand is
+    the whole point of the check.
+    """
+    from .wig_comb import frame_disagreement
+
+    vote = frame_disagreement(pronto)
+    return None if vote is None else vote.as_dict()
+
+
+def _decoded_identity(pronto: str) -> dict[str, Any] | None:
+    from .ir_command import ProntoCommand
+    from .protocol_decode import try_decode_identity
+
+    try:
+        timings = ProntoCommand(pronto).get_raw_timings()
+    except Exception:
+        return None
+    identity = try_decode_identity(timings)
+    if identity is None:
+        return None
+    return {
+        "protocol": identity.protocol,
+        "address": identity.address,
+        "command": identity.command,
+        "fingerprint": identity.fingerprint,
+    }
+
+
+def pre_read(
+    lattice: LatticeReading,
+    pronto: str,
+    coordinates: dict[str, Any] | None = None,
+) -> CandidateVerdict:
+    """Read a candidate's fields and compare them to a target's label.
+
+    ``coordinates`` is the cell this candidate is proposed FOR. Without
+    them (a flat command, or a listen that is not yet aimed anywhere)
+    the read still happens and still reports what the bytes say -- there
+    is simply no claim to check it against, and ``matches`` stays None
+    rather than becoming a False nobody can justify.
+    """
+    verdict = CandidateVerdict(
+        frame_vote=_frame_vote(pronto),
+        decoded=_decoded_identity(pronto),
+    )
+    if not lattice.readable:
+        verdict.declined = field_readers.NO_MAP
+        return verdict
+
+    field_map = lattice.field_map
+    reading = field_readers.read_code(
+        pronto, [field_map], prefer=field_map.protocol_id
+    )
+    if not reading.identified:
+        verdict.declined = reading.declined or field_readers.NO_MAP
+        return verdict
+    verdict.protocol = reading.protocol_id
+
+    for rule in field_map.integrity:
+        if not rule.ratified:
+            continue
+        verdict.integrity[rule.type] = field_readers.check_integrity(
+            reading, rule
+        )
+
+    comparable = []
+    for spec in field_map.fields:
+        if not spec.ratified:
+            continue
+        value = field_readers.read_field(reading, spec)
+        if value is None:
+            continue
+        verdict.raw_read[spec.name] = value
+        domain = _axis_domain(lattice, spec.name)
+        label = _label_for(spec, domain, value)
+        if label is not None:
+            verdict.reads_as[spec.name] = label
+        if coordinates is None:
+            continue
+        axis = FIELD_COORDINATE.get(spec.name)
+        claimed = (
+            coordinates.get(POWER_FIELD, "on") if spec.name == POWER_FIELD
+            else (None if axis is None else coordinates.get(axis))
+        )
+        if claimed is None:
+            continue
+        expected = field_readers.expected_value(spec, claimed)
+        if expected is None:
+            continue
+        verdict.claims[spec.name] = claimed
+        verdict.raw_expected[spec.name] = expected
+        comparable.append(spec.name)
+        if expected != value:
+            verdict.mismatches.append(spec.name)
+    if comparable:
+        verdict.matches = not verdict.mismatches
+    return verdict
+
+
+# ---------------------------------------------------------------------------
 # P6: causes, not findings
 # ---------------------------------------------------------------------------
 
@@ -594,6 +794,11 @@ def _axis_domain(lattice: LatticeReading, field_name: str) -> list[Any]:
     label this file does not contain is not a label this file can be
     said to read as.
     """
+    if field_name == POWER_FIELD:
+        # Power has no lattice axis -- it is the difference between the
+        # cells and the off code -- so its domain is stated rather than
+        # gathered, and the read-back can name it like any other field.
+        return ["on", "off"]
     axis = FIELD_COORDINATE.get(field_name)
     if axis is None:
         return []

--- a/custom_components/hair/tangles.py
+++ b/custom_components/hair/tangles.py
@@ -152,6 +152,9 @@ class TangleListing:
     #: the rows so a surface that asks a person to decide has something
     #: to show, without any of it counting as something wrong.
     advisories: list[dict[str, Any]] = field(default_factory=list)
+    #: Rows a person has already answered with KEEP. Off the work list,
+    #: still on the record.
+    attested: list[dict[str, Any]] = field(default_factory=list)
     matrix: bool = False
     #: The comb's coverage block for this projection, verbatim.
     coverage: dict[str, Any] | None = None
@@ -168,6 +171,7 @@ class TangleListing:
             "rows": [row.as_dict() for row in self.rows],
             "clusters": [c.as_dict() for c in self.clusters],
             "advisories": [dict(a) for a in self.advisories],
+            "attested": [dict(a) for a in self.attested],
             "matrix": self.matrix,
             "coverage": self.coverage,
             "protocol": self.protocol,
@@ -355,8 +359,25 @@ def list_tangles(
                 signal.alias, device.id,
             )
 
-    listing.rows = rows
-    listing.clusters = cluster_rows(rows, lattice)
+    # An attested row has been ANSWERED: somebody looked at it, tested
+    # it on their own hardware and vouched for it. It leaves the work
+    # list and is reported separately, because a card offering to repair
+    # something a person already settled is the surface nagging.
+    #
+    # The finding itself is untouched. Keep never deletes a finding, and
+    # the receipt still carries it -- attested is a different thing from
+    # clean and has to read as one.
+    answered = []
+    open_rows = []
+    for row in rows:
+        record = standing_attestation(device, row, lattice)
+        if record is None:
+            open_rows.append(row)
+            continue
+        answered.append(replace(row, attested=record))
+    listing.rows = open_rows
+    listing.attested = [row.as_dict() for row in answered]
+    listing.clusters = cluster_rows(open_rows, lattice)
     return listing
 
 
@@ -891,6 +912,84 @@ def portholes_for(device: IRDevice, coordinates: dict[str, Any]) -> list:
         command for command in device.commands
         if is_porthole(command) and _coord_key(command.matrix_cell) == anchor
     ]
+
+
+# ---------------------------------------------------------------------------
+# P5: the KEEP outcome
+# ---------------------------------------------------------------------------
+
+KEEP_NO_FINDING = "no_finding"
+KEEP_NOT_TESTED = "not_tested"
+
+#: Where a carried attestation waits between the exporter and the comb
+#: receipt it belongs in. Removed as soon as the receipt is stamped.
+ATTESTED_PENDING = "comb_attested_pending"
+#: The block inside the receipt.
+ATTESTED_KEY = "attested"
+
+
+def attestation_key(
+    target_key: str, digest: str, map_version: str | None
+) -> str:
+    """What an attestation is ABOUT, expressed so it can expire itself.
+
+    The bytes and the map that doubted them. Change either and this key
+    stops matching, the attestation stops applying, and the finding is
+    open again -- which is the whole expiry mechanism. Nothing is
+    scheduled, nothing is swept, and there is no state that can be
+    wrong: an attestation that does not apply simply does not match.
+    """
+    return f"{target_key}|{digest}|{map_version or '-'}"
+
+
+def build_attestation(
+    row: TangleRow, lattice: LatticeReading, *, note: str | None = None
+) -> dict[str, Any]:
+    """A person's answer to a finding: looked at it, it works, keep it."""
+    version = lattice.field_map.version if lattice.readable else None
+    record: dict[str, Any] = {
+        "key": attestation_key(row.target.key, row.digest, version),
+        "target": row.target.key,
+        "kind": row.target.kind,
+        "digest": row.digest,
+        "classes": list(row.classes),
+        "tested": True,
+        "attested": _now(),
+    }
+    if lattice.readable:
+        record["map"] = {
+            "id": lattice.field_map.protocol_id, "version": version,
+        }
+    if note:
+        record["note"] = note
+    return record
+
+
+def standing_attestation(
+    device: IRDevice, row: TangleRow, lattice: LatticeReading
+) -> dict[str, Any] | None:
+    """The attestation covering this row's CURRENT bytes, if any."""
+    version = lattice.field_map.version if lattice.readable else None
+    wanted = attestation_key(row.target.key, row.digest, version)
+    for record in device.tangle_attestations:
+        if record.get("key") == wanted:
+            return record
+    return None
+
+
+def carry_attestations(wig: Any, device: IRDevice) -> None:
+    """Park the device's attestations where the re-comb will find them.
+
+    A wig leaving for the closet gets a fresh receipt, and the receipt
+    is where an attestation belongs: the file then carries both the
+    math and the human's answer, and the shop's own re-derive sees
+    both. Parked rather than stamped because the receipt does not exist
+    yet at export time -- ``recomb`` writes it, and folds this in.
+    """
+    if device.tangle_attestations:
+        wig.extra[ATTESTED_PENDING] = [
+            dict(record) for record in device.tangle_attestations
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/hair/tangles.py
+++ b/custom_components/hair/tangles.py
@@ -742,6 +742,22 @@ PROVENANCE_KEY = "hair_repair"
 TIER_AIR_TESTED = "air-tested"
 TIER_RULE_DERIVED = "rule-derived"
 
+#: Stamped in a minted wig's ``extra`` when the repair write-through
+#: (C10) is what minted it. The write-through reads it back off the
+#: device's current source before deciding whether it may supersede,
+#: which is the whole guard: this machinery deletes only files it
+#: wrote itself. A person's own wig -- the contributor's original, a
+#: hand-saved copy -- never carries the stamp, so the first repair on
+#: an adopted device always mints BESIDE the original and leaves it
+#: standing, and only later repairs replace the version before them.
+REPAIR_SUCCESSOR = "hair_repair_successor"
+
+#: What a write-through reports when there was no wig to write to.
+#: Not a failure: a device built from scratch has no source, and
+#: saying so is the honest answer rather than an error the caller has
+#: to special-case.
+WROTE_NOT_ADOPTED = "not-adopted"
+
 APPLY_NO_FINDING = "no_finding"
 APPLY_NOT_TESTED = "not_tested"
 APPLY_BAD_CANDIDATE = "bad_candidate"

--- a/custom_components/hair/tangles.py
+++ b/custom_components/hair/tangles.py
@@ -39,6 +39,7 @@ from . import field_readers
 from .models import IRCommand, IRDevice
 from .wig_comb import (
     ADVISORY_CHECKS,
+    CHECK_DUPLICATED_NEIGHBOUR,
     CHECK_FIELD_MISMATCH,
     FIELD_COORDINATE,
     POWER_FIELD,
@@ -136,6 +137,7 @@ class TangleListing:
     """Every open finding on one device, plus what was looked at."""
 
     rows: list[TangleRow] = field(default_factory=list)
+    clusters: list[TangleCluster] = field(default_factory=list)
     matrix: bool = False
     #: The comb's coverage block for this projection, verbatim.
     coverage: dict[str, Any] | None = None
@@ -150,6 +152,7 @@ class TangleListing:
     def as_dict(self) -> dict[str, Any]:
         return {
             "rows": [row.as_dict() for row in self.rows],
+            "clusters": [c.as_dict() for c in self.clusters],
             "matrix": self.matrix,
             "coverage": self.coverage,
             "protocol": self.protocol,
@@ -251,8 +254,8 @@ def list_tangles(
         listing.candidate_sources = ["donor", "capture", "paste"]
 
     rows: list[TangleRow] = []
+    lattice = read_lattice(matrix)
     if matrix is not None:
-        lattice = read_lattice(matrix)
         portholes = {
             _coord_key(command.matrix_cell): command.id
             for command in device.commands
@@ -330,6 +333,7 @@ def list_tangles(
             )
 
     listing.rows = rows
+    listing.clusters = cluster_rows(rows, lattice)
     return listing
 
 
@@ -501,6 +505,250 @@ def find_donor(
             },
         }, None
     return None, ABSTAIN_NO_READING
+
+
+# ---------------------------------------------------------------------------
+# P6: causes, not findings
+# ---------------------------------------------------------------------------
+
+#: The same field wrong by the same STEP across many cells. A shifted
+#: column is one mistake, not one mistake per cell, and this is the rule
+#: that says so.
+CLUSTER_SHIFT = "same-shift"
+#: The same field reading the same wrong value, where the step between
+#: label and reading cannot be expressed (a non-numeric axis, or a
+#: reading whose label this lattice does not contain).
+CLUSTER_READING = "same-reading"
+#: Codes that are byte-identical where the lattice says they should
+#: differ. The copy-paste class.
+CLUSTER_IDENTICAL = "identical-bytes"
+#: Same class, same field, nothing else in common.
+CLUSTER_FIELD = "same-field"
+#: Whatever refuses to cluster. Never invented structure.
+CLUSTER_SINGLETON = "singleton"
+
+_CLUSTER_ORDER = (
+    CLUSTER_SHIFT,
+    CLUSTER_READING,
+    CLUSTER_IDENTICAL,
+    CLUSTER_FIELD,
+    CLUSTER_SINGLETON,
+)
+
+#: Every member already has a correct copy of its bytes elsewhere in
+#: the lattice: the card can offer a repair outright.
+MECHANIC_DONOR = "donor"
+#: No donor, but the field is one the map vouches for, so one capture
+#: that reads as the missing value can seed the rest (P7).
+MECHANIC_WITNESS = "witness"
+#: Nothing can be derived. Press the button again, or paste.
+MECHANIC_RECAPTURE = "recapture"
+
+
+@dataclass(frozen=True)
+class TangleCluster:
+    """One CAUSE, and the one action that answers it.
+
+    Two axes decide a card. The cause says why these targets are wrong
+    together; the mechanic says what can be done about them. They are
+    both needed because a single cause can straddle two roads -- the
+    Komeco column is one shift, but the cells at the bottom of its range
+    have nothing to copy from and have to be witnessed instead, and a
+    card has one primary action or it is not a card.
+    """
+
+    id: str
+    rule: str
+    #: The cause this card belongs to. Cards that share it are the same
+    #: mistake reached by different roads.
+    cause: str
+    mechanic: str
+    #: The finding class every member leads with.
+    check: str
+    field: str | None
+    members: list[str]
+    detail: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def size(self) -> int:
+        return len(self.members)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "rule": self.rule,
+            "cause": self.cause,
+            "mechanic": self.mechanic,
+            "check": self.check,
+            "field": self.field,
+            "members": list(self.members),
+            "size": self.size,
+            "detail": dict(self.detail),
+        }
+
+
+def _axis_domain(lattice: LatticeReading, field_name: str) -> list[Any]:
+    """Every value this lattice actually uses on one field's axis.
+
+    The domain comes from the wig, never from the map's vocabulary: a
+    label this file does not contain is not a label this file can be
+    said to read as.
+    """
+    axis = FIELD_COORDINATE.get(field_name)
+    if axis is None:
+        return []
+    seen = []
+    for cell in lattice.cells.values():
+        value = getattr(cell, axis, None)
+        if value is not None and value not in seen:
+            seen.append(value)
+    return sorted(seen, key=lambda v: (isinstance(v, str), v))
+
+
+def _label_for(spec: Any, domain: list[Any], value: int) -> Any:
+    """Which label encodes to this byte, or None.
+
+    The inverse of ``expected_value``, done by asking the map to encode
+    each label this lattice uses and seeing which one lands. No
+    arithmetic is inverted, so an encoding as awkward as ZHLT01's
+    reversed nibble costs nothing.
+    """
+    for label in domain:
+        if field_readers.expected_value(spec, label) == value:
+            return label
+    return None
+
+
+def _cause_of(
+    row: TangleRow, lattice: LatticeReading
+) -> tuple[str, tuple, str | None, dict[str, Any]]:
+    """The rule that claims this row, its cause key, field and detail.
+
+    Rules are tried in the brief's order and the row's LEADING class
+    decides which are eligible: a cell that is both a duplicate and a
+    mismatch is a duplicate first, because that is the finding the comb
+    ranks higher and the one whose repair is different in kind.
+    """
+    leading = row.classes[0] if row.classes else CLUSTER_SINGLETON
+
+    if leading == CHECK_FIELD_MISMATCH:
+        fields = _mismatched_fields(row.findings)
+        name = fields[0] if fields else None
+        params = row.findings[0].get("params", {})
+        expected, read = params.get("expected"), params.get("read")
+        spec = lattice.spec_for(name) if name else None
+        if spec is not None and expected is not None and read is not None:
+            domain = _axis_domain(lattice, name)
+            claimed = _label_for(spec, domain, int(str(expected), 16))
+            actual = _label_for(spec, domain, int(str(read), 16))
+            if isinstance(claimed, int | float) and isinstance(
+                    actual, int | float):
+                step = float(actual) - float(claimed)
+                return CLUSTER_SHIFT, (CLUSTER_SHIFT, name, step), name, {
+                    "field": name, "step": step,
+                }
+            if claimed is not None and actual is not None:
+                return CLUSTER_READING, (
+                    CLUSTER_READING, name, str(claimed), str(actual),
+                ), name, {"field": name, "claimed": claimed,
+                          "reads_as": actual}
+        if name is not None and expected is not None and read is not None:
+            return CLUSTER_READING, (
+                CLUSTER_READING, name, str(expected), str(read),
+            ), name, {"field": name, "expected": expected, "read": read}
+        if name is not None:
+            return CLUSTER_FIELD, (CLUSTER_FIELD, name), name, {
+                "field": name}
+
+    if leading == CHECK_DUPLICATED_NEIGHBOUR:
+        return CLUSTER_IDENTICAL, (
+            CLUSTER_IDENTICAL, row.digest,
+        ), None, {"digest": row.digest}
+
+    return CLUSTER_SINGLETON, (
+        CLUSTER_SINGLETON, row.id,
+    ), None, {}
+
+
+def _mechanic(row: TangleRow, lattice: LatticeReading) -> str:
+    if row.has_donor:
+        return MECHANIC_DONOR
+    if (
+        row.target.kind == TARGET_CELL
+        and row.donor_abstain == ABSTAIN_NO_READING
+        and lattice.readable
+    ):
+        # The search reached the end of a readable lattice on a field
+        # the map vouches for and found nothing. That is exactly the
+        # case a witnessed capture answers.
+        return MECHANIC_WITNESS
+    return MECHANIC_RECAPTURE
+
+
+def _best_mechanic(found: list[str]) -> str:
+    """The strongest road any member of a card can take."""
+    for mechanic in (MECHANIC_DONOR, MECHANIC_WITNESS, MECHANIC_RECAPTURE):
+        if mechanic in found:
+            return mechanic
+    return MECHANIC_RECAPTURE
+
+
+def cluster_rows(
+    rows: list[TangleRow], lattice: LatticeReading
+) -> list[TangleCluster]:
+    """Group a listing's rows into causes, deterministically.
+
+    Pure, and stable for unchanged inputs: every id is built from the
+    cause itself rather than from a counter, so the same lattice yields
+    the same cards in the same order on any install and after any
+    restart.
+    """
+    buckets: dict[tuple, list[TangleRow]] = {}
+    meta: dict[tuple, tuple[str, str | None, dict[str, Any]]] = {}
+    mechanics: dict[tuple, list[str]] = {}
+    for row in rows:
+        rule, cause, field_name, detail = _cause_of(row, lattice)
+        mechanic = _mechanic(row, lattice)
+        # A cause whose repair is per-target splits by road, because a
+        # card has ONE primary action: the Komeco column is one shift,
+        # but its bottom four have nothing to copy from and have to be
+        # witnessed instead. A byte-identical group does NOT split --
+        # its whole point is to list every location that carries the
+        # same code, and the answer is about the group, not the member.
+        key = cause if rule == CLUSTER_IDENTICAL else (*cause, mechanic)
+        buckets.setdefault(key, []).append(row)
+        meta.setdefault(key, (rule, field_name, detail))
+        mechanics.setdefault(key, []).append(mechanic)
+
+    clusters: list[TangleCluster] = []
+    for key, members in buckets.items():
+        rule, field_name, detail = meta[key]
+        mechanic = _best_mechanic(mechanics[key])
+        spans = {
+            axis: sorted({
+                str((row.target.coordinates or {}).get(axis))
+                for row in members
+                if (row.target.coordinates or {}).get(axis) is not None
+            })
+            for axis in ("mode", "fan", "swing")
+        }
+        clusters.append(TangleCluster(
+            id=":".join(str(part) for part in key),
+            rule=rule,
+            cause=":".join(str(part) for part in key[:-1]),
+            mechanic=mechanic,
+            check=members[0].classes[0] if members[0].classes else "",
+            field=field_name,
+            members=[row.id for row in members],
+            detail={**detail, "spans": {k: v for k, v in spans.items() if v}},
+        ))
+    clusters.sort(key=lambda c: (
+        _CLUSTER_ORDER.index(c.rule) if c.rule in _CLUSTER_ORDER
+        else len(_CLUSTER_ORDER),
+        -c.size,
+        c.id,
+    ))
+    return clusters
 
 
 def _coord_key(coordinates: Any) -> tuple:

--- a/custom_components/hair/tangles.py
+++ b/custom_components/hair/tangles.py
@@ -801,10 +801,37 @@ def build_provenance(
     return record
 
 
-def _extras_of(holder: Any) -> dict[str, Any]:
+def repair_extras(holder: Any) -> dict[str, Any]:
+    """The unknown-keys bag a repair record lives in.
+
+    A cell and a command keep theirs under different names, and asking
+    with ``or`` rather than by type is how a cell with an EMPTY extras
+    dict falls through to the attribute it does not have.
+    """
     if isinstance(holder, IRCommand):
         return holder._extra
     return holder.extra
+
+
+def repair_bytes(holder: Any) -> str:
+    """Whatever this holder currently transmits."""
+    return holder.code if isinstance(holder, IRCommand) else holder.pronto
+
+
+def restore_holder(
+    holder: Any, pronto: str, extras: dict[str, Any]
+) -> None:
+    """Put a holder back exactly as it was, bytes and record together."""
+    if isinstance(holder, IRCommand):
+        holder.code = pronto
+    else:
+        holder.pronto = pronto
+    bag = repair_extras(holder)
+    bag.clear()
+    bag.update(extras)
+
+
+_extras_of = repair_extras
 
 
 def write_repair(
@@ -864,6 +891,154 @@ def portholes_for(device: IRDevice, coordinates: dict[str, Any]) -> list:
         command for command in device.commands
         if is_porthole(command) and _coord_key(command.matrix_cell) == anchor
     ]
+
+
+# ---------------------------------------------------------------------------
+# P8: one cause, one run
+# ---------------------------------------------------------------------------
+
+BATCH_EMPTY = "nothing_to_apply"
+BATCH_SAMPLE_SHORT = "sample_incomplete"
+BATCH_NO_CANDIDATE = "no_candidate"
+
+#: How many cells a run proves on air before writing the rest. Two,
+#: chosen to span the card's modes -- the same philosophy as a dimension
+#: check, which attests axes rather than walking 600 cells.
+DEFAULT_SAMPLE = 2
+
+
+def choose_sample(
+    rows: dict[str, TangleRow], members: list[str], size: int = DEFAULT_SAMPLE
+) -> list[str]:
+    """Which members of a card get pressed at, in a stable order.
+
+    Modes first: a card that spans heating and cooling proves one of
+    each before it writes either, because a rule that holds in one mode
+    is exactly the kind of thing that does not hold in the other. Once
+    every mode is represented the remaining picks spread across the
+    card, and a single-member card tests that member.
+
+    Deterministic, so the sample a person was asked to press is the
+    sample the write then records.
+    """
+    ordered = sorted(m for m in members if m in rows)
+    if not ordered:
+        return []
+    by_mode: dict[Any, list[str]] = {}
+    for member in ordered:
+        mode = (rows[member].target.coordinates or {}).get("mode")
+        by_mode.setdefault(mode, []).append(member)
+
+    picked: list[str] = [group[0] for group in by_mode.values()]
+    if len(picked) < size:
+        spare = [m for m in ordered if m not in picked]
+        # From the far end first, so a shifted column is proved at both
+        # ends rather than twice at the same corner.
+        while spare and len(picked) < size:
+            picked.append(spare.pop(-1))
+    return sorted(picked[:max(1, size)] if len(picked) > size else picked)
+
+
+def sample_covers_modes(
+    rows: dict[str, TangleRow], members: list[str], tested: list[str]
+) -> bool:
+    """Every mode this card touches was proved on air by something."""
+    def _modes(ids: list[str]) -> set:
+        return {
+            (rows[i].target.coordinates or {}).get("mode")
+            for i in ids if i in rows
+        }
+
+    return _modes(members) <= _modes(tested)
+
+
+@dataclass
+class BatchPlan:
+    """What one run is about to do, before anybody presses anything."""
+
+    cluster: str
+    candidates: dict[str, dict[str, Any]] = field(default_factory=dict)
+    sample: list[str] = field(default_factory=list)
+    declined: dict[str, str] = field(default_factory=dict)
+    refused: str | None = None
+    witness: dict[str, Any] | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "cluster": self.cluster,
+            "candidates": {k: dict(v) for k, v in self.candidates.items()},
+            "sample": list(self.sample),
+            "declined": dict(self.declined),
+            "refused": self.refused,
+            "witness": dict(self.witness) if self.witness else None,
+        }
+
+
+def plan_batch(
+    listing: TangleListing,
+    lattice: LatticeReading,
+    cluster_id: str,
+    *,
+    witness: str | None = None,
+    witness_target: str | None = None,
+    supplied: dict[str, str] | None = None,
+    sample_size: int = DEFAULT_SAMPLE,
+) -> BatchPlan:
+    """Resolve every member's candidate, then choose what to prove.
+
+    THE WHOLE CARD IS RESOLVED BEFORE ANYTHING IS WRITTEN. On a shifted
+    column the correct bytes for one cell are the bytes the cell below
+    it is carrying right now, so resolving as you write would walk the
+    shift down the column and hand back codes it had just replaced.
+    """
+    rows = {row.id: row for row in listing.rows}
+    cluster = next(
+        (c for c in listing.clusters if c.id == cluster_id), None)
+    if cluster is None:
+        return BatchPlan(cluster=cluster_id, refused=BATCH_EMPTY)
+    plan = BatchPlan(cluster=cluster_id)
+    members = [m for m in cluster.members if m in rows]
+
+    if witness is not None:
+        result = synthesize(
+            lattice, [rows[m] for m in members], witness,
+            cluster.field or "temperature", witness_target=witness_target,
+        )
+        if result.refused:
+            plan.refused = result.refused
+            return plan
+        plan.witness = result.witness
+        plan.declined.update(result.declined)
+        for member, candidate in result.candidates.items():
+            plan.candidates[member] = candidate
+    for member in members:
+        if member in plan.candidates:
+            continue
+        pronto = (supplied or {}).get(member)
+        source = ORIGIN_PASTE
+        detail: dict[str, Any] = {}
+        if pronto is None and rows[member].has_donor:
+            pronto = rows[member].donor["pronto"]
+            source = ORIGIN_DONOR
+            detail = {"donor": rows[member].donor["key"]}
+        if pronto is None:
+            plan.declined[member] = BATCH_NO_CANDIDATE
+            continue
+        plan.candidates[member] = {
+            "pronto": pronto,
+            "digest": _cell_digest(pronto),
+            "origin": source,
+            "verdict": pre_read(
+                lattice, pronto, rows[member].target.coordinates
+            ).as_dict(),
+            **detail,
+        }
+    if not plan.candidates:
+        plan.refused = BATCH_EMPTY
+        return plan
+    plan.sample = choose_sample(
+        rows, list(plan.candidates), size=sample_size)
+    return plan
 
 
 # ---------------------------------------------------------------------------
@@ -1411,6 +1586,65 @@ def _axis_domain(lattice: LatticeReading, field_name: str) -> list[Any]:
     return sorted(seen, key=lambda v: (isinstance(v, str), v))
 
 
+def _ring_domain(lattice: LatticeReading, field_name: str) -> list[Any]:
+    """The domain a step is counted around: one label per byte value.
+
+    ``_axis_domain`` answers "what values does this file use", which is
+    the right question for reading a byte back as a label. It is the
+    wrong one for measuring a shift, because a lattice can carry two
+    labels that encode to the SAME byte -- the Komeco file has both 16
+    and 32, and ZHLT01's special case sends them identically. Counting
+    positions around a domain with a duplicate in it puts the wrap one
+    step out and splits one cause into two.
+
+    So the ring keeps the first label that claims each byte and drops
+    the rest. What is left is the field's own cycle.
+    """
+    spec = lattice.spec_for(field_name)
+    if spec is None:
+        return []
+    seen: set[int] = set()
+    domain: list[Any] = []
+    for label in _axis_domain(lattice, field_name):
+        value = field_readers.expected_value(spec, label)
+        if value is None or value in seen:
+            continue
+        seen.add(value)
+        domain.append(label)
+    return domain
+
+
+def _ring_step(domain: list[Any], claimed: Any, actual: Any) -> int | None:
+    """How far a reading sits from its label, in positions on the ring.
+
+    Counted the shorter way around, because a field is a fixed number of
+    bits and its top wraps to its bottom: a column that sends one step
+    high sends 20 for 19 AND 16 for 31, and those are the same mistake
+    arriving at the end of the domain.
+
+    This is not a tidier way to say it. Split into two causes, the cells
+    at the top of the range draw their donor from a cell the other cause
+    owns -- and whichever runs first destroys the only copy of the bytes
+    the other needed, or leaves a byte-identical twin at the seam that
+    reclassifies the cell out of its own card. The chain is one cause
+    and has to be repaired in one run.
+
+    The shorter way around also keeps a genuine long shift honest: a
+    reading seven positions down stays -7 rather than folding into +9.
+    """
+    if claimed is None or actual is None:
+        return None
+    try:
+        here, there = domain.index(claimed), domain.index(actual)
+    except ValueError:
+        return None
+    size = len(domain)
+    if size < 2:
+        return None
+    step = (there - here) % size
+    return step - size if step > size // 2 else step
+
+
 def _label_for(spec: Any, domain: list[Any], value: int) -> Any:
     """Which label encodes to this byte, or None.
 
@@ -1425,6 +1659,42 @@ def _label_for(spec: Any, domain: list[Any], value: int) -> Any:
     return None
 
 
+def _donor_debts(
+    rows: dict[str, TangleRow], clusters: list[TangleCluster]
+) -> dict[str, set[str]]:
+    """Which cards hand donors to which other cards.
+
+    Cards are not always independent, and the Komeco lattice shows why.
+    The cells at the TOP of its range draw their donor from the cell one
+    step below them -- which belongs to the big card. Apply the big card
+    first and that donor is overwritten, destroying the only copy of the
+    bytes the top cells needed; the top card then has nothing to copy
+    from and degrades to asking for a press.
+
+    Nothing is corrupted either way, which is why this is an ordering
+    and not a guard. But a card that quietly turns into a chore because
+    of the order somebody happened to click in is a bad surprise, and
+    the dependency is knowable, so it is written down.
+    """
+    owner = {}
+    for cluster in clusters:
+        for member in cluster.members:
+            owner[member] = cluster.id
+    key_to_row = {
+        rows[m].target.key: m for m in rows
+    }
+    debts: dict[str, set[str]] = {c.id: set() for c in clusters}
+    for cluster in clusters:
+        for member in cluster.members:
+            donor = rows[member].donor if member in rows else None
+            if not donor:
+                continue
+            supplier = owner.get(key_to_row.get(donor["key"], ""))
+            if supplier is not None and supplier != cluster.id:
+                debts[supplier].add(cluster.id)
+    return debts
+
+
 def _cause_of(
     row: TangleRow, lattice: LatticeReading
 ) -> tuple[str, tuple, str | None, dict[str, Any]]:
@@ -1437,19 +1707,41 @@ def _cause_of(
     """
     leading = row.classes[0] if row.classes else CLUSTER_SINGLETON
 
+    # A row that is BOTH a twin and a lie is a lie first, even though
+    # the comb ranks the twin higher. The severity order is about which
+    # finding a person should read first, and it is right; this is about
+    # which finding is the CAUSE, and a duplicate whose own bytes also
+    # disagree with its own label is a symptom of that disagreement.
+    #
+    # It is what a half-repaired shift looks like from the inside. Copy
+    # a donor into a cell and it matches the still-broken neighbour it
+    # copied from until that neighbour is repaired too, so ranking the
+    # twin first would pull cells out of the very card that is about to
+    # fix them. The same rule makes a four-cell copy-paste drift land as
+    # one card rather than as three plus a pair.
+    if CHECK_FIELD_MISMATCH in row.classes:
+        leading = CHECK_FIELD_MISMATCH
+
     if leading == CHECK_FIELD_MISMATCH:
         fields = _mismatched_fields(row.findings)
         name = fields[0] if fields else None
-        params = row.findings[0].get("params", {})
+        # The FIELD-MISMATCH finding's params, not the row's first: a
+        # row that is also a twin leads with the twin, whose params say
+        # which neighbour it matches rather than what it reads as.
+        params = next(
+            (dict(f.get("params") or {}) for f in row.findings
+             if f.get("check") == CHECK_FIELD_MISMATCH),
+            {},
+        )
         expected, read = params.get("expected"), params.get("read")
         spec = lattice.spec_for(name) if name else None
         if spec is not None and expected is not None and read is not None:
             domain = _axis_domain(lattice, name)
             claimed = _label_for(spec, domain, int(str(expected), 16))
             actual = _label_for(spec, domain, int(str(read), 16))
-            if isinstance(claimed, int | float) and isinstance(
-                    actual, int | float):
-                step = float(actual) - float(claimed)
+            step = _ring_step(
+                _ring_domain(lattice, name), claimed, actual)
+            if step is not None:
                 return CLUSTER_SHIFT, (CLUSTER_SHIFT, name, step), name, {
                     "field": name, "step": step,
                 }
@@ -1548,7 +1840,14 @@ def cluster_rows(
             members=[row.id for row in members],
             detail={**detail, "spans": {k: v for k, v in spans.items() if v}},
         ))
+    debts = _donor_debts({row.id: row for row in rows}, clusters)
+    for cluster in clusters:
+        if debts.get(cluster.id):
+            # Worked top down, this card would take the donors another
+            # card is waiting on, so it sorts after the cards it feeds.
+            cluster.detail["feeds"] = sorted(debts[cluster.id])
     clusters.sort(key=lambda c: (
+        len(debts.get(c.id, ())),
         _CLUSTER_ORDER.index(c.rule) if c.rule in _CLUSTER_ORDER
         else len(_CLUSTER_ORDER),
         -c.size,

--- a/custom_components/hair/tangles.py
+++ b/custom_components/hair/tangles.py
@@ -35,15 +35,22 @@ import logging
 from dataclasses import dataclass, field, replace
 from typing import Any
 
+from . import field_readers
 from .models import IRCommand, IRDevice
 from .wig_comb import (
     ADVISORY_CHECKS,
+    CHECK_FIELD_MISMATCH,
+    FIELD_COORDINATE,
+    POWER_FIELD,
     SEVERITY_ORDER,
+    Coverage,
     Finding,
     comb_wig,
+    matrix_codes,
+    read_family,
 )
 from .wig_export import build_wig_from_device
-from .wig_format import ClimateMatrix, cell_key, row_digest
+from .wig_format import ClimateCell, ClimateMatrix, cell_key, row_digest
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -101,10 +108,11 @@ class TangleRow:
     findings: list[dict[str, Any]]
     pronto: str
     digest: str
-    #: P2 fills these in. False here means "not searched yet"; the
-    #: listing says which sources a row does have.
     has_donor: bool = False
     donor: dict[str, Any] | None = None
+    #: Why the donor search came back empty, when it did. An abstention
+    #: with a reason is a result; a silent None reads as "not looked at".
+    donor_abstain: str | None = None
     #: P5 fills this in: a standing attestation covering these bytes.
     attested: dict[str, Any] | None = None
 
@@ -118,6 +126,7 @@ class TangleRow:
             "digest": self.digest,
             "has_donor": self.has_donor,
             "donor": dict(self.donor) if self.donor else None,
+            "donor_abstain": self.donor_abstain,
             "attested": dict(self.attested) if self.attested else None,
         }
 
@@ -243,6 +252,7 @@ def list_tangles(
 
     rows: list[TangleRow] = []
     if matrix is not None:
+        lattice = read_lattice(matrix)
         portholes = {
             _coord_key(command.matrix_cell): command.id
             for command in device.commands
@@ -257,6 +267,8 @@ def list_tangles(
                 "mode": cell.mode, "fan": cell.fan,
                 "swing": cell.swing, "temp": cell.temp,
             }
+            payload = [f.to_dict() for f in findings]
+            donor, abstain = find_donor(lattice, key, payload)
             rows.append(TangleRow(
                 id=row_id(TARGET_CELL, key),
                 target=TangleTarget(
@@ -265,9 +277,12 @@ def list_tangles(
                     coordinates=coordinates,
                 ),
                 classes=[f.check for f in findings],
-                findings=[f.to_dict() for f in findings],
+                findings=payload,
                 pronto=cell.pronto,
                 digest=_cell_digest(cell.pronto),
+                has_donor=donor is not None,
+                donor=donor,
+                donor_abstain=abstain,
             ))
         for key in ("off", "on"):
             findings = grouped.pop(key, None)
@@ -316,6 +331,176 @@ def list_tangles(
 
     listing.rows = rows
     return listing
+
+
+# ---------------------------------------------------------------------------
+# P2: the donor search
+# ---------------------------------------------------------------------------
+
+#: No cell anywhere in this lattice reads as the value this one claims.
+#: The honest end of the search, and a loud one: the abstention is what
+#: sends a card to the witnessed-capture road instead of inventing bytes.
+ABSTAIN_NO_READING = "no-cell-reads-this"
+#: The field the cell disagrees on is not one this map vouches for, so
+#: there is nothing to search against.
+ABSTAIN_NOT_RATIFIED = "field-not-ratified"
+#: Nothing read the lattice at all.
+ABSTAIN_UNREADABLE = "unreadable"
+#: The finding is not a field mismatch, so a donor is the wrong idea:
+#: a damaged capture is not repaired by another cell's bytes.
+ABSTAIN_NOT_A_FIELD = "not-a-field-finding"
+
+
+@dataclass
+class LatticeReading:
+    """Every cell of one lattice, read once, with its map.
+
+    Built ONCE per listing and never re-read mid-run. A donor is chosen
+    against the lattice as it stands before any write; re-reading after
+    each write would let a repair chase its own tail through a column
+    that is one long shift.
+    """
+
+    field_map: Any = None
+    readings: dict[str, Any] = field(default_factory=dict)
+    cells: dict[str, ClimateCell] = field(default_factory=dict)
+
+    @property
+    def readable(self) -> bool:
+        return self.field_map is not None
+
+    def spec_for(self, field_name: str) -> Any:
+        if self.field_map is None:
+            return None
+        return self.field_map.field_named(field_name)
+
+    def reads(self, key: str, spec: Any) -> int | None:
+        reading = self.readings.get(key)
+        if reading is None or spec is None:
+            return None
+        return field_readers.read_field(reading, spec)
+
+
+def read_lattice(matrix: ClimateMatrix | None) -> LatticeReading:
+    """Decode every cell of a lattice once, under one family vote."""
+    if matrix is None:
+        return LatticeReading()
+    codes = matrix_codes(matrix)
+    field_map, readings = read_family(codes, Coverage())
+    return LatticeReading(
+        field_map=field_map,
+        readings=readings,
+        cells={cell_key(cell): cell for cell in matrix.cells},
+    )
+
+
+def _mismatched_fields(findings: list[dict[str, Any]]) -> list[str]:
+    """Which field names a row's field-mismatch findings name.
+
+    The comb writes the field as a locale key so the diagnosis renders
+    in the reader's language; the name is the tail of it.
+    """
+    names = []
+    for finding in findings:
+        if finding.get("check") != CHECK_FIELD_MISMATCH:
+            continue
+        raw = str(finding.get("params", {}).get("field", ""))
+        name = raw.rsplit(".", 1)[-1]
+        if name and name not in names:
+            names.append(name)
+    return names
+
+
+def _coordinate_of(cell: ClimateCell, field_name: str) -> Any:
+    if field_name == POWER_FIELD:
+        return "on"
+    axis = FIELD_COORDINATE.get(field_name)
+    return None if axis is None else getattr(cell, axis, None)
+
+
+def _elsewhere(cell: ClimateCell, exclude: set[str]) -> tuple:
+    """The cell's coordinates on every axis the search is NOT varying.
+
+    A donor has to be the same cell in every respect except the thing
+    that is wrong with the target. Without this the search would happily
+    offer a cooling frame to repair a heating one, because the only
+    field it can compare is the one they agree on.
+    """
+    axes = [
+        axis for name, axis in FIELD_COORDINATE.items()
+        if name not in exclude
+    ]
+    return tuple(getattr(cell, axis, None) for axis in sorted(axes))
+
+
+def find_donor(
+    lattice: LatticeReading,
+    key: str,
+    findings: list[dict[str, Any]],
+) -> tuple[dict[str, Any] | None, str | None]:
+    """A cell whose READ is what this cell's LABEL claims, or a reason.
+
+    Never constructs and never guesses. The search is a lookup over
+    codes that already exist in this lattice: if one of them already
+    sends what this cell is supposed to send, that frame is the repair.
+    If none does, the search says so and stops -- which is the whole
+    reason the witnessed-capture road exists.
+    """
+    if not lattice.readable:
+        return None, ABSTAIN_UNREADABLE
+    target = lattice.cells.get(key)
+    if target is None:
+        return None, ABSTAIN_UNREADABLE
+    fields = _mismatched_fields(findings)
+    if not fields:
+        return None, ABSTAIN_NOT_A_FIELD
+
+    wanted: dict[str, int] = {}
+    for name in fields:
+        spec = lattice.spec_for(name)
+        if spec is None or not spec.ratified:
+            return None, ABSTAIN_NOT_RATIFIED
+        expected = field_readers.expected_value(
+            spec, _coordinate_of(target, name)
+        )
+        if expected is None:
+            return None, ABSTAIN_NOT_RATIFIED
+        wanted[name] = expected
+
+    varying = set(fields)
+    anchor = _elsewhere(target, varying)
+    for candidate_key, candidate in lattice.cells.items():
+        if candidate_key == key:
+            continue
+        if _elsewhere(candidate, varying) != anchor:
+            continue
+        if any(
+            lattice.reads(candidate_key, lattice.spec_for(name)) != value
+            for name, value in wanted.items()
+        ):
+            continue
+        return {
+            "key": candidate_key,
+            "coordinates": {
+                "mode": candidate.mode, "fan": candidate.fan,
+                "swing": candidate.swing, "temp": candidate.temp,
+            },
+            "pronto": candidate.pronto,
+            "digest": _cell_digest(candidate.pronto),
+            # STRUCTURED, not a sentence. This branch writes no
+            # user-facing text; the surface renders "the frame at
+            # heat_cool/medium/21 reads as 22" from these three facts.
+            "reasoning": {
+                "fields": list(fields),
+                "labelled": {
+                    name: _coordinate_of(candidate, name) for name in fields
+                },
+                "reads_as": {
+                    name: _coordinate_of(target, name) for name in fields
+                },
+            },
+        }, None
+    return None, ABSTAIN_NO_READING
 
 
 def _coord_key(coordinates: Any) -> tuple:

--- a/custom_components/hair/tests/test_tangles_apply.py
+++ b/custom_components/hair/tests/test_tangles_apply.py
@@ -1,0 +1,397 @@
+"""The one door, and what it refuses.
+
+Everything else in this flow reads. This writes, and it is the only
+thing that does: there is no general cell editor, and there is no way to
+reach a lattice cell except by naming a finding that is open against it
+right now.
+
+Three things make the door narrow. It takes a finding reference and
+refuses a target with nothing wrong with it. It requires the caller to
+assert that somebody pressed the button, which is RECORDED and never
+verified -- the server cannot watch an air conditioner respond and must
+not pretend to. And it refuses bytes that read as the wrong thing unless
+the caller says out loud that they are overriding the reading, which is
+what turns a frustrated user's third attempt into evidence about the map
+instead of a silent bad write.
+
+Every write leaves the bytes it replaced beside it, so the undo needs
+nothing but the thing it is undoing.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.hair.const import DOMAIN
+from custom_components.hair.models import (
+    CommandCategory,
+    IRCommand,
+    IRDevice,
+)
+from custom_components.hair.tangles import (
+    APPLY_DISAGREEMENT_UNDECLARED,
+    APPLY_NO_FINDING,
+    APPLY_NOT_TESTED,
+    APPLY_NOTHING_TO_REVERT,
+    PROVENANCE_KEY,
+    list_tangles,
+    read_repair,
+)
+from custom_components.hair.websocket_api import (
+    ws_tangle_apply,
+    ws_tangle_revert,
+)
+from custom_components.hair.wig_comb import CHECK_FIELD_MISMATCH
+from custom_components.hair.wig_format import Wig, cell_key, parse_wig
+
+FIXTURES = Path(__file__).parent / "fixtures"
+KOMECO = (FIXTURES / "wigs"
+          / "komeco-airconditioner-kos-09qc-3hx-perfect-fit.wig.json")
+DREO = (FIXTURES / "wigs"
+        / "dreo-fan-dr-haf004s-perfect-fit.wig.json")
+
+TARGET_KEY = "heat_cool/medium/off/25"
+TARGET = f"cell:{TARGET_KEY}"
+DONOR_KEY = "heat_cool/medium/off/24"
+
+
+def _wig(path: Path) -> Wig:
+    parsed = parse_wig(path.read_text())
+    assert parsed.wig is not None, parsed.errors
+    return parsed.wig
+
+
+@pytest.fixture
+def komeco() -> Wig:
+    return _wig(KOMECO)
+
+
+@pytest.fixture
+def wired(fake_hass, komeco, tmp_path):
+    """A Komeco device with one porthole over the target cell."""
+    matrix = komeco.climate
+    cells = {cell_key(c): c for c in matrix.cells}
+    device = IRDevice(name="Komeco", climate_matrix=True,
+                      emitter_entity_ids=["infrared.blaster"])
+    device.add_command(IRCommand(
+        name="Heat_cool 25 medium off", category=CommandCategory.CUSTOM,
+        protocol="PRONTO", code=cells[TARGET_KEY].pronto, repeat_count=0,
+        matrix_cell={"mode": "heat_cool", "fan": "medium",
+                     "swing": "off", "temp": 25.0},
+        comb_suspect=True, comb_finding=CHECK_FIELD_MISMATCH,
+    ))
+    manager = MagicMock()
+    manager.get_device = MagicMock(return_value=device)
+    manager.async_get_matrix = AsyncMock(return_value=matrix)
+    manager.async_update_device = AsyncMock()
+    listener = MagicMock()
+    fake_hass.config.config_dir = str(tmp_path)
+    fake_hass.data[DOMAIN] = {"entry-1": {
+        "device_manager": manager, "matrix_listener": listener,
+    }}
+    return fake_hass, device, matrix, cells, manager, listener
+
+
+def _conn():
+    connection = MagicMock()
+    connection.send_result = MagicMock()
+    connection.send_error = MagicMock()
+    return connection
+
+
+async def _apply(hass, device, pronto, **extra):
+    connection = _conn()
+    payload = {
+        "id": 1, "type": "hair/device/tangle/apply",
+        "device_id": device.id, "target": TARGET,
+        "pronto": pronto, "tested": True,
+    }
+    payload.update(extra)
+    await ws_tangle_apply(hass, connection, payload)
+    return connection
+
+
+class TestTheWrite:
+    @pytest.mark.asyncio
+    async def test_the_bytes_land_in_the_cell(self, wired):
+        hass, device, _matrix, cells, manager, _listener = wired
+        donor = cells[DONOR_KEY].pronto
+        connection = await _apply(hass, device, donor, source="donor")
+        connection.send_error.assert_not_called()
+        assert cells[TARGET_KEY].pronto == donor
+        manager.async_update_device.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_only_that_cell_moves(self, wired):
+        hass, device, _matrix, cells, _manager, _listener = wired
+        before = {
+            key: cell.pronto for key, cell in cells.items()
+            if key != TARGET_KEY
+        }
+        await _apply(hass, device, cells[DONOR_KEY].pronto, source="donor")
+        assert {
+            key: cell.pronto for key, cell in cells.items()
+            if key != TARGET_KEY
+        } == before
+
+    @pytest.mark.asyncio
+    async def test_the_porthole_follows_the_cell(self, wired):
+        """The porthole is what TEST sends. A repair that left it behind
+        would hand somebody a button still transmitting the code they
+        just replaced."""
+        hass, device, _matrix, cells, _manager, _listener = wired
+        donor = cells[DONOR_KEY].pronto
+        await _apply(hass, device, donor, source="donor")
+        porthole = device.commands[0]
+        assert porthole.code == donor
+        assert read_repair(porthole) is not None
+
+    @pytest.mark.asyncio
+    async def test_the_record_carries_the_undo(self, wired):
+        hass, device, _matrix, cells, _manager, _listener = wired
+        was = cells[TARGET_KEY].pronto
+        connection = await _apply(
+            hass, device, cells[DONOR_KEY].pronto, source="donor")
+        record = connection.send_result.call_args.args[1]["provenance"]
+        assert record["prior"]["pronto"] == was
+        assert record["origin"] == "fix"
+        assert record["source"] == "donor"
+        assert record["tested"] is True
+        assert record["finding"]["key"] == TARGET_KEY
+        assert record["finding"]["classes"] == [CHECK_FIELD_MISMATCH]
+        assert record["map"]["id"] == "ZHLT01"
+        assert record["map"]["version"]
+
+    @pytest.mark.asyncio
+    async def test_the_record_rides_the_cell_itself(self, wired):
+        """Inside the cell's own extras, so it travels with the matrix
+        file and into an exported wig without a format change."""
+        hass, device, _matrix, cells, _manager, _listener = wired
+        await _apply(hass, device, cells[DONOR_KEY].pronto, source="donor")
+        assert PROVENANCE_KEY in cells[TARGET_KEY].extra
+
+    @pytest.mark.asyncio
+    async def test_a_live_entity_is_told_the_lattice_moved(self, wired):
+        """A climate entity loads its matrix once. Before repairs that
+        was safe; now it is not, and the signal is the difference
+        between a fixed cell and a fixed cell nobody transmits."""
+        hass, device, _matrix, cells, _manager, listener = wired
+        await _apply(hass, device, cells[DONOR_KEY].pronto, source="donor")
+        listener.invalidate.assert_called_once_with(device.id)
+
+    @pytest.mark.asyncio
+    async def test_the_row_leaves_the_listing(self, wired):
+        hass, device, matrix, cells, _manager, _listener = wired
+        await _apply(hass, device, cells[DONOR_KEY].pronto, source="donor")
+        remaining = [
+            row for row in list_tangles(device, matrix).rows
+            if CHECK_FIELD_MISMATCH in row.classes
+        ]
+        assert TARGET_KEY not in {row.target.key for row in remaining}
+        assert len(remaining) == 51
+
+
+class TestWhatItRefuses:
+    @pytest.mark.asyncio
+    async def test_without_a_press_there_is_no_write(self, wired):
+        hass, device, _matrix, cells, _manager, _listener = wired
+        was = cells[TARGET_KEY].pronto
+        connection = _conn()
+        await ws_tangle_apply(hass, connection, {
+            "id": 1, "type": "hair/device/tangle/apply",
+            "device_id": device.id, "target": TARGET,
+            "pronto": cells[DONOR_KEY].pronto, "tested": False,
+        })
+        assert connection.send_error.call_args.args[1] == APPLY_NOT_TESTED
+        assert cells[TARGET_KEY].pronto == was
+
+    @pytest.mark.asyncio
+    async def test_a_healthy_cell_cannot_be_edited_through_this_door(
+            self, wired):
+        """Not a cell editor. A target with nothing open against it is
+        refused even with a perfectly good candidate in hand."""
+        hass, device, _matrix, cells, _manager, _listener = wired
+        healthy = "cell:cool/high/off/22"
+        was = cells["cool/high/off/22"].pronto
+        connection = _conn()
+        await ws_tangle_apply(hass, connection, {
+            "id": 1, "type": "hair/device/tangle/apply",
+            "device_id": device.id, "target": healthy,
+            "pronto": cells["cool/high/off/23"].pronto, "tested": True,
+        })
+        assert connection.send_error.call_args.args[1] == APPLY_NO_FINDING
+        assert cells["cool/high/off/22"].pronto == was
+
+    @pytest.mark.asyncio
+    async def test_bytes_that_read_wrong_need_saying_so(self, wired):
+        """The escalation ladder's third rung has to be DECLARED. A
+        silent write of bytes our own reader disagrees with would lose
+        the only evidence that our reading might be the thing at
+        fault."""
+        hass, device, _matrix, cells, _manager, _listener = wired
+        was = cells[TARGET_KEY].pronto
+        connection = await _apply(hass, device, cells[
+            "heat_cool/medium/off/28"].pronto)
+        assert connection.send_error.call_args.args[1] == (
+            APPLY_DISAGREEMENT_UNDECLARED)
+        assert cells[TARGET_KEY].pronto == was
+
+    @pytest.mark.asyncio
+    async def test_declared_disagreement_writes_and_records_the_reading(
+            self, wired):
+        """A remote sends what its display shows. A repeated off-by-one
+        is the signature of a map defect, so the write is allowed and
+        what our reader claimed is written down beside it."""
+        hass, device, _matrix, cells, _manager, _listener = wired
+        wrong = cells["heat_cool/medium/off/28"].pronto
+        connection = await _apply(
+            hass, device, wrong, reading_disagreed=True, source="capture")
+        connection.send_error.assert_not_called()
+        assert cells[TARGET_KEY].pronto == wrong
+        record = read_repair(cells[TARGET_KEY])
+        assert record["reading_disagreed"]["user_attested"] is True
+        assert record["reading_disagreed"]["reads_as"]["temperature"] == 29.0
+        assert record["reading_disagreed"]["claims"]["temperature"] == 25.0
+        assert record["reading_disagreed"]["mismatches"] == ["temperature"]
+
+    @pytest.mark.asyncio
+    async def test_an_unusable_code_is_refused(self, wired):
+        hass, device, _matrix, cells, _manager, _listener = wired
+        was = cells[TARGET_KEY].pronto
+        connection = await _apply(hass, device, "not a pronto code")
+        assert connection.send_error.call_args.args[1] == "bad_candidate"
+        assert cells[TARGET_KEY].pronto == was
+
+
+class TestPuttingItBack:
+    @pytest.mark.asyncio
+    async def test_revert_restores_the_exact_bytes(self, wired):
+        hass, device, _matrix, cells, _manager, _listener = wired
+        was = cells[TARGET_KEY].pronto
+        await _apply(hass, device, cells[DONOR_KEY].pronto, source="donor")
+        assert cells[TARGET_KEY].pronto != was
+
+        connection = _conn()
+        await ws_tangle_revert(hass, connection, {
+            "id": 2, "type": "hair/device/tangle/revert",
+            "device_id": device.id, "target": TARGET,
+        })
+        connection.send_error.assert_not_called()
+        assert cells[TARGET_KEY].pronto == was
+        assert PROVENANCE_KEY not in cells[TARGET_KEY].extra
+
+    @pytest.mark.asyncio
+    async def test_the_finding_comes_back(self, wired):
+        hass, device, matrix, cells, _manager, _listener = wired
+        await _apply(hass, device, cells[DONOR_KEY].pronto, source="donor")
+        connection = _conn()
+        await ws_tangle_revert(hass, connection, {
+            "id": 2, "type": "hair/device/tangle/revert",
+            "device_id": device.id, "target": TARGET,
+        })
+        rows = list_tangles(device, matrix).rows
+        assert TARGET_KEY in {row.target.key for row in rows}
+
+    @pytest.mark.asyncio
+    async def test_the_porthole_comes_back_too(self, wired):
+        hass, device, _matrix, cells, _manager, _listener = wired
+        was = device.commands[0].code
+        await _apply(hass, device, cells[DONOR_KEY].pronto, source="donor")
+        connection = _conn()
+        await ws_tangle_revert(hass, connection, {
+            "id": 2, "type": "hair/device/tangle/revert",
+            "device_id": device.id, "target": TARGET,
+        })
+        assert device.commands[0].code == was
+
+    @pytest.mark.asyncio
+    async def test_nothing_to_revert_says_so(self, wired):
+        hass, device, _matrix, _cells, _manager, _listener = wired
+        connection = _conn()
+        await ws_tangle_revert(hass, connection, {
+            "id": 2, "type": "hair/device/tangle/revert",
+            "device_id": device.id, "target": TARGET,
+        })
+        assert connection.send_error.call_args.args[1] == (
+            APPLY_NOTHING_TO_REVERT)
+
+    @pytest.mark.asyncio
+    async def test_one_step_back_and_no_further(self, wired):
+        """Not a history. After a revert there is no record left, so a
+        second revert has nothing to undo and says so rather than
+        walking backwards through bytes nobody kept."""
+        hass, device, _matrix, cells, _manager, _listener = wired
+        await _apply(hass, device, cells[DONOR_KEY].pronto, source="donor")
+        for expected_error in (None, APPLY_NOTHING_TO_REVERT):
+            connection = _conn()
+            await ws_tangle_revert(hass, connection, {
+                "id": 2, "type": "hair/device/tangle/revert",
+                "device_id": device.id, "target": TARGET,
+            })
+            if expected_error is None:
+                connection.send_error.assert_not_called()
+            else:
+                assert connection.send_error.call_args.args[1] == (
+                    expected_error)
+
+
+class TestFlatCommands:
+    @pytest.fixture
+    def dreo(self, fake_hass, tmp_path):
+        wig = _wig(DREO)
+        device = IRDevice(name="Dreo", emitter_entity_ids=["infrared.b"])
+        for signal in wig.signals:
+            device.add_command(IRCommand(
+                name=signal.alias, category=CommandCategory.CUSTOM,
+                protocol="PRONTO", code=signal.pronto,
+            ))
+        manager = MagicMock()
+        manager.get_device = MagicMock(return_value=device)
+        manager.async_get_matrix = AsyncMock(return_value=None)
+        manager.async_update_device = AsyncMock()
+        fake_hass.config.config_dir = str(tmp_path)
+        fake_hass.data[DOMAIN] = {"entry-1": {"device_manager": manager}}
+        return fake_hass, device, manager
+
+    @pytest.mark.asyncio
+    async def test_a_flat_repair_goes_through_the_command(self, dreo):
+        """Same door, same record. The persistence rides
+        async_update_device so the known-command index rebuilds on the
+        new bytes and the entity hooks fire."""
+        hass, device, manager = dreo
+        row = list_tangles(device, None).rows[0]
+        clean = next(c for c in device.commands
+                     if c.id != row.target.command_id).code
+        connection = _conn()
+        await ws_tangle_apply(hass, connection, {
+            "id": 1, "type": "hair/device/tangle/apply",
+            "device_id": device.id, "target": row.id,
+            "pronto": clean, "tested": True, "source": "paste",
+        })
+        connection.send_error.assert_not_called()
+        command = device.get_command(row.target.command_id)
+        assert command.code == clean
+        record = read_repair(command)
+        assert record["prior"]["pronto"] == row.pronto
+        manager.async_update_device.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_flat_revert_puts_the_capture_back(self, dreo):
+        hass, device, _manager = dreo
+        row = list_tangles(device, None).rows[0]
+        clean = next(c for c in device.commands
+                     if c.id != row.target.command_id).code
+        await ws_tangle_apply(hass, _conn(), {
+            "id": 1, "type": "hair/device/tangle/apply",
+            "device_id": device.id, "target": row.id,
+            "pronto": clean, "tested": True, "source": "paste",
+        })
+        connection = _conn()
+        await ws_tangle_revert(hass, connection, {
+            "id": 2, "type": "hair/device/tangle/revert",
+            "device_id": device.id, "target": row.id,
+        })
+        connection.send_error.assert_not_called()
+        assert device.get_command(row.target.command_id).code == row.pronto

--- a/custom_components/hair/tests/test_tangles_batch.py
+++ b/custom_components/hair/tests/test_tangles_batch.py
@@ -1,0 +1,420 @@
+"""One cause, one run.
+
+Fittings never walked six hundred cells; a dimension check attests axes.
+Repairs follow the same philosophy: a run presses at a representative
+sample spanning the card's modes and, on a pass, writes every member in
+one batch, with each cell's record honest about which tier it got.
+
+The batch is not only the safe unit, it is the CORRECT one. The Komeco
+column is a shift, so the right bytes for one cell are the bytes the cell
+below it is carrying right now. Apply one cell of that cause and it ends
+up byte-identical to its still-broken neighbour, which the duplicate
+check then reports -- correctly. Apply the whole cause and the shift
+walks back and the twins never exist.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.hair import field_readers
+from custom_components.hair.const import DOMAIN
+from custom_components.hair.models import IRDevice
+from custom_components.hair.tangles import (
+    BATCH_SAMPLE_SHORT,
+    TIER_AIR_TESTED,
+    TIER_RULE_DERIVED,
+    choose_sample,
+    list_tangles,
+    read_lattice,
+    read_repair,
+    rewrite_field,
+)
+from custom_components.hair.websocket_api import (
+    ws_tangle_apply_batch,
+    ws_tangle_plan,
+    ws_tangle_revert_run,
+)
+from custom_components.hair.wig_comb import comb_wig
+from custom_components.hair.wig_format import Wig, cell_key, parse_wig
+
+FIXTURES = Path(__file__).parent / "fixtures"
+KOMECO = (FIXTURES / "wigs"
+          / "komeco-airconditioner-kos-09qc-3hx-perfect-fit.wig.json")
+
+DONOR_CARD = "same-shift:temperature:1:donor"
+WITNESS_CARD = "same-shift:temperature:1:witness"
+
+
+def _wig() -> Wig:
+    parsed = parse_wig(KOMECO.read_text())
+    assert parsed.wig is not None, parsed.errors
+    return parsed.wig
+
+
+@pytest.fixture
+def wired(fake_hass, tmp_path):
+    wig = _wig()
+    device = IRDevice(name="Komeco", climate_matrix=True,
+                      emitter_entity_ids=["infrared.blaster"])
+    manager = MagicMock()
+    manager.get_device = MagicMock(return_value=device)
+    manager.async_get_matrix = AsyncMock(return_value=wig.climate)
+    manager.async_update_device = AsyncMock()
+    fake_hass.config.config_dir = str(tmp_path)
+    fake_hass.data[DOMAIN] = {"entry-1": {
+        "device_manager": manager, "matrix_listener": MagicMock(),
+    }}
+    return fake_hass, device, wig
+
+
+def _press(lattice, wig, row):
+    """A capture that reads as the row's own label on this hardware.
+
+    Stands in for the press: built from a healthy cell of the same
+    column, so it carries the remote's own timings the way a real
+    capture would.
+    """
+    spec = lattice.spec_for("temperature")
+    cells = {cell_key(c): c for c in wig.climate.cells}
+    coordinates = row.target.coordinates
+    sibling = cells[
+        f"{coordinates['mode']}/{coordinates['fan']}"
+        f"/{coordinates['swing']}/16"
+    ]
+    built = rewrite_field(
+        lattice.field_map, sibling.pronto, spec,
+        field_readers.expected_value(spec, coordinates["temp"]),
+    )
+    assert built is not None
+    return built
+
+
+def _conn():
+    connection = MagicMock()
+    connection.send_result = MagicMock()
+    connection.send_error = MagicMock()
+    return connection
+
+
+async def _plan(hass, device, cluster, **extra):
+    connection = _conn()
+    payload = {"id": 1, "type": "hair/device/tangle/plan",
+               "device_id": device.id, "cluster": cluster}
+    payload.update(extra)
+    await ws_tangle_plan(hass, connection, payload)
+    connection.send_error.assert_not_called()
+    return connection.send_result.call_args.args[1]
+
+
+async def _run(hass, device, cluster, tested, **extra):
+    connection = _conn()
+    payload = {
+        "id": 2, "type": "hair/device/tangle/apply-batch",
+        "device_id": device.id, "cluster": cluster,
+        "tested": True, "tested_targets": tested,
+    }
+    payload.update(extra)
+    await ws_tangle_apply_batch(hass, connection, payload)
+    return connection
+
+
+class TestChoosingWhatToPressAt:
+    def test_modes_come_first(self, wired):
+        _hass, device, wig = wired
+        listing = list_tangles(device, wig.climate)
+        rows = {row.id: row for row in listing.rows}
+        card = next(c for c in listing.clusters if c.id == DONOR_CARD)
+        sample = choose_sample(rows, card.members)
+        assert 1 <= len(sample) <= 2
+        assert set(sample) <= set(card.members)
+
+    def test_a_single_member_card_tests_that_member(self, wired):
+        _hass, device, wig = wired
+        listing = list_tangles(device, wig.climate)
+        rows = {row.id: row for row in listing.rows}
+        only = listing.rows[0].id
+        assert choose_sample(rows, [only]) == [only]
+
+    def test_the_choice_is_stable(self, wired):
+        _hass, device, wig = wired
+        listing = list_tangles(device, wig.climate)
+        rows = {row.id: row for row in listing.rows}
+        card = next(c for c in listing.clusters if c.id == DONOR_CARD)
+        assert choose_sample(rows, card.members) == choose_sample(
+            rows, card.members)
+
+
+class TestThePlan:
+    @pytest.mark.asyncio
+    async def test_a_donor_card_resolves_every_member(self, wired):
+        hass, device, _wig = wired
+        plan = await _plan(hass, device, DONOR_CARD)
+        assert plan["refused"] is None
+        assert len(plan["candidates"]) == 48
+        assert plan["declined"] == {}
+        assert plan["sample"]
+
+    @pytest.mark.asyncio
+    async def test_every_candidate_arrives_with_its_read_back(self, wired):
+        hass, device, _wig = wired
+        plan = await _plan(hass, device, DONOR_CARD)
+        for candidate in plan["candidates"].values():
+            assert candidate["verdict"]["matches"] is True
+            assert candidate["origin"] == "donor"
+
+    @pytest.mark.asyncio
+    async def test_the_plan_writes_nothing(self, wired):
+        hass, device, wig = wired
+        before = [cell.pronto for cell in wig.climate.cells]
+        await _plan(hass, device, DONOR_CARD)
+        assert [cell.pronto for cell in wig.climate.cells] == before
+
+    @pytest.mark.asyncio
+    async def test_a_witness_card_needs_a_witness(self, wired):
+        """No donor anywhere, and nothing supplied: the card resolves to
+        nothing rather than to something invented."""
+        hass, device, _wig = wired
+        plan = await _plan(hass, device, WITNESS_CARD)
+        assert plan["refused"] == "nothing_to_apply"
+
+    @pytest.mark.asyncio
+    async def test_the_whole_card_is_resolved_before_anything_moves(
+            self, wired):
+        """On a shifted column, resolving as you write would walk the
+        shift down and hand back codes it had just replaced. Every
+        candidate here comes from the lattice as it stands."""
+        hass, device, wig = wired
+        plan = await _plan(hass, device, DONOR_CARD)
+        cells = {cell_key(c): c for c in wig.climate.cells}
+        for candidate in plan["candidates"].values():
+            donor = candidate["donor"]
+            assert cells[donor].pronto == candidate["pronto"]
+
+
+class TestTheRun:
+    @pytest.mark.asyncio
+    async def test_a_pass_writes_every_member(self, wired):
+        hass, device, wig = wired
+        plan = await _plan(hass, device, DONOR_CARD)
+        connection = await _run(hass, device, DONOR_CARD, plan["sample"])
+        connection.send_error.assert_not_called()
+        result = connection.send_result.call_args.args[1]
+        assert result["applied"] == 48
+        cells = {cell_key(c): c for c in wig.climate.cells}
+        for member, candidate in plan["candidates"].items():
+            assert cells[member.split(":", 1)[1]].pronto == candidate[
+                "pronto"]
+
+    @pytest.mark.asyncio
+    async def test_the_record_says_which_tier_each_cell_got(self, wired):
+        """Honest about what was proved. The pressed cells are
+        air-tested; the rest are rule-derived, and the record names the
+        cells the rule was proved on."""
+        hass, device, wig = wired
+        plan = await _plan(hass, device, DONOR_CARD)
+        await _run(hass, device, DONOR_CARD, plan["sample"])
+        cells = {cell_key(c): c for c in wig.climate.cells}
+        tested_keys = {t.split(":", 1)[1] for t in plan["sample"]}
+        tiers = {}
+        for member in plan["candidates"]:
+            key = member.split(":", 1)[1]
+            record = read_repair(cells[key])
+            tiers[key] = record["tier"]
+            assert set(record["tested_cells"]) == tested_keys
+        for key, tier in tiers.items():
+            expected = (TIER_AIR_TESTED if key in tested_keys
+                        else TIER_RULE_DERIVED)
+            assert tier == expected
+
+    @pytest.mark.asyncio
+    async def test_one_run_one_id(self, wired):
+        hass, device, wig = wired
+        plan = await _plan(hass, device, DONOR_CARD)
+        connection = await _run(hass, device, DONOR_CARD, plan["sample"])
+        run = connection.send_result.call_args.args[1]["run"]
+        cells = {cell_key(c): c for c in wig.climate.cells}
+        runs = {
+            read_repair(cells[m.split(":", 1)[1]])["run"]
+            for m in plan["candidates"]
+        }
+        assert runs == {run}
+
+    @pytest.mark.asyncio
+    async def test_an_untested_mode_refuses_the_whole_run(self, wired):
+        """A rule proved in cooling is exactly the kind of thing that
+        does not hold in heating."""
+        hass, device, wig = wired
+        before = [cell.pronto for cell in wig.climate.cells]
+        connection = await _run(hass, device, DONOR_CARD, [])
+        assert connection.send_error.call_args.args[1] == BATCH_SAMPLE_SHORT
+        assert [cell.pronto for cell in wig.climate.cells] == before
+
+    @pytest.mark.asyncio
+    async def test_a_failed_run_leaves_the_lattice_byte_identical(
+            self, wired, monkeypatch):
+        """No partial batches, ever -- proved by comparing every cell,
+        not by trusting the code path."""
+        hass, device, wig = wired
+        plan = await _plan(hass, device, DONOR_CARD)
+        before = [cell.pronto for cell in wig.climate.cells]
+
+        def _boom(*args, **kwargs):
+            raise OSError("disk went away")
+
+        monkeypatch.setattr(
+            "custom_components.hair.matrix_store.write_matrix", _boom)
+        connection = await _run(hass, device, DONOR_CARD, plan["sample"])
+        assert connection.send_error.call_args.args[1] == "write_failed"
+        assert [cell.pronto for cell in wig.climate.cells] == before
+        assert all(read_repair(cell) is None for cell in wig.climate.cells)
+
+    @pytest.mark.asyncio
+    async def test_the_card_leaves_the_listing(self, wired):
+        hass, device, wig = wired
+        plan = await _plan(hass, device, DONOR_CARD)
+        await _run(hass, device, DONOR_CARD, plan["sample"])
+        cards = {c.id for c in list_tangles(device, wig.climate).clusters}
+        assert DONOR_CARD not in cards
+
+
+class TestUndoingARun:
+    @pytest.mark.asyncio
+    async def test_one_apply_is_one_undo(self, wired):
+        hass, device, wig = wired
+        before = [cell.pronto for cell in wig.climate.cells]
+        plan = await _plan(hass, device, DONOR_CARD)
+        connection = await _run(hass, device, DONOR_CARD, plan["sample"])
+        run = connection.send_result.call_args.args[1]["run"]
+
+        undo = _conn()
+        await ws_tangle_revert_run(hass, undo, {
+            "id": 3, "type": "hair/device/tangle/revert-run",
+            "device_id": device.id, "run": run,
+        })
+        undo.send_error.assert_not_called()
+        assert [cell.pronto for cell in wig.climate.cells] == before
+        assert all(read_repair(cell) is None for cell in wig.climate.cells)
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_run_says_so(self, wired):
+        hass, device, _wig = wired
+        connection = _conn()
+        await ws_tangle_revert_run(hass, connection, {
+            "id": 3, "type": "hair/device/tangle/revert-run",
+            "device_id": device.id, "run": "nope",
+        })
+        assert connection.send_error.call_args.args[1] == (
+            "nothing_to_revert")
+
+    @pytest.mark.asyncio
+    async def test_a_second_run_is_undone_on_its_own(self, wired):
+        """Two runs, one taken back: the other stays."""
+        hass, device, wig = wired
+        first = await _plan(hass, device, DONOR_CARD)
+        run_one = (await _run(
+            hass, device, DONOR_CARD, first["sample"]
+        )).send_result.call_args.args[1]["run"]
+
+        listing = list_tangles(device, wig.climate)
+        witness = next(c for c in listing.clusters
+                       if c.mechanic == "witness")
+        rows = {r.id: r for r in listing.rows}
+        lattice = read_lattice(wig.climate)
+        aimed = sorted(witness.members)[0]
+        press = _press(lattice, wig, rows[aimed])
+        second = await _plan(
+            hass, device, witness.id, witness=press, witness_target=aimed)
+        await _run(hass, device, witness.id, second["sample"],
+                   witness=press, witness_target=aimed)
+
+        undo = _conn()
+        await ws_tangle_revert_run(hass, undo, {
+            "id": 3, "type": "hair/device/tangle/revert-run",
+            "device_id": device.id, "run": run_one,
+        })
+        undo.send_error.assert_not_called()
+        cells = {cell_key(c): c for c in wig.climate.cells}
+        for member, candidate in second["candidates"].items():
+            assert cells[member.split(":", 1)[1]].pronto == candidate[
+                "pronto"]
+
+
+class TestTheCauseIsTheUnit:
+    @pytest.mark.asyncio
+    async def test_the_shift_walks_back_inside_the_card(self, wired):
+        """Why a cause is applied whole.
+
+        One cell of this card, applied alone, ends up byte-identical to
+        the neighbour it copied from until that neighbour is repaired
+        too. Applied whole, the shift walks back in one step and no two
+        cells the card touched carry the same code.
+
+        The card's lower EDGE is a different matter and is not a defect:
+        cell 20 takes what 19 was carrying, and 19 belongs to the card
+        that needs a press, so the two match until that press happens.
+        The comb reports the pair, correctly.
+        """
+        hass, device, wig = wired
+        plan = await _plan(hass, device, DONOR_CARD)
+        await _run(hass, device, DONOR_CARD, plan["sample"])
+        touched = [m.split(":", 1)[1] for m in plan["candidates"]]
+        cells = {cell_key(c): c for c in wig.climate.cells}
+        codes = [cells[key].pronto for key in touched]
+        assert len(set(codes)) == len(codes)
+
+        twins = [
+            f for f in comb_wig(wig).findings
+            if f.check == "duplicated-neighbour"
+        ]
+        assert {f.params["temp"] for f in twins} == {"20"}
+        assert {f.params["other"] for f in twins} == {"19"}
+
+    @pytest.mark.asyncio
+    async def test_the_whole_chain_is_one_card(self, wired):
+        """The cells at the top of the range are the same mistake as the
+        rest of the column -- a four-bit field wrapping is still one step
+        high. Split apart they break each other: whichever card ran first
+        would either overwrite the donor the other was waiting on, or
+        leave a byte-identical twin at the seam that reclassifies a cell
+        out of its own card.
+        """
+        _hass, device, wig = wired
+        cards = list_tangles(device, wig.climate).clusters
+        assert len(cards) == 2
+        donor = next(c for c in cards if c.mechanic == "donor")
+        assert donor.size == 48
+        assert donor.detail["step"] == 1
+        keys = {m.rsplit("/", 1)[-1] for m in donor.members}
+        assert "31" in keys and "20" in keys
+
+    @pytest.mark.asyncio
+    async def test_donors_and_one_press_leave_the_file_clean(self, wired):
+        """The whole loop through the shipped handlers.
+
+        One run repairs 48 cells, one press repairs the four nobody
+        could copy for, and the comb comes back with nothing.
+        """
+        hass, device, wig = wired
+        plan = await _plan(hass, device, DONOR_CARD)
+        connection = await _run(hass, device, DONOR_CARD, plan["sample"])
+        connection.send_error.assert_not_called()
+
+        listing = list_tangles(device, wig.climate)
+        card = next(c for c in listing.clusters if c.mechanic == "witness")
+        rows = {r.id: r for r in listing.rows}
+        aimed = sorted(card.members)[0]
+        press = _press(read_lattice(wig.climate), wig, rows[aimed])
+        second = await _plan(
+            hass, device, card.id, witness=press, witness_target=aimed)
+        assert second["refused"] is None
+        assert len(second["candidates"]) == 4
+        connection = await _run(
+            hass, device, card.id, second["sample"],
+            witness=press, witness_target=aimed)
+        connection.send_error.assert_not_called()
+
+        assert comb_wig(wig).findings == []
+        assert list_tangles(device, wig.climate).rows == []

--- a/custom_components/hair/tests/test_tangles_candidates.py
+++ b/custom_components/hair/tests/test_tangles_candidates.py
@@ -1,0 +1,370 @@
+"""Reading a candidate, sending it, and hearing one from the air.
+
+Three doors, one rule between them: NOTHING here writes. A candidate is
+read, transmitted, or heard; the person watching the unit decides, and
+the guarded write is somewhere else entirely.
+
+The read-back is the point. "Invalid" tells somebody nothing; "reads as
+26 degrees, and this cell claims 25" tells them exactly what they are
+looking at, in the words their own remote uses.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.hair.const import DOMAIN
+from custom_components.hair.models import (
+    CommandCategory,
+    IRCommand,
+    IRDevice,
+)
+from custom_components.hair.tangles import (
+    list_tangles,
+    pre_read,
+    project_device,
+    read_lattice,
+)
+from custom_components.hair.websocket_api import (
+    ws_tangle_pre_read,
+    ws_tangle_test_send,
+)
+from custom_components.hair.wig_format import Wig, cell_key, parse_wig
+
+FIXTURES = Path(__file__).parent / "fixtures"
+KOMECO = (FIXTURES / "wigs"
+          / "komeco-airconditioner-kos-09qc-3hx-perfect-fit.wig.json")
+DREO = (FIXTURES / "wigs"
+        / "dreo-fan-dr-haf004s-perfect-fit.wig.json")
+
+TARGET = "heat_cool/medium/off/25"
+
+
+def _wig(path: Path) -> Wig:
+    parsed = parse_wig(path.read_text())
+    assert parsed.wig is not None, parsed.errors
+    return parsed.wig
+
+
+@pytest.fixture(scope="module")
+def komeco() -> Wig:
+    return _wig(KOMECO)
+
+
+@pytest.fixture(scope="module")
+def lattice(komeco):
+    return read_lattice(komeco.climate)
+
+
+@pytest.fixture(scope="module")
+def komeco_rows(komeco):
+    return {
+        row.target.key: row for row in list_tangles(
+            IRDevice(name="Komeco", climate_matrix=True), komeco.climate
+        ).rows
+    }
+
+
+def _cell(komeco: Wig, key: str):
+    return next(c for c in komeco.climate.cells if cell_key(c) == key)
+
+
+class TestReadingACandidate:
+    def test_the_right_bytes_read_as_the_label(self, lattice, komeco,
+                                               komeco_rows):
+        """The donor, read against the cell it is offered for."""
+        row = komeco_rows[TARGET]
+        verdict = pre_read(lattice, row.donor["pronto"], row.target.coordinates)
+        assert verdict.matches is True
+        assert verdict.mismatches == []
+        assert verdict.reads_as["temperature"] == 25.0
+        assert verdict.claims["temperature"] == 25.0
+        assert verdict.protocol == "ZHLT01"
+
+    def test_the_wrong_bytes_say_what_they_actually_are(self, lattice,
+                                                        komeco, komeco_rows):
+        """Never just "invalid". The user pressed 18 when we asked for
+        19, and the only useful thing to tell them is which one we
+        heard."""
+        row = komeco_rows[TARGET]
+        wrong = _cell(komeco, "heat_cool/medium/off/28")
+        verdict = pre_read(lattice, wrong.pronto, row.target.coordinates)
+        assert verdict.matches is False
+        assert verdict.mismatches == ["temperature"]
+        assert verdict.reads_as["temperature"] == 29.0
+        assert verdict.claims["temperature"] == 25.0
+
+    def test_a_row_carries_what_its_own_bytes_say(self, komeco_rows):
+        """"says Heat 26, will say Heat 25" comes from here."""
+        verdict = komeco_rows[TARGET].verdict
+        assert verdict["reads_as"]["temperature"] == 26.0
+        assert verdict["claims"]["temperature"] == 25.0
+        assert verdict["matches"] is False
+
+    def test_integrity_rides_the_same_line(self, lattice, komeco_rows):
+        """The map's own checksum, on the candidate. A rule that cannot
+        be evaluated is None here and never a pass."""
+        row = komeco_rows[TARGET]
+        verdict = pre_read(lattice, row.donor["pronto"], row.target.coordinates)
+        assert verdict.integrity == {"complement_pairs": True}
+
+    def test_no_target_means_no_verdict_about_a_claim(self, lattice, komeco):
+        """Read the bytes, report them, claim nothing. matches stays
+        None rather than becoming a False nobody can justify."""
+        verdict = pre_read(lattice, _cell(komeco, "cool/high/off/22").pronto)
+        assert verdict.matches is None
+        assert verdict.mismatches == []
+        assert verdict.reads_as["temperature"] == 22.0
+        assert verdict.claims == {}
+
+    def test_unreadable_bytes_decline_rather_than_guess(self, lattice):
+        verdict = pre_read(
+            lattice, "0000 006D 0004 0000 0060 0020 0020 0020 0020 0060")
+        assert verdict.protocol is None
+        assert verdict.declined
+        assert verdict.reads_as == {}
+
+
+class TestTheFrameCheckRidesAlong:
+    def test_a_noisy_candidate_carries_its_vote(self, lattice):
+        """R1's check, on the candidate itself. A capture whose repeats
+        disagree is a bad capture whatever it reads as."""
+        dreo = _wig(DREO)
+        noisy = next(s for s in dreo.signals
+                     if s.alias == "Oscillate Horizontal")
+        verdict = pre_read(lattice, noisy.pronto)
+        assert verdict.frame_vote is not None
+        assert verdict.frame_vote["frames"] > 1
+
+    def test_a_clean_candidate_carries_none(self, lattice, komeco):
+        verdict = pre_read(lattice, _cell(komeco, "cool/high/off/22").pronto)
+        assert verdict.frame_vote is None
+
+
+class TestFlatCommands:
+    def test_a_flat_row_still_gets_read(self):
+        """No lattice, so no label to check against -- but the frame
+        vote and the decoded identity are the read-back a flat command
+        has, and both still arrive."""
+        dreo = _wig(DREO)
+        device = IRDevice(name="Dreo")
+        for signal in dreo.signals:
+            device.add_command(IRCommand(
+                name=signal.alias, category=CommandCategory.CUSTOM,
+                protocol="PRONTO", code=signal.pronto,
+            ))
+        rows = list_tangles(device, None).rows
+        assert rows
+        for row in rows:
+            assert row.verdict["matches"] is None
+            assert row.verdict["frame_vote"] is not None
+
+    def test_the_flat_read_uses_the_same_family_vote(self):
+        """A single code matching one map by coincidence must not name a
+        family for a whole remote -- R2's bench find, and it applies to
+        a device exactly as it applies to a file."""
+        dreo = _wig(DREO)
+        device = IRDevice(name="Dreo")
+        for signal in dreo.signals:
+            device.add_command(IRCommand(
+                name=signal.alias, category=CommandCategory.CUSTOM,
+                protocol="PRONTO", code=signal.pronto,
+            ))
+        wig, _sources = project_device(device, None)
+        assert read_lattice(None, wig).field_map is None
+
+
+class TestOverTheWire:
+    @pytest.fixture
+    def wired(self, fake_hass, komeco):
+        device = IRDevice(name="Komeco", climate_matrix=True,
+                          emitter_entity_ids=["infrared.blaster"])
+        manager = MagicMock()
+        manager.get_device = MagicMock(return_value=device)
+        manager.async_get_matrix = AsyncMock(return_value=komeco.climate)
+        manager.async_test_send = AsyncMock(
+            return_value={"infrared.blaster"})
+        fake_hass.data[DOMAIN] = {"entry-1": {"device_manager": manager}}
+        return fake_hass, device, manager
+
+    @pytest.mark.asyncio
+    async def test_pre_read_over_the_wire(self, wired, komeco):
+        hass, device, _manager = wired
+        donor = _cell(komeco, "heat_cool/medium/off/24")
+        connection = MagicMock()
+        await ws_tangle_pre_read(hass, connection, {
+            "id": 1, "type": "hair/device/tangle/pre-read",
+            "device_id": device.id, "pronto": donor.pronto,
+            "target": f"cell:{TARGET}",
+        })
+        connection.send_error.assert_not_called()
+        payload = connection.send_result.call_args.args[1]
+        assert payload["matches"] is True
+        assert payload["reads_as"]["temperature"] == 25.0
+
+    @pytest.mark.asyncio
+    async def test_a_target_with_no_finding_is_refused(self, wired, komeco):
+        """The pre-read is part of a repair, and there is no repair for
+        a cell nothing is wrong with."""
+        hass, device, _manager = wired
+        connection = MagicMock()
+        await ws_tangle_pre_read(hass, connection, {
+            "id": 1, "type": "hair/device/tangle/pre-read",
+            "device_id": device.id,
+            "pronto": _cell(komeco, "cool/high/off/22").pronto,
+            "target": "cell:cool/high/off/22",
+        })
+        connection.send_result.assert_not_called()
+        assert connection.send_error.call_args.args[1] == "unknown_target"
+
+    @pytest.mark.asyncio
+    async def test_test_send_transmits_and_saves_nothing(self, wired, komeco):
+        hass, device, manager = wired
+        donor = _cell(komeco, "heat_cool/medium/off/24")
+        connection = MagicMock()
+        await ws_tangle_test_send(hass, connection, {
+            "id": 1, "type": "hair/device/tangle/test-send",
+            "device_id": device.id, "pronto": donor.pronto, "send_count": 1,
+        })
+        connection.send_error.assert_not_called()
+        assert connection.send_result.call_args.args[1]["sent"] is True
+        manager.async_test_send.assert_awaited_once()
+        manager.async_update_device.assert_not_called()
+        assert not device.commands
+
+    @pytest.mark.asyncio
+    async def test_a_device_with_no_emitters_says_so(self, wired, komeco):
+        hass, device, manager = wired
+        manager.async_test_send = AsyncMock(
+            side_effect=RuntimeError("Device x has no emitters configured"))
+        connection = MagicMock()
+        await ws_tangle_test_send(hass, connection, {
+            "id": 1, "type": "hair/device/tangle/test-send",
+            "device_id": device.id,
+            "pronto": _cell(komeco, "cool/high/off/22").pronto,
+        })
+        connection.send_result.assert_not_called()
+        assert connection.send_error.call_args.args[1] == "send_failed"
+
+
+class TestListeningIntoContext:
+    """The same listen path, aimed at a target.
+
+    Nothing about listening changes: one capture, the R1 notice, the
+    Mirror filter, the timeout. What is added is the read-back against
+    the cell the capture was aimed at, so a surface can answer "heard
+    it: 25 degrees" or "heard 29" without a second round trip.
+    """
+
+    class _Monitor:
+        def __init__(self):
+            self.subscribers = []
+
+        def subscribe(self, cb):
+            self.subscribers.append(cb)
+
+        def unsubscribe(self, cb):
+            if cb in self.subscribers:
+                self.subscribers.remove(cb)
+
+        def emit(self, summary):
+            for cb in list(self.subscribers):
+                cb(summary)
+
+    @staticmethod
+    def _store(pronto):
+        signal = MagicMock()
+        signal.code = pronto
+        signal.protocol = "PRONTO"
+        signal.decoded_fingerprint = None
+        signal.decoded_protocol = None
+        signal.heard_by = ["infrared.receiver"]
+        device = MagicMock()
+        device.get_signal_by_id = MagicMock(return_value=signal)
+        store = MagicMock()
+        store.get_device = MagicMock(return_value=device)
+        return store
+
+    async def _arm(self, fake_hass, komeco, pronto, target=None):
+        from custom_components.hair.websocket_api import ws_tangle_listen
+
+        device = IRDevice(name="Komeco", climate_matrix=True,
+                          emitter_entity_ids=["infrared.blaster"])
+        manager = MagicMock()
+        manager.get_device = MagicMock(return_value=device)
+        manager.async_get_matrix = AsyncMock(return_value=komeco.climate)
+        monitor = self._Monitor()
+        fake_hass.data[DOMAIN] = {"entry-1": {
+            "device_manager": manager,
+            "signal_monitor": monitor,
+            "signal_store": self._store(pronto),
+        }}
+        connection = MagicMock()
+        connection.subscriptions = {}
+        msg = {"id": 9, "type": "hair/device/tangle/listen",
+               "device_id": device.id}
+        if target:
+            msg["target"] = target
+        await ws_tangle_listen(fake_hass, connection, msg)
+        return connection, monitor
+
+    @pytest.mark.asyncio
+    async def test_a_right_press_reads_back_as_the_label(self, fake_hass,
+                                                         komeco):
+        donor = _cell(komeco, "heat_cool/medium/off/24")
+        connection, monitor = await self._arm(
+            fake_hass, komeco, donor.pronto, f"cell:{TARGET}")
+        assert connection.send_result.call_args.args[1] == {"listening": True}
+
+        monitor.emit({"device_id": "d", "device_fingerprint": "f",
+                      "signal_id": "s", "protocol": "PRONTO",
+                      "code": donor.pronto})
+        event = connection.send_event.call_args.args[1]
+        assert event["type"] == "tangle_capture"
+        assert event["target"] == f"cell:{TARGET}"
+        assert event["verdict"]["matches"] is True
+        assert event["verdict"]["reads_as"]["temperature"] == 25.0
+
+    @pytest.mark.asyncio
+    async def test_a_wrong_press_says_what_it_heard(self, fake_hass, komeco):
+        """The 19-heard-as-18 case. The capture is parked, not armed,
+        and the surface has the number it needs to say so."""
+        wrong = _cell(komeco, "heat_cool/medium/off/28")
+        connection, monitor = await self._arm(
+            fake_hass, komeco, wrong.pronto, f"cell:{TARGET}")
+        monitor.emit({"device_id": "d", "device_fingerprint": "f",
+                      "signal_id": "s", "protocol": "PRONTO",
+                      "code": wrong.pronto})
+        verdict = connection.send_event.call_args.args[1]["verdict"]
+        assert verdict["matches"] is False
+        assert verdict["reads_as"]["temperature"] == 29.0
+
+    @pytest.mark.asyncio
+    async def test_an_unaimed_listen_still_reads(self, fake_hass, komeco):
+        cell = _cell(komeco, "cool/high/off/22")
+        connection, monitor = await self._arm(
+            fake_hass, komeco, cell.pronto)
+        monitor.emit({"device_id": "d", "device_fingerprint": "f",
+                      "signal_id": "s", "protocol": "PRONTO",
+                      "code": cell.pronto})
+        event = connection.send_event.call_args.args[1]
+        assert "target" not in event
+        assert event["verdict"]["matches"] is None
+        assert event["verdict"]["reads_as"]["temperature"] == 22.0
+
+    @pytest.mark.asyncio
+    async def test_the_capture_notice_still_rides(self, fake_hass, komeco):
+        """R1's warn-and-allow line is not replaced by the read-back;
+        both facts reach the surface together."""
+        noisy = next(s for s in _wig(DREO).signals
+                     if s.alias == "Oscillate Horizontal")
+        connection, monitor = await self._arm(
+            fake_hass, komeco, noisy.pronto, f"cell:{TARGET}")
+        monitor.emit({"device_id": "d", "device_fingerprint": "f",
+                      "signal_id": "s", "protocol": "PRONTO",
+                      "code": noisy.pronto})
+        event = connection.send_event.call_args.args[1]
+        assert event["repeats_disagree"]["frames"] > 1
+        assert event["verdict"]["frame_vote"]["frames"] > 1

--- a/custom_components/hair/tests/test_tangles_clusters.py
+++ b/custom_components/hair/tests/test_tangles_clusters.py
@@ -34,6 +34,7 @@ from custom_components.hair.tangles import (
     MECHANIC_WITNESS,
     list_tangles,
 )
+from custom_components.hair.wig_comb import CHECK_DUPLICATED_NEIGHBOUR
 from custom_components.hair.wig_format import Wig, cell_key, parse_wig
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -63,29 +64,35 @@ def komeco():
 
 
 class TestTheKomecoCards:
-    def test_fifty_two_findings_three_cards(self, komeco):
+    def test_fifty_two_findings_two_cards(self, komeco):
         """The number that decides whether this surface is usable."""
         assert len(komeco.rows) == 52
-        assert len(komeco.clusters) == 3
+        assert len(komeco.clusters) == 2
 
-    def test_the_three_cards_are_what_actually_went_wrong(self, komeco):
-        """Pinned by identity, not by count.
-
-        The column sends one step high. Forty-four of those cells have a
-        correct copy one step below them. Four at the TOP of the range
-        wrap the four-bit field instead of stepping, which is the same
-        mistake arriving at the end of the domain. Four at the BOTTOM
-        have nothing below them to copy.
+    def test_the_two_cards_are_what_actually_went_wrong(self, komeco):
+        """Pinned by identity, not by count. The column sends one step
+        high. Forty-eight of those cells have a correct copy one step
+        below them; four at the bottom have nothing below them to copy.
         """
         shape = {
             (c.rule, c.mechanic, c.detail.get("step")): c.size
             for c in komeco.clusters
         }
         assert shape == {
-            (CLUSTER_SHIFT, MECHANIC_DONOR, 1.0): 44,
-            (CLUSTER_SHIFT, MECHANIC_DONOR, -15.0): 4,
-            (CLUSTER_SHIFT, MECHANIC_WITNESS, 1.0): 4,
+            (CLUSTER_SHIFT, MECHANIC_DONOR, 1): 48,
+            (CLUSTER_SHIFT, MECHANIC_WITNESS, 1): 4,
         }
+
+    def test_the_top_of_the_range_is_the_same_cause(self, komeco):
+        """A four-bit field wrapping is still one step high. Counting
+        the step around the field's own ring is what keeps the cells at
+        the top of the domain in the card that repairs them -- split
+        out, they draw their donor from a cell the other card
+        overwrites."""
+        card = next(c for c in komeco.clusters
+                    if c.mechanic == MECHANIC_DONOR)
+        tops = {m for m in card.members if m.endswith("/31")}
+        assert len(tops) == 4
 
     def test_the_witness_card_is_the_bottom_of_the_range(self, komeco):
         card = next(c for c in komeco.clusters
@@ -96,6 +103,16 @@ class TestTheKomecoCards:
             "cell:heat_cool/medium/off/19",
             "cell:heat_cool/medium/vertical/19",
         }
+
+    def test_a_card_that_feeds_another_is_offered_after_it(self, komeco):
+        """The witness card holds the donors the big card needs, so it
+        sorts behind it. Worked top down, every donor is still there
+        when its card runs."""
+        card = next(c for c in komeco.clusters
+                    if c.mechanic == MECHANIC_WITNESS)
+        assert card.detail["feeds"] == [
+            "same-shift:temperature:1:donor"]
+        assert komeco.clusters[-1] is card
 
     def test_every_row_is_on_exactly_one_card(self, komeco):
         """A row on no card is a repair nobody is offered; a row on two
@@ -125,9 +142,8 @@ class TestDeterminism:
         """So a card the user opened yesterday is the same card today,
         on any install, after any restart."""
         assert {c.id for c in komeco.clusters} == {
-            "same-shift:temperature:1.0:donor",
-            "same-shift:temperature:-15.0:donor",
-            "same-shift:temperature:1.0:witness",
+            "same-shift:temperature:1:donor",
+            "same-shift:temperature:1:witness",
         }
         for card in komeco.clusters:
             assert card.id.startswith(card.cause)
@@ -159,55 +175,57 @@ class TestNoInventedStructure:
 
 
 class TestByteIdenticalGroups:
-    def test_a_shared_code_lists_every_location(self):
-        """One card per shared code, listing everywhere it appears --
-        and NOT split by road, because the answer to "these four cells
-        send the same bytes" is about the group, not the member.
+    def test_a_twin_that_also_lies_is_filed_as_the_lie(self):
+        """The severity order is about which finding a person reads
+        first, and it is right. This is about which finding is the
+        CAUSE, and a duplicate whose own bytes also disagree with its
+        own label is a symptom of that disagreement.
+
+        It matters because that is what a half-repaired shift looks
+        like from the inside: copy a donor into a cell and it matches
+        the still-broken neighbour it copied from until that neighbour
+        is repaired too. Ranking the twin first would pull cells out of
+        the very card about to fix them.
         """
-        def drift(cells):
-            for swing in ("off", "both", "horizontal", "vertical"):
-                cells[f"cool/medium/{swing}/22"].pronto = cells[
-                    f"cool/medium/{swing}/23"].pronto
-
-        listing = _komeco_listing(drift)
-        duplicates = [c for c in listing.clusters
-                      if c.rule == CLUSTER_IDENTICAL]
-        assert len(duplicates) == 4
-        assert all(card.size == 2 for card in duplicates)
-        for card in duplicates:
-            assert len({m.rsplit("/", 1)[-1] for m in card.members}) == 2
-
-    def test_the_duplicate_outranks_the_mismatch_that_came_with_it(self):
-        """A cell that is both a duplicate and a lie is a duplicate
-        first: the comb ranks it higher, and its repair is different in
-        kind -- one of the two has to change, and no donor decides
-        which."""
         def drift(cells):
             cells["cool/medium/off/22"].pronto = cells[
                 "cool/medium/off/23"].pronto
 
         listing = _komeco_listing(drift)
-        card = next(c for c in listing.clusters
-                    if c.rule == CLUSTER_IDENTICAL)
-        assert set(card.members) == {
-            "cell:cool/medium/off/22", "cell:cool/medium/off/23"}
+        rows = {r.target.key: r for r in listing.rows}
+        liar = rows["cool/medium/off/22"]
+        assert liar.classes[0] == CHECK_DUPLICATED_NEIGHBOUR
+        card = next(c for c in listing.clusters if liar.id in c.members)
+        assert card.rule == CLUSTER_SHIFT
+
+    def test_the_healthy_twin_stands_alone_until_its_partner_is_fixed(self):
+        """Cell 23 is correct. It is only a duplicate because 22 is
+        carrying its code, and that stops being true the moment 22 is
+        repaired -- so it is its own small card and not part of the
+        repair."""
+        def drift(cells):
+            cells["cool/medium/off/22"].pronto = cells[
+                "cool/medium/off/23"].pronto
+
+        listing = _komeco_listing(drift)
+        rows = {r.target.key: r for r in listing.rows}
+        healthy = rows["cool/medium/off/23"]
+        assert healthy.classes == [CHECK_DUPLICATED_NEIGHBOUR]
+        card = next(c for c in listing.clusters if healthy.id in c.members)
+        assert card.rule == CLUSTER_IDENTICAL
+        assert card.members == [healthy.id]
 
 
 class TestTheDriftedColumn:
-    def test_a_four_cell_drift_does_not_land_as_one_card(self):
-        """The SG15H shape, and an honest correction to the expectation
-        written for it.
+    def test_a_four_cell_drift_joins_the_cause_that_explains_it(self):
+        """The SG15H shape.
 
-        Four cells sending T+1 inside an otherwise healthy column do NOT
-        collapse to a single card of four, and cannot. The top member of
-        any contiguous one-step drift is byte-identical to the healthy
-        cell above it -- that is what a one-step drift MEANS at its
-        upper edge -- so the duplicate check claims that pair, and the
-        bottom member has nothing left below it that reads as its label.
-        What survives in the shift card is the middle.
-
-        Pinned to what the checks actually compute rather than tuned to
-        a number reached by a different method.
+        Four cells sending one step high inside an otherwise healthy
+        column are the same mistake as any other one-step drift, so they
+        join that card -- except the one at the bottom, which has
+        nothing left below it that reads as its label and needs a press
+        instead. The healthy cell above the drift is briefly a duplicate
+        of its top member and says so on its own.
         """
         def drift(cells):
             source = {t: cells[f"cool/high/off/{t}"].pronto
@@ -216,27 +234,16 @@ class TestTheDriftedColumn:
                 cells[f"cool/high/off/{t}"].pronto = source[t + 1]
 
         listing = _komeco_listing(drift)
-        cards = {
-            card.id: card for card in listing.clusters
-            if any("cool/high/off" in member for member in card.members)
-        }
-        drifted = {
-            member for card in cards.values() for member in card.members
-            if "cool/high/off" in member
-        }
-        assert drifted == {
-            "cell:cool/high/off/20", "cell:cool/high/off/21",
-            "cell:cool/high/off/22", "cell:cool/high/off/23",
-            "cell:cool/high/off/24",
-        }
-        duplicate = next(c for c in cards.values()
-                         if c.rule == CLUSTER_IDENTICAL)
-        assert set(duplicate.members) == {
-            "cell:cool/high/off/23", "cell:cool/high/off/24"}
-
-        witness = next(c for c in cards.values()
-                       if c.mechanic == MECHANIC_WITNESS)
-        assert "cell:cool/high/off/20" in witness.members
+        placed = {}
+        for card in listing.clusters:
+            for member in card.members:
+                if "cool/high/off" in member:
+                    placed[member.rsplit("/", 1)[-1]] = card
+        assert set(placed) == {"20", "21", "22", "23", "24"}
+        assert {placed[t].mechanic for t in ("21", "22", "23")} == {
+            MECHANIC_DONOR}
+        assert placed["20"].mechanic == MECHANIC_WITNESS
+        assert placed["24"].rule == CLUSTER_IDENTICAL
 
     def test_two_drifted_columns_of_the_same_step_share_a_card(self):
         """Deliberate. The diagnosis is true of every member -- the
@@ -253,7 +260,7 @@ class TestTheDriftedColumn:
 
         listing = _komeco_listing(drift)
         card = next(c for c in listing.clusters
-                    if c.id == "same-shift:temperature:1.0:donor")
+                    if c.id == "same-shift:temperature:1:donor")
         assert "cell:cool/high/off/21" in card.members
         assert "cell:heat_cool/medium/off/25" in card.members
         assert sorted(card.detail["spans"]["mode"]) == ["cool", "heat_cool"]

--- a/custom_components/hair/tests/test_tangles_clusters.py
+++ b/custom_components/hair/tests/test_tangles_clusters.py
@@ -1,0 +1,260 @@
+"""Causes, not findings.
+
+Fifty-two findings must not read as fifty-two chores. The comb emits one
+finding per cell because that is what it observed; this tier asks what
+went wrong ONCE and lists the cells as the evidence behind it.
+
+Two axes decide a card, and both are needed. The CAUSE says why these
+targets are wrong together. The MECHANIC says what can be done about
+them, and it has to split a cause when one road runs out: the Komeco
+column is a single shift, but the four cells at the bottom of its range
+have nothing to copy from and have to be witnessed instead, and a card
+with two primary actions is not a card.
+
+Nothing here invents structure. Where the rules do not group, the row
+stands alone.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from custom_components.hair.models import (
+    CommandCategory,
+    IRCommand,
+    IRDevice,
+)
+from custom_components.hair.tangles import (
+    CLUSTER_IDENTICAL,
+    CLUSTER_SHIFT,
+    CLUSTER_SINGLETON,
+    MECHANIC_DONOR,
+    MECHANIC_RECAPTURE,
+    MECHANIC_WITNESS,
+    list_tangles,
+)
+from custom_components.hair.wig_format import Wig, cell_key, parse_wig
+
+FIXTURES = Path(__file__).parent / "fixtures"
+KOMECO = (FIXTURES / "wigs"
+          / "komeco-airconditioner-kos-09qc-3hx-perfect-fit.wig.json")
+DREO = (FIXTURES / "wigs"
+        / "dreo-fan-dr-haf004s-perfect-fit.wig.json")
+
+
+def _wig(path: Path) -> Wig:
+    parsed = parse_wig(path.read_text())
+    assert parsed.wig is not None, parsed.errors
+    return parsed.wig
+
+
+def _komeco_listing(mutate=None):
+    wig = _wig(KOMECO)
+    if mutate is not None:
+        mutate({cell_key(c): c for c in wig.climate.cells})
+    return list_tangles(
+        IRDevice(name="Komeco", climate_matrix=True), wig.climate)
+
+
+@pytest.fixture(scope="module")
+def komeco():
+    return _komeco_listing()
+
+
+class TestTheKomecoCards:
+    def test_fifty_two_findings_three_cards(self, komeco):
+        """The number that decides whether this surface is usable."""
+        assert len(komeco.rows) == 52
+        assert len(komeco.clusters) == 3
+
+    def test_the_three_cards_are_what_actually_went_wrong(self, komeco):
+        """Pinned by identity, not by count.
+
+        The column sends one step high. Forty-four of those cells have a
+        correct copy one step below them. Four at the TOP of the range
+        wrap the four-bit field instead of stepping, which is the same
+        mistake arriving at the end of the domain. Four at the BOTTOM
+        have nothing below them to copy.
+        """
+        shape = {
+            (c.rule, c.mechanic, c.detail.get("step")): c.size
+            for c in komeco.clusters
+        }
+        assert shape == {
+            (CLUSTER_SHIFT, MECHANIC_DONOR, 1.0): 44,
+            (CLUSTER_SHIFT, MECHANIC_DONOR, -15.0): 4,
+            (CLUSTER_SHIFT, MECHANIC_WITNESS, 1.0): 4,
+        }
+
+    def test_the_witness_card_is_the_bottom_of_the_range(self, komeco):
+        card = next(c for c in komeco.clusters
+                    if c.mechanic == MECHANIC_WITNESS)
+        assert set(card.members) == {
+            "cell:heat_cool/medium/both/19",
+            "cell:heat_cool/medium/horizontal/19",
+            "cell:heat_cool/medium/off/19",
+            "cell:heat_cool/medium/vertical/19",
+        }
+
+    def test_every_row_is_on_exactly_one_card(self, komeco):
+        """A row on no card is a repair nobody is offered; a row on two
+        is a repair somebody applies twice."""
+        members = [m for c in komeco.clusters for m in c.members]
+        assert sorted(members) == sorted(r.id for r in komeco.rows)
+
+    def test_a_card_says_what_it_spans(self, komeco):
+        """The representative test picks its sample from this."""
+        for card in komeco.clusters:
+            assert card.detail["spans"]["mode"] == ["heat_cool"]
+            assert card.detail["spans"]["fan"] == ["medium"]
+            assert card.detail["spans"]["swing"] == [
+                "both", "horizontal", "off", "vertical"]
+
+    def test_the_cards_name_the_field(self, komeco):
+        assert {c.field for c in komeco.clusters} == {"temperature"}
+
+
+class TestDeterminism:
+    def test_two_calls_agree(self):
+        first, second = _komeco_listing(), _komeco_listing()
+        assert [c.as_dict() for c in first.clusters] == [
+            c.as_dict() for c in second.clusters]
+
+    def test_ids_come_from_the_cause_not_a_counter(self, komeco):
+        """So a card the user opened yesterday is the same card today,
+        on any install, after any restart."""
+        assert {c.id for c in komeco.clusters} == {
+            "same-shift:temperature:1.0:donor",
+            "same-shift:temperature:-15.0:donor",
+            "same-shift:temperature:1.0:witness",
+        }
+        for card in komeco.clusters:
+            assert card.id.startswith(card.cause)
+
+
+class TestNoInventedStructure:
+    def test_the_dreo_stays_two_separate_things(self):
+        """Two noisy captures on one remote are two accidents, not a
+        pattern. The receipt carries no capture session to group them
+        by, so grouping them would be a claim nothing supports."""
+        wig = _wig(DREO)
+        device = IRDevice(name="Dreo")
+        for signal in wig.signals:
+            device.add_command(IRCommand(
+                name=signal.alias, category=CommandCategory.CUSTOM,
+                protocol="PRONTO", code=signal.pronto,
+                send_count=signal.send_count,
+                repeat_count=signal.ditto_count,
+                tx_force_raw=signal.bypass_protocol,
+            ))
+        listing = list_tangles(device, None)
+        assert len(listing.clusters) == 2
+        assert {c.rule for c in listing.clusters} == {CLUSTER_SINGLETON}
+        assert {c.mechanic for c in listing.clusters} == {MECHANIC_RECAPTURE}
+        assert all(c.size == 1 for c in listing.clusters)
+
+    def test_a_clean_device_has_no_cards(self):
+        assert list_tangles(IRDevice(name="Bare"), None).clusters == []
+
+
+class TestByteIdenticalGroups:
+    def test_a_shared_code_lists_every_location(self):
+        """One card per shared code, listing everywhere it appears --
+        and NOT split by road, because the answer to "these four cells
+        send the same bytes" is about the group, not the member.
+        """
+        def drift(cells):
+            for swing in ("off", "both", "horizontal", "vertical"):
+                cells[f"cool/medium/{swing}/22"].pronto = cells[
+                    f"cool/medium/{swing}/23"].pronto
+
+        listing = _komeco_listing(drift)
+        duplicates = [c for c in listing.clusters
+                      if c.rule == CLUSTER_IDENTICAL]
+        assert len(duplicates) == 4
+        assert all(card.size == 2 for card in duplicates)
+        for card in duplicates:
+            assert len({m.rsplit("/", 1)[-1] for m in card.members}) == 2
+
+    def test_the_duplicate_outranks_the_mismatch_that_came_with_it(self):
+        """A cell that is both a duplicate and a lie is a duplicate
+        first: the comb ranks it higher, and its repair is different in
+        kind -- one of the two has to change, and no donor decides
+        which."""
+        def drift(cells):
+            cells["cool/medium/off/22"].pronto = cells[
+                "cool/medium/off/23"].pronto
+
+        listing = _komeco_listing(drift)
+        card = next(c for c in listing.clusters
+                    if c.rule == CLUSTER_IDENTICAL)
+        assert set(card.members) == {
+            "cell:cool/medium/off/22", "cell:cool/medium/off/23"}
+
+
+class TestTheDriftedColumn:
+    def test_a_four_cell_drift_does_not_land_as_one_card(self):
+        """The SG15H shape, and an honest correction to the expectation
+        written for it.
+
+        Four cells sending T+1 inside an otherwise healthy column do NOT
+        collapse to a single card of four, and cannot. The top member of
+        any contiguous one-step drift is byte-identical to the healthy
+        cell above it -- that is what a one-step drift MEANS at its
+        upper edge -- so the duplicate check claims that pair, and the
+        bottom member has nothing left below it that reads as its label.
+        What survives in the shift card is the middle.
+
+        Pinned to what the checks actually compute rather than tuned to
+        a number reached by a different method.
+        """
+        def drift(cells):
+            source = {t: cells[f"cool/high/off/{t}"].pronto
+                      for t in (21, 22, 23, 24)}
+            for t in (20, 21, 22, 23):
+                cells[f"cool/high/off/{t}"].pronto = source[t + 1]
+
+        listing = _komeco_listing(drift)
+        cards = {
+            card.id: card for card in listing.clusters
+            if any("cool/high/off" in member for member in card.members)
+        }
+        drifted = {
+            member for card in cards.values() for member in card.members
+            if "cool/high/off" in member
+        }
+        assert drifted == {
+            "cell:cool/high/off/20", "cell:cool/high/off/21",
+            "cell:cool/high/off/22", "cell:cool/high/off/23",
+            "cell:cool/high/off/24",
+        }
+        duplicate = next(c for c in cards.values()
+                         if c.rule == CLUSTER_IDENTICAL)
+        assert set(duplicate.members) == {
+            "cell:cool/high/off/23", "cell:cool/high/off/24"}
+
+        witness = next(c for c in cards.values()
+                       if c.mechanic == MECHANIC_WITNESS)
+        assert "cell:cool/high/off/20" in witness.members
+
+    def test_two_drifted_columns_of_the_same_step_share_a_card(self):
+        """Deliberate. The diagnosis is true of every member -- the
+        temperature reads one step high -- and the card carries the
+        spans, so a surface can still name both columns. Splitting by
+        coordinate would multiply the Komeco load by its swing count for
+        no gain in what anybody has to decide.
+        """
+        def drift(cells):
+            source = {t: cells[f"cool/high/off/{t}"].pronto
+                      for t in (21, 22, 23, 24)}
+            for t in (20, 21, 22, 23):
+                cells[f"cool/high/off/{t}"].pronto = source[t + 1]
+
+        listing = _komeco_listing(drift)
+        card = next(c for c in listing.clusters
+                    if c.id == "same-shift:temperature:1.0:donor")
+        assert "cell:cool/high/off/21" in card.members
+        assert "cell:heat_cool/medium/off/25" in card.members
+        assert sorted(card.detail["spans"]["mode"]) == ["cool", "heat_cool"]
+        assert sorted(card.detail["spans"]["fan"]) == ["high", "medium"]

--- a/custom_components/hair/tests/test_tangles_donors.py
+++ b/custom_components/hair/tests/test_tangles_donors.py
@@ -1,0 +1,194 @@
+"""The donor search: a repair that already exists somewhere in the wig.
+
+A donor is not a reconstruction. Nothing here builds a frame, adjusts
+one, or reasons about what bytes ought to look like. It asks one
+question of codes that are already in the lattice -- does any of them
+already send what this cell is supposed to send -- and where the answer
+is no it says so and stops.
+
+The Komeco column is the worked example and the reason the abstention
+matters. Its defect is a shift: every cell sends what the next one up
+should send. So 48 of the 52 have a donor sitting one step below them,
+and the four at the bottom of the range have nothing to draw on,
+because no code anywhere in that wig reads as 19.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from custom_components.hair.models import IRDevice
+from custom_components.hair.tangles import (
+    ABSTAIN_NO_READING,
+    ABSTAIN_NOT_A_FIELD,
+    ABSTAIN_NOT_RATIFIED,
+    ABSTAIN_UNREADABLE,
+    find_donor,
+    list_tangles,
+    read_lattice,
+)
+from custom_components.hair.wig_comb import (
+    CHECK_FIELD_MISMATCH,
+    CHECK_FRAME_DISAGREEMENT,
+)
+from custom_components.hair.wig_format import ClimateCell, ClimateMatrix, Wig, parse_wig
+
+FIXTURES = Path(__file__).parent / "fixtures"
+KOMECO = (FIXTURES / "wigs"
+          / "komeco-airconditioner-kos-09qc-3hx-perfect-fit.wig.json")
+
+#: The four cells at the bottom of the defective column. Nothing in the
+#: wig reads as 19, so the search has nowhere to look.
+NO_DONOR = {
+    "heat_cool/medium/both/19",
+    "heat_cool/medium/horizontal/19",
+    "heat_cool/medium/off/19",
+    "heat_cool/medium/vertical/19",
+}
+
+
+@pytest.fixture(scope="module")
+def komeco() -> Wig:
+    parsed = parse_wig(KOMECO.read_text())
+    assert parsed.wig is not None, parsed.errors
+    return parsed.wig
+
+
+@pytest.fixture(scope="module")
+def listing(komeco):
+    return list_tangles(IRDevice(name="Komeco", climate_matrix=True),
+                        komeco.climate)
+
+
+def _mismatch(field: str = "temperature") -> list[dict]:
+    return [{"check": CHECK_FIELD_MISMATCH,
+             "params": {"field": f"comb.field.{field}"}}]
+
+
+class TestTheKomecoColumn:
+    def test_forty_eight_of_fifty_two(self, listing):
+        """The ticket's acceptance number, and the abstention beside
+        it. A search that found 52 would have invented four."""
+        assert len(listing.rows) == 52
+        assert sum(1 for row in listing.rows if row.has_donor) == 48
+
+    def test_the_four_that_abstain_are_the_bottom_of_the_range(self, listing):
+        without = {row.target.key for row in listing.rows
+                   if not row.has_donor}
+        assert without == NO_DONOR
+
+    def test_an_abstention_says_why(self, listing):
+        """Silence and "I looked and there is nothing" are different
+        answers, and only one of them tells a person what to do next."""
+        for row in listing.rows:
+            if row.has_donor:
+                assert row.donor_abstain is None
+            else:
+                assert row.donor_abstain == ABSTAIN_NO_READING
+
+    def test_the_donor_is_the_cell_one_step_down(self, listing):
+        """Pinned concretely rather than by shape: the column sends
+        T+1, so the frame that reads as 25 is the one labelled 24."""
+        row = next(r for r in listing.rows
+                   if r.target.key == "heat_cool/medium/off/25")
+        assert row.donor["key"] == "heat_cool/medium/off/24"
+        assert row.donor["reasoning"] == {
+            "fields": ["temperature"],
+            "labelled": {"temperature": 24.0},
+            "reads_as": {"temperature": 25.0},
+        }
+
+    def test_the_donor_carries_the_bytes_and_their_digest(self, listing,
+                                                          komeco):
+        row = next(r for r in listing.rows
+                   if r.target.key == "heat_cool/medium/off/25")
+        source = next(c for c in komeco.climate.cells
+                      if c.temp == 24 and c.fan == "medium"
+                      and c.mode == "heat_cool" and c.swing == "off")
+        assert row.donor["pronto"] == source.pronto
+        assert row.donor["pronto"] != row.pronto
+
+    def test_a_donor_never_comes_from_another_corner_of_the_lattice(
+            self, listing):
+        """The only field this map ratifies on these cells is
+        temperature, so nothing but the coordinate anchor stops a
+        cooling frame being offered to repair a heating one."""
+        for row in listing.rows:
+            if not row.has_donor:
+                continue
+            here, there = row.target.coordinates, row.donor["coordinates"]
+            assert (here["mode"], here["fan"], here["swing"]) == (
+                there["mode"], there["fan"], there["swing"])
+            assert here["temp"] != there["temp"]
+
+
+class TestWhenItRefuses:
+    def test_a_damaged_capture_has_no_donor(self, komeco):
+        """Another cell's bytes do not repair a noisy recording of this
+        one. The search declines the class rather than offering the
+        nearest thing it can find."""
+        lattice = read_lattice(komeco.climate)
+        donor, reason = find_donor(
+            lattice, "heat_cool/medium/off/25",
+            [{"check": CHECK_FRAME_DISAGREEMENT, "params": {}}],
+        )
+        assert donor is None
+        assert reason == ABSTAIN_NOT_A_FIELD
+
+    def test_a_provisional_field_is_not_searched(self, komeco):
+        """ZHLT01 marks mode provisional -- its own family inverts two
+        mode values between files. A field the map will not vouch for
+        cannot decide which frame is the right one."""
+        lattice = read_lattice(komeco.climate)
+        donor, reason = find_donor(
+            lattice, "heat_cool/medium/off/25", _mismatch("mode"))
+        assert donor is None
+        assert reason == ABSTAIN_NOT_RATIFIED
+
+    def test_an_unreadable_lattice_abstains(self):
+        cells = [ClimateCell(mode="cool", fan="auto", temp=float(t),
+                             pronto="0000 006D 0004 0000 0060 0020 0020 "
+                                    "0020 0020 0020 0020 0060")
+                 for t in (20, 21)]
+        matrix = ClimateMatrix(
+            min_temp=20.0, max_temp=21.0,
+            off="0000 006D 0002 0000 0060 0020 0020 0060",
+            cells=cells, modes=["cool"], fan_modes=["auto"],
+        )
+        lattice = read_lattice(matrix)
+        assert not lattice.readable
+        donor, reason = find_donor(lattice, "cool/auto/20", _mismatch())
+        assert donor is None
+        assert reason == ABSTAIN_UNREADABLE
+
+    def test_no_lattice_at_all_abstains(self):
+        lattice = read_lattice(None)
+        assert not lattice.readable
+        assert find_donor(lattice, "anything", _mismatch()) == (
+            None, ABSTAIN_UNREADABLE)
+
+
+class TestStability:
+    def test_the_same_lattice_gives_the_same_donors(self, komeco):
+        """Derived and pure: two calls over unchanged bytes agree, so a
+        card the user opened twice never offers two different repairs."""
+        device = IRDevice(name="Komeco", climate_matrix=True)
+        first = list_tangles(device, komeco.climate)
+        second = list_tangles(device, komeco.climate)
+        assert [row.as_dict() for row in first.rows] == [
+            row.as_dict() for row in second.rows]
+
+    def test_the_lattice_is_read_before_any_repair_lands(self, komeco,
+                                                         listing):
+        """Every donor in one listing is resolved against the lattice as
+        it stands, not against a lattice that is being written to. On a
+        shifted column a search that re-read after each write would
+        chase the shift and hand back the bytes it had just replaced.
+        """
+        lattice = read_lattice(komeco.climate)
+        for row in listing.rows:
+            if not row.has_donor:
+                continue
+            assert lattice.cells[row.donor["key"]].pronto == row.donor[
+                "pronto"]

--- a/custom_components/hair/tests/test_tangles_end_to_end.py
+++ b/custom_components/hair/tests/test_tangles_end_to_end.py
@@ -474,6 +474,66 @@ class TestBackToTheCloset:
             (wigs_dir(tmp_path) / saved["filename"]).read_text())
         assert not successor.get("fittings")
 
+    @pytest.mark.asyncio
+    async def test_the_closet_has_it_without_anybody_saving(
+            self, adopted, _no_signing):
+        """The C10 acceptance: run the loop and never call save.
+
+        Same repairs as the test above, same KEEP, and then nothing --
+        no dialog, no save handler, no second decision asked of the
+        person. What makes the surface's "Your wig has been updated."
+        true is that it was already true before anything rendered.
+
+        The write-through's own guarantees live in
+        test_tangles_writethrough.py; what this pins is that the LOOP
+        arrives at a repaired wig on the shelf on its own.
+        """
+        hass, device, tmp_path, source = adopted
+
+        listing = await _tangles(hass, device)
+        card = next(c for c in listing["clusters"]
+                    if c["mechanic"] == "donor")
+        plan = await _call(ws_tangle_plan, hass, {
+            "id": 6, "type": "hair/device/tangle/plan",
+            "device_id": device.id, "cluster": card["id"],
+        })
+        batch = await _call(ws_tangle_apply_batch, hass, {
+            "id": 7, "type": "hair/device/tangle/apply-batch",
+            "device_id": device.id, "cluster": card["id"],
+            "tested": True, "tested_targets": plan["sample"],
+        })
+        listing = await _tangles(hass, device)
+        kept = await _call(ws_tangle_keep, hass, {
+            "id": 8, "type": "hair/device/tangle/keep",
+            "device_id": device.id, "target": listing["rows"][0]["id"],
+            "tested": True, "note": "runs fine on my unit",
+        })
+
+        # The line the surface gates on, on both messages.
+        assert batch["wig"]["written"] is True
+        assert kept["wig"]["written"] is True
+
+        shelf = sorted(p.name for p in wigs_dir(tmp_path).glob("*.wig.json"))
+        assert SOURCE in shelf, "the contributor's file is still theirs"
+        assert len(shelf) == 2, shelf
+
+        repaired = parse_wig(
+            (wigs_dir(tmp_path) / kept["wig"]["filename"]).read_text()).wig
+        assert repaired is not None
+        assert source.wig_id in repaired.supersedes
+
+        # The repairs, the record and the human's answer all travelled.
+        matrix = load_matrix(str(tmp_path), device.id)
+        cells = {cell_key(c): c for c in repaired.climate.cells}
+        for cell in matrix.cells:
+            assert cells[cell_key(cell)].pronto == cell.pronto
+        assert sum(
+            1 for cell in cells.values()
+            if (getattr(cell, "extra", None) or {}).get(PROVENANCE_KEY)
+        ) == 48
+        assert repaired.extra[COMB_KEY][ATTESTED_KEY][0]["note"] == (
+            "runs fine on my unit")
+
 
 class TestTheFlatFan:
     """The Dreo: seven buttons, two noisy captures, no lattice at all.

--- a/custom_components/hair/tests/test_tangles_end_to_end.py
+++ b/custom_components/hair/tests/test_tangles_end_to_end.py
@@ -1,0 +1,606 @@
+"""The whole loop, through the shipped handlers.
+
+A contributor's file arrives with 52 wrong cells. Somebody adopts it,
+works the cards the surface would show them, presses their own remote
+once for the cells nothing could be copied for, vouches for one finding
+they decided is fine, and saves the result back to the closet -- and
+what lands there is clean, carries the record of every repair, and no
+longer claims the fittings that were signed over the broken bytes.
+
+Nothing below reaches past a websocket handler. The adopt is the adopt,
+the repairs are the repairs, and the save is the save. The point of the
+file is that the pieces fit together, not that each works alone -- that
+is what the other five suites are for.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.hair import field_readers
+from custom_components.hair.const import DOMAIN
+from custom_components.hair.matrix_store import load_matrix, matrix_content_hash
+from custom_components.hair.tangles import (
+    APPLY_NO_FINDING,
+    APPLY_NOT_TESTED,
+    ATTESTED_KEY,
+    PROVENANCE_KEY,
+    TIER_AIR_TESTED,
+    TIER_RULE_DERIVED,
+    read_lattice,
+    rewrite_field,
+)
+from custom_components.hair.websocket_api import (
+    ws_device_tangles,
+    ws_tangle_apply,
+    ws_tangle_apply_batch,
+    ws_tangle_keep,
+    ws_tangle_plan,
+    ws_tangle_revert,
+    ws_wig_make_device,
+    ws_wigs_save,
+)
+from custom_components.hair.wig_comb import COMB_KEY, comb_wig, stamp_receipt
+from custom_components.hair.wig_format import cell_key, parse_wig, serialize_wig
+from custom_components.hair.wig_store import ensure_wigs_dir, wigs_dir
+
+FIXTURES = Path(__file__).parent / "fixtures"
+KOMECO = (FIXTURES / "wigs"
+          / "komeco-airconditioner-kos-09qc-3hx-perfect-fit.wig.json")
+DREO = (FIXTURES / "wigs"
+        / "dreo-fan-dr-haf004s-perfect-fit.wig.json")
+SOURCE = "komeco.wig.json"
+
+
+def _conn():
+    connection = MagicMock()
+    connection.send_result = MagicMock()
+    connection.send_error = MagicMock()
+    return connection
+
+
+async def _call(handler, hass, payload, *, expect_error=None):
+    connection = _conn()
+    await handler(hass, connection, payload)
+    if expect_error is None:
+        connection.send_error.assert_not_called()
+        return connection.send_result.call_args.args[1]
+    assert connection.send_error.call_args.args[1] == expect_error
+    connection.send_result.assert_not_called()
+    return None
+
+
+@pytest.fixture
+def _no_signing(monkeypatch):
+    monkeypatch.setattr(
+        "custom_components.hair.fitting_signing.async_get_private_key",
+        AsyncMock(return_value=None),
+    )
+
+
+@pytest.fixture
+async def adopted(fake_hass, tmp_path):
+    """The contributor's file, combed at import and adopted for real.
+
+    ``async_get_matrix`` reads the matrix FILE rather than holding an
+    object, so every repair below round-trips through disk exactly as it
+    would on a running install.
+    """
+    parsed = parse_wig(KOMECO.read_text())
+    assert parsed.wig is not None, parsed.errors
+    wig = parsed.wig
+    stamp_receipt(wig, comb_wig(wig), "2026-08-22")
+    ensure_wigs_dir(tmp_path)
+    (wigs_dir(tmp_path) / SOURCE).write_text(
+        serialize_wig(wig), encoding="utf-8")
+
+    fake_hass.config.config_dir = str(tmp_path)
+    devices: list = []
+    manager = MagicMock()
+    manager.async_create_device = AsyncMock(
+        side_effect=lambda d: devices.append(d))
+    manager.async_update_device = AsyncMock()
+    manager._auto_map_command = MagicMock()
+    manager.get_device = MagicMock(
+        side_effect=lambda did: next(
+            (d for d in devices if d.id == did), None))
+    manager.async_get_matrix = AsyncMock(
+        side_effect=lambda did: load_matrix(str(tmp_path), did))
+    store = MagicMock()
+    store.get_device = MagicMock(
+        side_effect=lambda did: next(
+            (d for d in devices if d.id == did), None))
+    store.get_all_devices = MagicMock(side_effect=lambda: list(devices))
+    fake_hass.data[DOMAIN] = {"entry-1": {
+        "device_manager": manager, "store": store,
+        "matrix_listener": MagicMock(), "fitting_manager": None,
+    }}
+
+    result = await _call(ws_wig_make_device, fake_hass, {
+        "id": 1, "type": "hair/wigs/make-device", "filename": SOURCE,
+        "name": "Komeco", "device_type": "ac",
+        "emitter_entity_ids": ["infrared.blaster"],
+    })
+    assert result["cell_rows"] == 52
+    return fake_hass, devices[0], tmp_path, wig
+
+
+async def _tangles(hass, device):
+    return await _call(ws_device_tangles, hass, {
+        "id": 2, "type": "hair/device/tangles", "device_id": device.id,
+    })
+
+
+async def _press(hass, device, tmp_path, row):
+    """A capture reading as the row's own label, on this hardware."""
+    matrix = load_matrix(str(tmp_path), device.id)
+    lattice = read_lattice(matrix)
+    spec = lattice.spec_for("temperature")
+    coordinates = row["target"]["coordinates"]
+    sibling = next(
+        c for c in matrix.cells
+        if cell_key(c) == (
+            f"{coordinates['mode']}/{coordinates['fan']}"
+            f"/{coordinates['swing']}/16"
+        )
+    )
+    built = rewrite_field(
+        lattice.field_map, sibling.pronto, spec,
+        field_readers.expected_value(spec, coordinates["temp"]),
+    )
+    assert built is not None
+    return built
+
+
+class TestTheListingOnARealAdopt:
+    @pytest.mark.asyncio
+    async def test_fifty_two_rows_two_cards(self, adopted):
+        hass, device, _tmp, _wig = adopted
+        listing = await _tangles(hass, device)
+        assert len(listing["rows"]) == 52
+        assert len(listing["clusters"]) == 2
+        assert listing["protocol"] == "ZHLT01"
+
+    @pytest.mark.asyncio
+    async def test_forty_eight_have_a_donor_and_four_abstain(self, adopted):
+        hass, device, _tmp, _wig = adopted
+        listing = await _tangles(hass, device)
+        assert sum(1 for r in listing["rows"] if r["has_donor"]) == 48
+        abstained = [r for r in listing["rows"] if not r["has_donor"]]
+        assert {r["target"]["key"] for r in abstained} == {
+            "heat_cool/medium/both/19",
+            "heat_cool/medium/horizontal/19",
+            "heat_cool/medium/off/19",
+            "heat_cool/medium/vertical/19",
+        }
+        assert {r["donor_abstain"] for r in abstained} == {
+            "no-cell-reads-this"}
+
+
+class TestOneRepairAndItsUndo:
+    @pytest.mark.asyncio
+    async def test_apply_lands_on_disk_and_moves_the_hash(self, adopted):
+        hass, device, tmp_path, _wig = adopted
+        before_hash = matrix_content_hash(str(tmp_path), device.id)
+        listing = await _tangles(hass, device)
+        row = next(r for r in listing["rows"]
+                   if r["target"]["key"] == "heat_cool/medium/off/25")
+
+        await _call(ws_tangle_apply, hass, {
+            "id": 3, "type": "hair/device/tangle/apply",
+            "device_id": device.id, "target": row["id"],
+            "pronto": row["donor"]["pronto"], "tested": True,
+            "source": "donor",
+        })
+
+        matrix = load_matrix(str(tmp_path), device.id)
+        cell = next(c for c in matrix.cells
+                    if cell_key(c) == "heat_cool/medium/off/25")
+        assert cell.pronto == row["donor"]["pronto"]
+        assert PROVENANCE_KEY in cell.extra
+        assert matrix_content_hash(str(tmp_path), device.id) != before_hash
+
+    @pytest.mark.asyncio
+    async def test_the_finding_goes_and_comes_back(self, adopted):
+        hass, device, _tmp, _wig = adopted
+        listing = await _tangles(hass, device)
+        row = next(r for r in listing["rows"]
+                   if r["target"]["key"] == "heat_cool/medium/off/25")
+
+        await _call(ws_tangle_apply, hass, {
+            "id": 3, "type": "hair/device/tangle/apply",
+            "device_id": device.id, "target": row["id"],
+            "pronto": row["donor"]["pronto"], "tested": True,
+            "source": "donor",
+        })
+        after = await _tangles(hass, device)
+        assert len([
+            r for r in after["rows"]
+            if "field-mismatch" in r["classes"]
+        ]) == 51
+
+        await _call(ws_tangle_revert, hass, {
+            "id": 4, "type": "hair/device/tangle/revert",
+            "device_id": device.id, "target": row["id"],
+        })
+        restored = await _tangles(hass, device)
+        assert len(restored["rows"]) == 52
+        assert "heat_cool/medium/off/25" in {
+            r["target"]["key"] for r in restored["rows"]}
+
+
+class TestTheGuardRails:
+    @pytest.mark.asyncio
+    async def test_apply_without_a_press_refuses(self, adopted):
+        hass, device, _tmp, _wig = adopted
+        listing = await _tangles(hass, device)
+        row = next(r for r in listing["rows"] if r["has_donor"])
+        await _call(ws_tangle_apply, hass, {
+            "id": 3, "type": "hair/device/tangle/apply",
+            "device_id": device.id, "target": row["id"],
+            "pronto": row["donor"]["pronto"], "tested": False,
+        }, expect_error=APPLY_NOT_TESTED)
+
+    @pytest.mark.asyncio
+    async def test_apply_to_a_healthy_cell_refuses(self, adopted):
+        hass, device, _tmp, _wig = adopted
+        listing = await _tangles(hass, device)
+        row = next(r for r in listing["rows"] if r["has_donor"])
+        await _call(ws_tangle_apply, hass, {
+            "id": 3, "type": "hair/device/tangle/apply",
+            "device_id": device.id, "target": "cell:cool/high/off/22",
+            "pronto": row["donor"]["pronto"], "tested": True,
+        }, expect_error=APPLY_NO_FINDING)
+
+    @pytest.mark.asyncio
+    async def test_an_attestation_expires_when_the_map_moves(self, adopted):
+        """The finding comes back on its own. Nothing swept it: the
+        attestation names the map version it answered, and a map that
+        has learned something since is asking a new question."""
+        hass, device, _tmp, _wig = adopted
+        listing = await _tangles(hass, device)
+        row = next(r for r in listing["rows"] if r["has_donor"])
+        await _call(ws_tangle_keep, hass, {
+            "id": 5, "type": "hair/device/tangle/keep",
+            "device_id": device.id, "target": row["id"], "tested": True,
+        })
+        quiet = await _tangles(hass, device)
+        assert row["target"]["key"] not in {
+            r["target"]["key"] for r in quiet["rows"]}
+
+        record = device.tangle_attestations[0]
+        target, digest, _version = record["key"].split("|")
+        record["key"] = f"{target}|{digest}|a-newer-map"
+        again = await _tangles(hass, device)
+        assert row["target"]["key"] in {
+            r["target"]["key"] for r in again["rows"]}
+        assert again["attested"] == []
+
+
+class TestTheWholeFile:
+    @pytest.mark.asyncio
+    async def test_two_cards_one_press_and_the_comb_goes_quiet(
+            self, adopted):
+        hass, device, tmp_path, _wig = adopted
+
+        listing = await _tangles(hass, device)
+        donor_card = next(c for c in listing["clusters"]
+                          if c["mechanic"] == "donor")
+        plan = await _call(ws_tangle_plan, hass, {
+            "id": 6, "type": "hair/device/tangle/plan",
+            "device_id": device.id, "cluster": donor_card["id"],
+        })
+        assert len(plan["candidates"]) == 48
+        run = await _call(ws_tangle_apply_batch, hass, {
+            "id": 7, "type": "hair/device/tangle/apply-batch",
+            "device_id": device.id, "cluster": donor_card["id"],
+            "tested": True, "tested_targets": plan["sample"],
+        })
+        assert run["applied"] == 48
+
+        listing = await _tangles(hass, device)
+        witness_card = next(c for c in listing["clusters"]
+                            if c["mechanic"] == "witness")
+        aimed = sorted(witness_card["members"])[0]
+        row = next(r for r in listing["rows"] if r["id"] == aimed)
+        press = await _press(hass, device, tmp_path, row)
+
+        plan = await _call(ws_tangle_plan, hass, {
+            "id": 8, "type": "hair/device/tangle/plan",
+            "device_id": device.id, "cluster": witness_card["id"],
+            "witness": press, "witness_target": aimed,
+        })
+        assert len(plan["candidates"]) == 4
+        assert plan["witness"]["reads_as"] == 19.0
+        run = await _call(ws_tangle_apply_batch, hass, {
+            "id": 9, "type": "hair/device/tangle/apply-batch",
+            "device_id": device.id, "cluster": witness_card["id"],
+            "tested": True, "tested_targets": plan["sample"],
+            "witness": press, "witness_target": aimed,
+        })
+        assert run["applied"] == 4
+
+        final = await _tangles(hass, device)
+        assert final["rows"] == []
+        assert final["clusters"] == []
+        matrix = load_matrix(str(tmp_path), device.id)
+        assert [
+            f for f in comb_wig(
+                parse_wig(KOMECO.read_text()).wig
+            ).findings
+        ], "the fixture itself is still the broken one"
+        repaired = parse_wig(KOMECO.read_text()).wig
+        repaired.climate = matrix
+        assert comb_wig(repaired).findings == []
+
+    @pytest.mark.asyncio
+    async def test_the_record_says_what_was_proved_on_air(self, adopted):
+        hass, device, tmp_path, _wig = adopted
+        listing = await _tangles(hass, device)
+        card = next(c for c in listing["clusters"]
+                    if c["mechanic"] == "donor")
+        plan = await _call(ws_tangle_plan, hass, {
+            "id": 6, "type": "hair/device/tangle/plan",
+            "device_id": device.id, "cluster": card["id"],
+        })
+        await _call(ws_tangle_apply_batch, hass, {
+            "id": 7, "type": "hair/device/tangle/apply-batch",
+            "device_id": device.id, "cluster": card["id"],
+            "tested": True, "tested_targets": plan["sample"],
+        })
+        matrix = load_matrix(str(tmp_path), device.id)
+        tiers = {
+            cell.extra[PROVENANCE_KEY]["tier"]
+            for cell in matrix.cells if PROVENANCE_KEY in cell.extra
+        }
+        assert tiers == {TIER_AIR_TESTED, TIER_RULE_DERIVED}
+        tested = {
+            cell_key(cell) for cell in matrix.cells
+            if cell.extra.get(PROVENANCE_KEY, {}).get("tier")
+            == TIER_AIR_TESTED
+        }
+        assert tested == {t.split(":", 1)[1] for t in plan["sample"]}
+
+
+class TestBackToTheCloset:
+    @pytest.mark.asyncio
+    async def test_the_successor_is_clean_and_carries_the_repairs(
+            self, adopted, _no_signing):
+        """The owner's loop, end to end.
+
+        Repair the file, vouch for one finding, save it back as a new
+        wig -- and what reaches the shelf combs clean, says how every
+        cell got there, and carries the human's answer beside the math.
+        """
+        hass, device, tmp_path, source = adopted
+
+        listing = await _tangles(hass, device)
+        card = next(c for c in listing["clusters"]
+                    if c["mechanic"] == "donor")
+        plan = await _call(ws_tangle_plan, hass, {
+            "id": 6, "type": "hair/device/tangle/plan",
+            "device_id": device.id, "cluster": card["id"],
+        })
+        await _call(ws_tangle_apply_batch, hass, {
+            "id": 7, "type": "hair/device/tangle/apply-batch",
+            "device_id": device.id, "cluster": card["id"],
+            "tested": True, "tested_targets": plan["sample"],
+        })
+
+        listing = await _tangles(hass, device)
+        kept = listing["rows"][0]
+        await _call(ws_tangle_keep, hass, {
+            "id": 8, "type": "hair/device/tangle/keep",
+            "device_id": device.id, "target": kept["id"], "tested": True,
+            "note": "runs fine on my unit",
+        })
+
+        saved = await _call(ws_wigs_save, hass, {
+            "id": 9, "type": "hair/wigs/save", "device_id": device.id,
+            "mode": "create", "name": "Komeco KOS 09QC 3HX repaired",
+        })
+        successor = json.loads(
+            (wigs_dir(tmp_path) / saved["filename"]).read_text())
+
+        # A NEW file, not the one it came from.
+        assert saved["filename"] != SOURCE
+        assert successor["wig_id"] != source.wig_id
+
+        parsed = parse_wig(json.dumps(successor))
+        assert parsed.wig is not None, parsed.errors
+        repaired = parsed.wig
+
+        # The repaired bytes travelled.
+        cells = {cell_key(c): c for c in repaired.climate.cells}
+        matrix = load_matrix(str(tmp_path), device.id)
+        for cell in matrix.cells:
+            assert cells[cell_key(cell)].pronto == cell.pronto
+
+        # And so did the record of how they got there.
+        with_records = [
+            c for c in repaired.climate.cells if PROVENANCE_KEY in c.extra
+        ]
+        assert len(with_records) == 48
+        record = with_records[0].extra[PROVENANCE_KEY]
+        assert record["origin"] == "fix"
+        assert record["source"] == "donor"
+        assert record["tested"] is True
+        assert record["map"]["id"] == "ZHLT01"
+        assert record["prior"]["pronto"]
+
+        # The human's answer rides in the receipt beside the math.
+        receipt = repaired.extra[COMB_KEY]
+        assert receipt[ATTESTED_KEY][0]["note"] == "runs fine on my unit"
+        assert "comb_attested_pending" not in repaired.extra
+
+        # And a fresh comb of what reached the shelf finds the four the
+        # donors could not reach and nothing else.
+        left = comb_wig(repaired).findings
+        assert {f.check for f in left} == {
+            "duplicated-neighbour", "field-mismatch"}
+        assert receipt["suspects"] == len(left)
+
+    @pytest.mark.asyncio
+    async def test_the_priors_do_not_follow_the_repaired_bytes(
+            self, adopted, _no_signing):
+        """Fix-then-fit. A signed claim binds the lattice it was signed
+        over, and this is not that lattice any more, so the successor
+        arrives asking to be fitted rather than carrying somebody's word
+        for bytes they never saw.
+        """
+        hass, device, tmp_path, source = adopted
+        assert source.extra.get("fittings"), "fixture carries a fitting"
+
+        listing = await _tangles(hass, device)
+        card = next(c for c in listing["clusters"]
+                    if c["mechanic"] == "donor")
+        plan = await _call(ws_tangle_plan, hass, {
+            "id": 6, "type": "hair/device/tangle/plan",
+            "device_id": device.id, "cluster": card["id"],
+        })
+        await _call(ws_tangle_apply_batch, hass, {
+            "id": 7, "type": "hair/device/tangle/apply-batch",
+            "device_id": device.id, "cluster": card["id"],
+            "tested": True, "tested_targets": plan["sample"],
+        })
+        saved = await _call(ws_wigs_save, hass, {
+            "id": 9, "type": "hair/wigs/save", "device_id": device.id,
+            "mode": "create", "name": "Komeco repaired",
+        })
+        successor = json.loads(
+            (wigs_dir(tmp_path) / saved["filename"]).read_text())
+        assert not successor.get("fittings")
+
+
+class TestTheFlatFan:
+    """The Dreo: seven buttons, two noisy captures, no lattice at all.
+
+    Everything the matrix path leans on is absent here -- no oracle, no
+    donors, no coordinates -- so what is left has to work on its own:
+    the finding, its vote, a candidate somebody pastes, and the same
+    door.
+    """
+
+    @pytest.fixture
+    async def fan(self, fake_hass, tmp_path):
+        from custom_components.hair.models import (
+            CommandCategory,
+            IRCommand,
+            IRDevice,
+        )
+
+        parsed = parse_wig(DREO.read_text())
+        assert parsed.wig is not None, parsed.errors
+        wig = parsed.wig
+        device = IRDevice(name="Dreo", emitter_entity_ids=["infrared.b"])
+        for signal in wig.signals:
+            device.add_command(IRCommand(
+                name=signal.alias, category=CommandCategory.CUSTOM,
+                protocol="PRONTO", code=signal.pronto,
+                send_count=signal.send_count,
+                repeat_count=signal.ditto_count,
+                tx_force_raw=signal.bypass_protocol,
+            ))
+        manager = MagicMock()
+        manager.get_device = MagicMock(return_value=device)
+        manager.async_get_matrix = AsyncMock(return_value=None)
+        manager.async_update_device = AsyncMock()
+        manager.async_test_send = AsyncMock(return_value={"infrared.b"})
+        fake_hass.config.config_dir = str(tmp_path)
+        fake_hass.data[DOMAIN] = {"entry-1": {"device_manager": manager}}
+        return fake_hass, device, wig, manager
+
+    @pytest.mark.asyncio
+    async def test_two_rows_no_donors_and_it_says_why(self, fan):
+        hass, device, _wig, _manager = fan
+        listing = await _tangles(hass, device)
+        assert len(listing["rows"]) == 2
+        assert {r["classes"][0] for r in listing["rows"]} == {
+            "frame-disagreement"}
+        assert not any(r["has_donor"] for r in listing["rows"])
+        assert listing["field_tier"] == "no-lattice"
+        assert listing["candidate_sources"] == ["capture", "paste"]
+
+    @pytest.mark.asyncio
+    async def test_every_row_carries_its_vote(self, fan):
+        hass, device, _wig, _manager = fan
+        listing = await _tangles(hass, device)
+        for row in listing["rows"]:
+            vote = row["findings"][0]["params"]
+            assert int(vote["frames"]) > 1
+            assert row["verdict"]["frame_vote"]["frames"] > 1
+
+    @pytest.mark.asyncio
+    async def test_a_pasted_candidate_is_read_sent_and_applied(self, fan):
+        hass, device, wig, manager = fan
+        from custom_components.hair.websocket_api import (
+            ws_tangle_pre_read,
+            ws_tangle_test_send,
+        )
+
+        listing = await _tangles(hass, device)
+        row = listing["rows"][0]
+        clean = next(
+            s.pronto for s in wig.signals
+            if s.alias not in {r["target"]["key"] for r in listing["rows"]}
+        )
+
+        verdict = await _call(ws_tangle_pre_read, hass, {
+            "id": 3, "type": "hair/device/tangle/pre-read",
+            "device_id": device.id, "target": row["id"], "pronto": clean,
+        })
+        # No lattice, so no claim to check against -- and it says so
+        # rather than inventing a verdict.
+        assert verdict["matches"] is None
+        assert verdict["frame_vote"] is None
+
+        await _call(ws_tangle_test_send, hass, {
+            "id": 4, "type": "hair/device/tangle/test-send",
+            "device_id": device.id, "pronto": clean,
+        })
+        manager.async_test_send.assert_awaited_once()
+
+        await _call(ws_tangle_apply, hass, {
+            "id": 5, "type": "hair/device/tangle/apply",
+            "device_id": device.id, "target": row["id"],
+            "pronto": clean, "tested": True, "source": "paste",
+        })
+        command = device.get_command(row["target"]["command_id"])
+        assert command.code == clean
+        record = command._extra[PROVENANCE_KEY]
+        assert record["source"] == "paste"
+        assert record["prior"]["pronto"] == row["pronto"]
+
+    @pytest.mark.asyncio
+    async def test_the_second_row_is_kept_instead(self, fan):
+        """Two noisy captures, two different answers. One gets replaced;
+        the other works on this fan and its owner says so."""
+        hass, device, _wig, _manager = fan
+        listing = await _tangles(hass, device)
+        row = listing["rows"][1]
+        await _call(ws_tangle_keep, hass, {
+            "id": 6, "type": "hair/device/tangle/keep",
+            "device_id": device.id, "target": row["id"], "tested": True,
+            "note": "the fan does what I expect",
+        })
+        after = await _tangles(hass, device)
+        assert len(after["rows"]) == 1
+        assert len(after["attested"]) == 1
+        assert after["attested"][0]["classes"] == ["frame-disagreement"]
+
+    @pytest.mark.asyncio
+    async def test_a_flat_attestation_has_no_map_to_name(self, fan):
+        """Nothing read this remote, so the record says so by carrying
+        no map rather than by naming one it never used."""
+        hass, device, _wig, _manager = fan
+        listing = await _tangles(hass, device)
+        result = await _call(ws_tangle_keep, hass, {
+            "id": 6, "type": "hair/device/tangle/keep",
+            "device_id": device.id, "target": listing["rows"][0]["id"],
+            "tested": True,
+        })
+        assert "map" not in result["record"]
+        assert result["record"]["key"].endswith("|-")

--- a/custom_components/hair/tests/test_tangles_keep.py
+++ b/custom_components/hair/tests/test_tangles_keep.py
@@ -1,0 +1,245 @@
+"""The other outcome: looked at it, it works, keep it.
+
+A finding is a doubt about bytes. A person with the hardware in front of
+them can answer that doubt, and this records the answer -- which is a
+different act from repairing, and produces a different kind of record.
+
+Nothing is deleted. The finding stands in the receipt, the wig carries
+both the math and the human's answer, and the shop's own re-derive sees
+both. What changes is that the row leaves the work list, and combing
+stays quiet about it for exactly as long as the bytes and the map hold
+still.
+
+Expiry is structural, which is the part worth pinning. There is no
+scheduler, no sweep and no stored "still valid" flag that could be
+wrong: an attestation names the bytes and the map version it answered,
+and if either moves the name stops matching and the finding is simply
+open again.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.hair.const import DOMAIN
+from custom_components.hair.models import IRDevice
+from custom_components.hair.tangles import (
+    ATTESTED_KEY,
+    KEEP_NO_FINDING,
+    KEEP_NOT_TESTED,
+    list_tangles,
+)
+from custom_components.hair.websocket_api import ws_tangle_keep
+from custom_components.hair.wig_comb import CHECK_FIELD_MISMATCH, COMB_KEY
+from custom_components.hair.wig_export import build_wig_from_device
+from custom_components.hair.wig_format import Wig, cell_key, parse_wig
+from custom_components.hair.wig_save import recomb
+
+FIXTURES = Path(__file__).parent / "fixtures"
+KOMECO = (FIXTURES / "wigs"
+          / "komeco-airconditioner-kos-09qc-3hx-perfect-fit.wig.json")
+
+TARGET_KEY = "heat_cool/medium/off/25"
+TARGET = f"cell:{TARGET_KEY}"
+
+
+def _wig() -> Wig:
+    parsed = parse_wig(KOMECO.read_text())
+    assert parsed.wig is not None, parsed.errors
+    return parsed.wig
+
+
+@pytest.fixture
+def wired(fake_hass, tmp_path):
+    wig = _wig()
+    device = IRDevice(name="Komeco", climate_matrix=True,
+                      emitter_entity_ids=["infrared.blaster"])
+    manager = MagicMock()
+    manager.get_device = MagicMock(return_value=device)
+    manager.async_get_matrix = AsyncMock(return_value=wig.climate)
+    manager.async_update_device = AsyncMock()
+    fake_hass.config.config_dir = str(tmp_path)
+    fake_hass.data[DOMAIN] = {"entry-1": {
+        "device_manager": manager, "matrix_listener": MagicMock(),
+    }}
+    return fake_hass, device, wig
+
+
+def _conn():
+    connection = MagicMock()
+    connection.send_result = MagicMock()
+    connection.send_error = MagicMock()
+    return connection
+
+
+async def _keep(hass, device, target=TARGET, tested=True, **extra):
+    connection = _conn()
+    payload = {"id": 1, "type": "hair/device/tangle/keep",
+               "device_id": device.id, "target": target, "tested": tested}
+    payload.update(extra)
+    await ws_tangle_keep(hass, connection, payload)
+    return connection
+
+
+class TestRecordingTheAnswer:
+    @pytest.mark.asyncio
+    async def test_the_record_says_what_it_answers(self, wired):
+        hass, device, _wig = wired
+        connection = await _keep(hass, device, note="works on my unit")
+        connection.send_error.assert_not_called()
+        record = connection.send_result.call_args.args[1]["record"]
+        assert record["target"] == TARGET_KEY
+        assert record["classes"] == [CHECK_FIELD_MISMATCH]
+        assert record["tested"] is True
+        assert record["map"]["id"] == "ZHLT01"
+        assert record["map"]["version"]
+        assert record["note"] == "works on my unit"
+
+    @pytest.mark.asyncio
+    async def test_it_lives_with_the_device(self, wired):
+        """A statement about THIS installation's hardware, not about the
+        file, so it is device-side and travels with the device."""
+        hass, device, _wig = wired
+        await _keep(hass, device)
+        assert len(device.tangle_attestations) == 1
+        assert device.tangle_attestations[0]["target"] == TARGET_KEY
+
+    @pytest.mark.asyncio
+    async def test_keeping_twice_leaves_one_record(self, wired):
+        hass, device, _wig = wired
+        await _keep(hass, device)
+        await _keep(hass, device)
+        assert len(device.tangle_attestations) == 1
+
+    @pytest.mark.asyncio
+    async def test_the_row_leaves_the_work_list(self, wired):
+        hass, device, wig = wired
+        before = len(list_tangles(device, wig.climate).rows)
+        await _keep(hass, device)
+        listing = list_tangles(device, wig.climate)
+        assert len(listing.rows) == before - 1
+        assert TARGET_KEY not in {r.target.key for r in listing.rows}
+
+    @pytest.mark.asyncio
+    async def test_but_stays_on_the_record(self, wired):
+        """Attested is not clean and must never render as clean."""
+        hass, device, wig = wired
+        await _keep(hass, device)
+        listing = list_tangles(device, wig.climate)
+        assert len(listing.attested) == 1
+        answered = listing.attested[0]
+        assert answered["target"]["key"] == TARGET_KEY
+        assert answered["classes"] == [CHECK_FIELD_MISMATCH]
+        assert answered["attested"]["tested"] is True
+
+    @pytest.mark.asyncio
+    async def test_the_card_shrinks_by_one(self, wired):
+        hass, device, wig = wired
+        before = next(c for c in list_tangles(device, wig.climate).clusters
+                      if c.mechanic == "donor").size
+        await _keep(hass, device)
+        after = next(c for c in list_tangles(device, wig.climate).clusters
+                     if c.mechanic == "donor").size
+        assert after == before - 1
+
+
+class TestWhatItRefuses:
+    @pytest.mark.asyncio
+    async def test_without_a_press_there_is_nothing_to_vouch_for(self, wired):
+        hass, device, _wig = wired
+        connection = await _keep(hass, device, tested=False)
+        assert connection.send_error.call_args.args[1] == KEEP_NOT_TESTED
+        assert device.tangle_attestations == []
+
+    @pytest.mark.asyncio
+    async def test_a_healthy_cell_has_nothing_to_answer(self, wired):
+        hass, device, _wig = wired
+        connection = await _keep(hass, device, target="cell:cool/high/off/22")
+        assert connection.send_error.call_args.args[1] == KEEP_NO_FINDING
+        assert device.tangle_attestations == []
+
+
+class TestExpiryIsStructural:
+    @pytest.mark.asyncio
+    async def test_changed_bytes_open_the_finding_again(self, wired):
+        """Nothing swept it away. The attestation names the bytes it
+        answered, and these are not those bytes."""
+        hass, device, wig = wired
+        await _keep(hass, device)
+        cells = {cell_key(c): c for c in wig.climate.cells}
+        assert TARGET_KEY not in {
+            r.target.key for r in list_tangles(device, wig.climate).rows}
+
+        cells[TARGET_KEY].pronto = cells["heat_cool/medium/off/28"].pronto
+        listing = list_tangles(device, wig.climate)
+        assert TARGET_KEY in {r.target.key for r in listing.rows}
+        assert listing.attested == []
+        assert len(device.tangle_attestations) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_changed_map_opens_the_finding_again(self, wired):
+        """The map is half of what an attestation answers. A person
+        vouched for these bytes against what the map said THEN, and a
+        map that has learned something since is asking a new question.
+        """
+        hass, device, wig = wired
+        await _keep(hass, device)
+        record = device.tangle_attestations[0]
+        target, digest, _version = record["key"].split("|")
+        record["key"] = f"{target}|{digest}|somethingelse"
+
+        listing = list_tangles(device, wig.climate)
+        assert TARGET_KEY in {r.target.key for r in listing.rows}
+        assert listing.attested == []
+
+
+class TestItRidesOutWithTheWig:
+    @pytest.mark.asyncio
+    async def test_the_receipt_carries_both(self, wired):
+        """The file leaves with the math AND the human's answer, so the
+        shop's own re-derive sees both."""
+        hass, device, wig = wired
+        await _keep(hass, device, note="my unit is fine at 25")
+
+        build = build_wig_from_device(device, wig.climate)
+        assert build.wig is not None
+        recomb(build.wig)
+        receipt = build.wig.extra[COMB_KEY]
+        assert receipt["suspects"] == 52
+        carried = receipt[ATTESTED_KEY]
+        assert len(carried) == 1
+        assert carried[0]["target"] == TARGET_KEY
+        assert carried[0]["note"] == "my unit is fine at 25"
+
+    @pytest.mark.asyncio
+    async def test_the_finding_is_still_in_the_receipt(self, wired):
+        """Keep never deletes a finding. The cell is still doubted by
+        the math; a person has simply answered the doubt."""
+        hass, device, wig = wired
+        await _keep(hass, device)
+        build = build_wig_from_device(device, wig.climate)
+        recomb(build.wig)
+        keys = {
+            key for finding in build.wig.extra[COMB_KEY]["findings"]
+            for key in finding["keys"]
+        }
+        assert TARGET_KEY in keys
+
+    def test_a_device_with_no_answers_carries_no_block(self, wired):
+        """No empty block on a file nobody vouched for anything in."""
+        _hass, device, wig = wired
+        build = build_wig_from_device(device, wig.climate)
+        recomb(build.wig)
+        assert ATTESTED_KEY not in build.wig.extra[COMB_KEY]
+
+    @pytest.mark.asyncio
+    async def test_nothing_temporary_is_left_on_the_wig(self, wired):
+        """The block is parked on the way out and folded into the
+        receipt; the parking spot does not survive into the file."""
+        hass, device, wig = wired
+        await _keep(hass, device)
+        build = build_wig_from_device(device, wig.climate)
+        recomb(build.wig)
+        assert "comb_attested_pending" not in build.wig.extra

--- a/custom_components/hair/tests/test_tangles_listing.py
+++ b/custom_components/hair/tests/test_tangles_listing.py
@@ -1,0 +1,375 @@
+"""The tangle listing: what one device still has wrong with it.
+
+`test_field_sweep.py` pins what the comb FINDS in a file.
+`test_field_gate_to_closet.py` pins what adopt does with those findings.
+This pins the third leg: a device somebody is holding, listed as things
+that can be fixed, derived from the bytes the device carries RIGHT NOW.
+
+The Komeco fixture makes the case for deriving rather than remembering
+better than any argument could. Its own stored receipt is a version 1
+receipt written before the field tier existed, and it says zero
+suspects. A listing that read that receipt would tell the owner of a
+device with 52 wrong cells that there was nothing to do.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.hair.const import DOMAIN
+from custom_components.hair.models import (
+    CommandCategory,
+    IRCommand,
+    IRDevice,
+)
+from custom_components.hair.tangles import (
+    FIELD_TIER_NO_LATTICE,
+    FIELD_TIER_READ,
+    FIELD_TIER_UNMAPPED,
+    TARGET_CELL,
+    TARGET_COMMAND,
+    list_tangles,
+)
+from custom_components.hair.websocket_api import ws_device_tangles
+from custom_components.hair.wig_comb import (
+    CHECK_DUPLICATED_NEIGHBOUR,
+    CHECK_FIELD_MISMATCH,
+    CHECK_FRAME_DISAGREEMENT,
+    comb_wig,
+    receipt_summary,
+    stamp_receipt,
+)
+from custom_components.hair.wig_format import (
+    ClimateCell,
+    ClimateMatrix,
+    Wig,
+    cell_key,
+    parse_wig,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+KOMECO = (FIXTURES / "wigs"
+          / "komeco-airconditioner-kos-09qc-3hx-perfect-fit.wig.json")
+DREO = (FIXTURES / "wigs"
+        / "dreo-fan-dr-haf004s-perfect-fit.wig.json")
+
+
+def _wig(path: Path) -> Wig:
+    parsed = parse_wig(path.read_text())
+    assert parsed.wig is not None, parsed.errors
+    return parsed.wig
+
+
+def _flagged(wig: Wig, check: str) -> set[str]:
+    """The keys one check flagged. Cached: combing a 1,156-cell lattice
+    is real arithmetic and several tests want the same answer."""
+    cached = _FLAGGED_CACHE.get((id(wig), check))
+    if cached is None:
+        cached = {finding.keys[0] for finding in comb_wig(wig).findings
+                  if finding.check == check}
+        _FLAGGED_CACHE[(id(wig), check)] = cached
+    return cached
+
+
+_FLAGGED_CACHE: dict[tuple[int, str], set[str]] = {}
+
+
+@pytest.fixture
+def komeco_device():
+    """The Komeco lattice as an adopted device, portholes and all.
+
+    Built the way ``ws_wig_make_device`` builds one -- a matrix device
+    plus a coordinate-named porthole command per flagged cell -- so the
+    listing is exercised against the shape adopt actually produces.
+    """
+    wig = _wig(KOMECO)
+    stamp_receipt(wig, comb_wig(wig), "2026-08-22")
+    device = IRDevice(name="Komeco", climate_matrix=True)
+    flagged = _flagged(wig, CHECK_FIELD_MISMATCH)
+    for cell in wig.climate.cells:
+        if cell_key(cell) not in flagged:
+            continue
+        # Names differ per swing on purpose: ``add_command`` REPLACES a
+        # same-named command, so four cells sharing "Heat_cool 19
+        # medium" would leave one porthole where there should be four.
+        device.add_command(IRCommand(
+            name=f"Heat_cool {cell.temp:g} {cell.fan} {cell.swing}",
+            category=CommandCategory.CUSTOM,
+            protocol="PRONTO",
+            code=cell.pronto,
+            repeat_count=0,
+            matrix_cell={
+                "mode": cell.mode, "fan": cell.fan,
+                "swing": cell.swing, "temp": cell.temp,
+            },
+            comb_suspect=True,
+            comb_finding=CHECK_FIELD_MISMATCH,
+        ))
+    return device, wig
+
+
+@pytest.fixture
+def dreo_device():
+    """The Dreo fan as a flat device: seven buttons, two of them noisy."""
+    wig = _wig(DREO)
+    device = IRDevice(name="Dreo")
+    for signal in wig.signals:
+        device.add_command(IRCommand(
+            name=signal.alias,
+            category=CommandCategory.CUSTOM,
+            protocol="PRONTO",
+            code=signal.pronto,
+            send_count=signal.send_count,
+            repeat_count=signal.ditto_count,
+            tx_force_raw=signal.bypass_protocol,
+        ))
+    return device, wig
+
+
+class TestTheKomecoListing:
+    def test_fifty_two_rows(self, komeco_device):
+        """The number the whole fitting-integrity release exists for."""
+        device, wig = komeco_device
+        listing = list_tangles(device, wig.climate)
+        assert len(listing.rows) == 52
+
+    def test_on_the_coordinates_the_sweep_named(self, komeco_device):
+        """A set, not a count that happens to match."""
+        device, wig = komeco_device
+        listing = list_tangles(device, wig.climate)
+        assert {row.target.key for row in listing.rows} == _flagged(
+            wig, CHECK_FIELD_MISMATCH)
+        assert {row.target.kind for row in listing.rows} == {TARGET_CELL}
+
+    def test_every_row_carries_its_vote(self, komeco_device):
+        """"Wrong" is not a diagnosis. What it should send and what it
+        does send, in the reader's own language, is."""
+        device, wig = komeco_device
+        listing = list_tangles(device, wig.climate)
+        for row in listing.rows:
+            assert row.classes == [CHECK_FIELD_MISMATCH]
+            params = row.findings[0]["params"]
+            assert params["field"] == "comb.field.temperature"
+            assert params["protocol"] == "ZHLT01"
+            assert params["expected"] != params["read"]
+
+    def test_a_row_names_its_porthole(self, komeco_device):
+        """The porthole is the command toolset's handle on a cell. A row
+        that did not name it would leave the fix window unable to TEST
+        the thing it is about to replace."""
+        device, wig = komeco_device
+        listing = list_tangles(device, wig.climate)
+        assert all(row.target.command_id for row in listing.rows)
+        ids = {row.target.command_id for row in listing.rows}
+        assert len(ids) == 52
+
+    def test_the_porthole_is_not_listed_twice(self, komeco_device):
+        """A flagged cell lives in the lattice AND as a depth-0 command
+        holding a copy of the same bytes. The lattice is the authority;
+        listing both would offer one repair under two ids."""
+        device, wig = komeco_device
+        listing = list_tangles(device, wig.climate)
+        assert not [r for r in listing.rows if r.target.kind == TARGET_COMMAND]
+
+    def test_the_field_tier_reports_that_it_read(self, komeco_device):
+        device, wig = komeco_device
+        listing = list_tangles(device, wig.climate)
+        assert listing.protocol == "ZHLT01"
+        assert listing.field_tier == FIELD_TIER_READ
+        assert "donor" in listing.candidate_sources
+
+    def test_the_stored_receipt_would_have_said_nothing(self, komeco_device):
+        """The reason this tier combs instead of remembering.
+
+        The contributor's file carries a real receipt, and that receipt
+        is honest about what it knew when it was written: zero suspects,
+        version 1, no field tier in existence yet. Reading it would
+        report a clean device.
+        """
+        _device, wig = komeco_device
+        parsed = parse_wig(KOMECO.read_text())
+        assert parsed.wig is not None
+        stored = receipt_summary(parsed.wig)
+        assert stored is not None
+        assert stored["suspects"] == 0
+        assert len(list_tangles(_device, wig.climate).rows) == 52
+
+
+class TestTheDreoListing:
+    def test_the_two_noisy_captures(self, dreo_device):
+        device, wig = dreo_device
+        listing = list_tangles(device, None)
+        assert len(listing.rows) == 2
+        assert {row.target.key for row in listing.rows} == _flagged(
+            wig, CHECK_FRAME_DISAGREEMENT)
+
+    def test_rows_address_commands_by_id(self, dreo_device):
+        device, _wig = dreo_device
+        listing = list_tangles(device, None)
+        on_device = {command.id for command in device.commands}
+        for row in listing.rows:
+            assert row.target.kind == TARGET_COMMAND
+            assert row.target.command_id in on_device
+            assert row.id == f"{TARGET_COMMAND}:{row.target.command_id}"
+
+    def test_a_flat_device_is_told_it_has_no_lattice(self, dreo_device):
+        """No oracle, so no donors -- and saying which sources DO exist
+        is better than an empty donor field the caller has to interpret."""
+        device, _wig = dreo_device
+        listing = list_tangles(device, None)
+        assert listing.field_tier == FIELD_TIER_NO_LATTICE
+        assert listing.candidate_sources == ["capture", "paste"]
+        assert all(row.has_donor is False for row in listing.rows)
+
+
+class TestHonestSilence:
+    def test_a_clean_device_lists_nothing(self, dreo_device):
+        """Zero findings is zero rows, not an empty shell with a
+        reassuring header."""
+        _device, wig = dreo_device
+        clean = IRDevice(name="Clean")
+        good = {s.alias for s in wig.signals} - _flagged(
+            wig, CHECK_FRAME_DISAGREEMENT)
+        for signal in wig.signals:
+            if signal.alias not in good:
+                continue
+            clean.add_command(IRCommand(
+                name=signal.alias, category=CommandCategory.CUSTOM,
+                protocol="PRONTO", code=signal.pronto,
+            ))
+        assert list_tangles(clean, None).rows == []
+
+    def test_an_unmapped_lattice_says_so(self):
+        """A lattice no map covers passes every protocol-blind check and
+        has not one byte of its payload read. That is not a clean bill,
+        and the listing has to be able to tell them apart."""
+        cells = [
+            ClimateCell(mode="cool", fan="auto", temp=float(t),
+                        pronto="0000 006D 0004 0000 0060 0020 "
+                               "0020 0020 0020 0020 0020 0060")
+            for t in (20, 21)
+        ]
+        matrix = ClimateMatrix(
+            min_temp=20.0, max_temp=21.0, off="0000 006D 0002 0000 "
+            "0060 0020 0020 0060", cells=cells,
+            modes=["cool"], fan_modes=["auto"],
+        )
+        device = IRDevice(name="Unmapped", climate_matrix=True)
+        listing = list_tangles(device, matrix)
+        assert listing.protocol is None
+        assert listing.field_tier == FIELD_TIER_UNMAPPED
+        assert "donor" not in listing.candidate_sources
+
+    def test_a_device_with_nothing_to_export_lists_nothing(self):
+        """No commands and no lattice: the projection has no wig to
+        comb, and the honest answer is an empty listing rather than a
+        crash on None."""
+        assert list_tangles(IRDevice(name="Bare"), None).rows == []
+
+
+class TestDerivedNotRemembered:
+    def test_repairing_the_bytes_drops_the_finding(self, komeco_device):
+        """The whole point of deriving. Nothing is invalidated, nothing
+        is refreshed: the next call combs different bytes and reaches a
+        different answer."""
+        device, wig = komeco_device
+        matrix = wig.climate
+        target_key = "heat_cool/medium/off/25"
+        before = list_tangles(device, matrix)
+        assert CHECK_FIELD_MISMATCH in next(
+            r for r in before.rows if r.target.key == target_key).classes
+
+        donor = next(c for c in matrix.cells
+                     if cell_key(c) == "heat_cool/medium/off/24")
+        cell = next(c for c in matrix.cells if cell_key(c) == target_key)
+        assert cell.pronto != donor.pronto
+        cell.pronto = donor.pronto
+
+        after = list_tangles(device, matrix)
+        mismatches = [r for r in after.rows
+                      if CHECK_FIELD_MISMATCH in r.classes]
+        assert len(mismatches) == 51
+        assert target_key not in {r.target.key for r in mismatches}
+
+    def test_one_donor_fix_inside_a_shift_leaves_a_twin(self, komeco_device):
+        """Honest consequence, pinned rather than hidden.
+
+        The defective column is a SHIFT: every cell sends what the next
+        one up should send, so the correct bytes for 25 are the bytes 24
+        is carrying today. Copying them repairs 25 and, until 24 is
+        repaired from 23, leaves the two cells byte-identical -- which
+        the duplicated-neighbour check then reports, correctly.
+
+        The pair is an artifact of stopping halfway, not of the donor
+        rule. Applying the whole cause at once walks the shift back and
+        the twins never exist; this is why repairs are batched per cause
+        rather than offered one cell at a time.
+        """
+        device, wig = komeco_device
+        matrix = wig.climate
+        cells = {cell_key(c): c for c in matrix.cells}
+        cells["heat_cool/medium/off/25"].pronto = cells[
+            "heat_cool/medium/off/24"].pronto
+
+        rows = {r.target.key: r for r in list_tangles(device, matrix).rows}
+        assert CHECK_DUPLICATED_NEIGHBOUR in rows[
+            "heat_cool/medium/off/25"].classes
+        assert CHECK_DUPLICATED_NEIGHBOUR in rows[
+            "heat_cool/medium/off/24"].classes
+        assert CHECK_FIELD_MISMATCH in rows[
+            "heat_cool/medium/off/24"].classes
+
+    def test_the_digest_follows_the_bytes(self, dreo_device):
+        """Swapped for the OTHER noisy capture, so the row survives the
+        edit and the digest is the only thing that moved."""
+        device, _wig = dreo_device
+        rows = list_tangles(device, None).rows
+        first, other = rows[0], rows[1]
+        command = next(c for c in device.commands
+                       if c.id == first.target.command_id)
+        assert first.pronto == command.code
+        command.code = other.pronto
+        again = next(
+            r for r in list_tangles(device, None).rows
+            if r.target.command_id == command.id
+        )
+        assert again.digest != first.digest
+        assert again.pronto == command.code
+
+
+class TestOverTheWire:
+    @pytest.fixture
+    def wired(self, fake_hass, komeco_device):
+        device, wig = komeco_device
+        manager = MagicMock()
+        manager.get_device = MagicMock(return_value=device)
+        manager.async_get_matrix = AsyncMock(return_value=wig.climate)
+        fake_hass.data[DOMAIN] = {"entry-1": {"device_manager": manager}}
+        return fake_hass, device, manager
+
+    @pytest.mark.asyncio
+    async def test_the_handler_returns_the_listing(self, wired):
+        hass, device, _manager = wired
+        connection = MagicMock()
+        await ws_device_tangles(hass, connection, {
+            "id": 1, "type": "hair/device/tangles", "device_id": device.id,
+        })
+        connection.send_error.assert_not_called()
+        payload = connection.send_result.call_args.args[1]
+        assert len(payload["rows"]) == 52
+        assert payload["matrix"] is True
+        assert payload["protocol"] == "ZHLT01"
+        assert payload["coverage"]["protocol"]["readable"] == 1157
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_device_is_a_refusal(self, wired):
+        hass, _device, manager = wired
+        manager.get_device = MagicMock(return_value=None)
+        connection = MagicMock()
+        await ws_device_tangles(hass, connection, {
+            "id": 1, "type": "hair/device/tangles", "device_id": "nope",
+        })
+        connection.send_result.assert_not_called()
+        assert connection.send_error.call_args.args[1] == "not_found"

--- a/custom_components/hair/tests/test_tangles_synthesis.py
+++ b/custom_components/hair/tests/test_tangles_synthesis.py
@@ -1,0 +1,339 @@
+"""One press, N codes -- and the wall that keeps it honest.
+
+Four Komeco cells claim 19 degrees and no code anywhere in that wig
+reads as 19, so no donor exists and none can be invented. What CAN
+happen is this: the person sets their own remote to 19, presses it once,
+and that capture witnesses what 19 looks like on their hardware. Every
+remaining cell is then built from its own healthy sibling with only the
+witnessed field rewritten.
+
+The map could compute that byte on its own and is deliberately not
+allowed to. A value nobody demonstrated is a value nobody checked, and
+unreadable-never-guessed does not bend because the arithmetic happens to
+be easy. The witness is the authorization, not the arithmetic.
+
+Two walls hold this up. The map must vouch for BOTH the field being
+rewritten and every rule that proves the frame, or the whole run
+declines. And every candidate is put back through the same reader that
+judged the cell in the first place -- a candidate that fails its own
+read-back raises, because that is a defect in the synthesis and not a
+result to hand anybody.
+"""
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from custom_components.hair import field_readers
+from custom_components.hair.models import IRDevice
+from custom_components.hair.tangles import (
+    ORIGIN_CAPTURE,
+    ORIGIN_SYNTHESIZED,
+    SYNTH_FIELD_PROVISIONAL,
+    SYNTH_NO_WITNESS,
+    SYNTH_RULE_PROVISIONAL,
+    SYNTH_UNREADABLE,
+    SynthesisBug,
+    list_tangles,
+    pre_read,
+    read_lattice,
+    rewrite_field,
+    synthesize,
+)
+from custom_components.hair.wig_comb import comb_wig
+from custom_components.hair.wig_format import Wig, cell_key, parse_wig
+
+FIXTURES = Path(__file__).parent / "fixtures"
+KOMECO = (FIXTURES / "wigs"
+          / "komeco-airconditioner-kos-09qc-3hx-perfect-fit.wig.json")
+
+AIMED = "cell:heat_cool/medium/off/19"
+
+
+def _fresh() -> Wig:
+    parsed = parse_wig(KOMECO.read_text())
+    assert parsed.wig is not None, parsed.errors
+    return parsed.wig
+
+
+@pytest.fixture
+def komeco() -> Wig:
+    return _fresh()
+
+
+def _cells(wig: Wig) -> dict:
+    return {cell_key(cell): cell for cell in wig.climate.cells}
+
+
+def _witness(lattice, wig: Wig, degrees: float = 19.0) -> str:
+    """A capture that reads as ``degrees`` on this device's hardware.
+
+    Stands in for the press. Built from a healthy cell of the same
+    column so it carries this remote's own timings, which is exactly
+    what a real capture would carry.
+    """
+    spec = lattice.spec_for("temperature")
+    source = _cells(wig)["heat_cool/medium/off/16"]
+    built = rewrite_field(
+        lattice.field_map, source.pronto, spec,
+        field_readers.expected_value(spec, degrees),
+    )
+    assert built is not None
+    return built
+
+
+def _witness_card(wig: Wig):
+    device = IRDevice(name="Komeco", climate_matrix=True)
+    listing = list_tangles(device, wig.climate)
+    card = next(c for c in listing.clusters if c.mechanic == "witness")
+    return [row for row in listing.rows if row.id in card.members]
+
+
+class TestRewritingOneFieldInPlace:
+    def test_the_rewrite_reads_back_as_what_was_asked_for(self, komeco):
+        lattice = read_lattice(komeco.climate)
+        built = _witness(lattice, komeco, 19.0)
+        assert pre_read(lattice, built).reads_as["temperature"] == 19.0
+
+    def test_the_checksum_is_recomputed_not_left_stale(self, komeco):
+        """A frame carries its own proof. Rewriting a field and leaving
+        the complement bytes behind would produce a frame most receivers
+        throw away."""
+        lattice = read_lattice(komeco.climate)
+        built = _witness(lattice, komeco, 19.0)
+        assert pre_read(lattice, built).integrity == {"complement_pairs": True}
+
+    def test_everything_it_does_not_change_is_untouched(self, komeco):
+        """Not a rendering. The pulses this does not touch are the words
+        that arrived from the device, identical down to the hex."""
+        lattice = read_lattice(komeco.climate)
+        source = _cells(komeco)["heat_cool/medium/off/16"]
+        built = _witness(lattice, komeco, 19.0)
+        before = source.pronto.split()
+        after = built.split()
+        assert len(before) == len(after)
+        assert before[:4] == after[:4]
+        changed = [i for i, (a, b) in enumerate(zip(before, after,
+                                                    strict=True)) if a != b]
+        assert changed
+        assert len(changed) < len(before) // 4
+
+    def test_the_changed_pulses_look_like_the_ones_beside_them(self, komeco):
+        """Widths come from this code's own median zero and one, so a
+        synthesized frame stays a member of the family it came from."""
+        lattice = read_lattice(komeco.climate)
+        source = _cells(komeco)["heat_cool/medium/off/16"]
+        built = _witness(lattice, komeco, 19.0)
+        original = {int(w, 16) for w in source.pronto.split()[4:]}
+        assert all(int(w, 16) in original for w in built.split()[4:])
+
+    def test_a_recomputed_rule_satisfies_the_reader_that_checks_it(
+            self, komeco):
+        """THE coupling pin. The repair mirrors check_integrity's
+        arithmetic rather than importing it, because one asks and the
+        other answers. If they ever drift, this fails."""
+        lattice = read_lattice(komeco.climate)
+        built = _witness(lattice, komeco, 19.0)
+        reading = field_readers.read_code(
+            built, [lattice.field_map], prefer=lattice.field_map.protocol_id)
+        for rule in lattice.field_map.integrity:
+            if rule.ratified:
+                assert field_readers.check_integrity(reading, rule) is True
+
+
+class TestTheWitnessedCard:
+    def test_one_press_completes_all_four(self, komeco):
+        lattice = read_lattice(komeco.climate)
+        rows = _witness_card(komeco)
+        assert len(rows) == 4
+        result = synthesize(
+            lattice, rows, _witness(lattice, komeco), "temperature",
+            witness_target=AIMED,
+        )
+        assert result.refused is None
+        assert result.declined == {}
+        assert len(result.candidates) == 4
+
+    def test_only_the_aimed_cell_gets_the_capture(self, komeco):
+        """The bug this rule exists for, pinned.
+
+        Four cells needing 19 differ by SWING, and ZHLT01 marks swing
+        provisional. Handing all four the captured frame produced four
+        candidates that passed their own read-back while three carried
+        the wrong swing: the reader can only check what the map
+        ratifies. So every cell nobody aimed at is built from its own
+        sibling, which is right on every axis by construction.
+        """
+        lattice = read_lattice(komeco.climate)
+        rows = _witness_card(komeco)
+        result = synthesize(
+            lattice, rows, _witness(lattice, komeco), "temperature",
+            witness_target=AIMED,
+        )
+        assert result.candidates[AIMED]["origin"] == ORIGIN_CAPTURE
+        others = [c for rid, c in result.candidates.items() if rid != AIMED]
+        assert len(others) == 3
+        assert {c["origin"] for c in others} == {ORIGIN_SYNTHESIZED}
+        assert len({c["pronto"] for c in result.candidates.values()}) == 4
+
+    def test_each_cell_is_built_from_its_own_swing(self, komeco):
+        lattice = read_lattice(komeco.climate)
+        rows = _witness_card(komeco)
+        result = synthesize(
+            lattice, rows, _witness(lattice, komeco), "temperature",
+            witness_target=AIMED,
+        )
+        for row_id, candidate in result.candidates.items():
+            if candidate["origin"] != ORIGIN_SYNTHESIZED:
+                continue
+            swing = row_id.rsplit("/", 2)[-2]
+            assert candidate["sibling"].split("/")[2] == swing
+
+    def test_the_provenance_names_the_witness_and_the_sibling(self, komeco):
+        lattice = read_lattice(komeco.climate)
+        rows = _witness_card(komeco)
+        witness = _witness(lattice, komeco)
+        result = synthesize(
+            lattice, rows, witness, "temperature", witness_target=AIMED)
+        assert result.witness["reads_as"] == 19.0
+        assert result.witness["field"] == "temperature"
+        for candidate in result.candidates.values():
+            assert candidate["witness_digest"] == result.witness["digest"]
+            assert candidate["witness_field"] == "temperature"
+
+    def test_every_candidate_reads_back_as_its_own_cell(self, komeco):
+        lattice = read_lattice(komeco.climate)
+        rows = _witness_card(komeco)
+        result = synthesize(
+            lattice, rows, _witness(lattice, komeco), "temperature",
+            witness_target=AIMED)
+        for row in rows:
+            verdict = result.candidates[row.id]["verdict"]
+            assert verdict["matches"] is True
+            assert verdict["reads_as"]["temperature"] == 19.0
+
+
+class TestTheWall:
+    def test_a_provisional_field_declines_the_whole_run(self, komeco):
+        """The Galanz class stays untouchable. A field the map will not
+        vouch for cannot decide what a frame should carry."""
+        lattice = read_lattice(komeco.climate)
+        spec = lattice.spec_for("temperature")
+        demoted = replace(spec, confidence="provisional")
+        lattice.field_map = replace(
+            lattice.field_map,
+            fields=[demoted if f.name == "temperature" else f
+                    for f in lattice.field_map.fields],
+        )
+        result = synthesize(
+            lattice, _witness_card(komeco), "0000 006D", "temperature")
+        assert result.refused == SYNTH_FIELD_PROVISIONAL
+        assert result.candidates == {}
+
+    def test_the_class_this_protects_is_real(self):
+        """Not a hypothetical gate. OEM112 ships with a provisional
+        temperature over 970 disagreeing cells in five corpus files, and
+        that is precisely the family synthesis must not touch."""
+        oem = next(m for m in field_readers.library()
+                   if m.protocol_id == "OEM112")
+        assert oem.field_named("temperature").ratified is False
+
+    def test_a_provisional_integrity_rule_declines_the_whole_run(
+            self, komeco):
+        """A recomputed frame whose proof the map doubts is a guess
+        wearing a checksum."""
+        lattice = read_lattice(komeco.climate)
+        lattice.field_map = replace(
+            lattice.field_map,
+            integrity=[replace(rule, confidence="provisional")
+                       for rule in lattice.field_map.integrity],
+        )
+        result = synthesize(
+            lattice, _witness_card(komeco), "0000 006D", "temperature")
+        assert result.refused == SYNTH_RULE_PROVISIONAL
+
+    def test_the_families_that_rule_protects_are_real(self):
+        provisional = {
+            m.protocol_id for m in field_readers.library()
+            if any(not rule.ratified for rule in m.integrity)
+        }
+        assert {"GREE", "MHI48", "MHI160"} <= provisional
+
+    def test_a_capture_that_reads_as_something_else_witnesses_nothing(
+            self, komeco):
+        """The user pressed 18 when we asked for 19. Nothing is
+        synthesized from a value nobody demonstrated."""
+        lattice = read_lattice(komeco.climate)
+        result = synthesize(
+            lattice, _witness_card(komeco),
+            _witness(lattice, komeco, 24.0), "temperature",
+            witness_target=AIMED,
+        )
+        assert result.refused == SYNTH_NO_WITNESS
+        assert result.candidates == {}
+
+    def test_an_unreadable_capture_witnesses_nothing(self, komeco):
+        lattice = read_lattice(komeco.climate)
+        result = synthesize(
+            lattice, _witness_card(komeco),
+            "0000 006D 0002 0000 0060 0020 0020 0060", "temperature",
+        )
+        assert result.refused == SYNTH_NO_WITNESS
+
+    def test_no_lattice_refuses(self, komeco):
+        result = synthesize(
+            read_lattice(None), _witness_card(komeco), "x", "temperature")
+        assert result.refused == SYNTH_UNREADABLE
+
+    def test_a_candidate_that_fails_its_own_read_back_raises(
+            self, komeco, monkeypatch):
+        """Raised, never returned. A synthesized frame that does not read
+        as the cell it was built for is a defect in this module, and
+        handing it back as a result would put it in front of somebody as
+        a repair."""
+        lattice = read_lattice(komeco.climate)
+        wrong = _cells(komeco)["heat_cool/medium/off/28"].pronto
+        monkeypatch.setattr(
+            "custom_components.hair.tangles.rewrite_field",
+            lambda *args, **kwargs: wrong,
+        )
+        with pytest.raises(SynthesisBug):
+            synthesize(
+                lattice, _witness_card(komeco), _witness(lattice, komeco),
+                "temperature", witness_target=AIMED,
+            )
+
+
+class TestTheWholeRepair:
+    def test_donors_plus_one_witness_leave_the_lattice_clean(self, komeco):
+        """The owner's loop, proven on the real file.
+
+        Every donor resolved against the lattice as it stands, the four
+        witnessed cells synthesized from one press, all 52 written at
+        once -- and the comb comes back with nothing at all. Neither
+        half gets there alone: donors leave the bottom of the range
+        untouched and twinned against it, and the witness alone leaves
+        the other 48 lying.
+        """
+        lattice = read_lattice(komeco.climate)
+        device = IRDevice(name="Komeco", climate_matrix=True)
+        listing = list_tangles(device, komeco.climate)
+        rows = _witness_card(komeco)
+        result = synthesize(
+            lattice, rows, _witness(lattice, komeco), "temperature",
+            witness_target=AIMED)
+
+        plan = {row.target.key: row.donor["pronto"]
+                for row in listing.rows if row.has_donor}
+        for row_id, candidate in result.candidates.items():
+            plan[row_id.split(":", 1)[1]] = candidate["pronto"]
+        assert len(plan) == 52
+
+        cells = _cells(komeco)
+        for key, pronto in plan.items():
+            cells[key].pronto = pronto
+
+        assert comb_wig(komeco).findings == []
+        assert list_tangles(device, komeco.climate).rows == []

--- a/custom_components/hair/tests/test_tangles_writethrough.py
+++ b/custom_components/hair/tests/test_tangles_writethrough.py
@@ -1,0 +1,361 @@
+"""The closet follows the device, without anybody saving.
+
+A person who repairs an adopted device should not then have to go and
+find a save button. Their wig is what they care about; the device is
+where the work happened. So finishing a repair writes a new version of
+their wig on its own, and the surface is allowed to say "Your wig has
+been updated." only because the answer to that write came back on the
+same message that carried the repair.
+
+The part worth reading closely is what this will and will not delete.
+The succession machinery it rides can supersede -- remove the file it
+replaced and repoint the devices. Turned loose that would delete the
+contributor's original on the very first click. So a mint STAMPS what
+it wrote, and the stamp is what a later write reads before allowing
+itself to supersede: the flow only ever removes files the flow made.
+The original stays where it is, forever, and the closet settles at two
+files rather than one per repair.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.hair.const import DOMAIN
+from custom_components.hair.matrix_store import load_matrix
+from custom_components.hair.models import IRCommand, IRDevice
+from custom_components.hair.tangles import (
+    PROVENANCE_KEY,
+    REPAIR_SUCCESSOR,
+    WROTE_NOT_ADOPTED,
+)
+from custom_components.hair.websocket_api import (
+    ws_device_tangles,
+    ws_tangle_apply,
+    ws_tangle_apply_batch,
+    ws_tangle_keep,
+    ws_tangle_plan,
+    ws_tangle_revert,
+    ws_wig_make_device,
+)
+from custom_components.hair.wig_comb import comb_wig, stamp_receipt
+from custom_components.hair.wig_format import cell_key, parse_wig, serialize_wig
+from custom_components.hair.wig_store import ensure_wigs_dir, wigs_dir
+
+FIXTURES = Path(__file__).parent / "fixtures"
+KOMECO = (FIXTURES / "wigs"
+          / "komeco-airconditioner-kos-09qc-3hx-perfect-fit.wig.json")
+DREO = (FIXTURES / "wigs"
+        / "dreo-fan-dr-haf004s-perfect-fit.wig.json")
+SOURCE = "komeco.wig.json"
+
+
+def _conn():
+    connection = MagicMock()
+    connection.send_result = MagicMock()
+    connection.send_error = MagicMock()
+    return connection
+
+
+async def _call(handler, hass, payload, *, expect_error=None):
+    connection = _conn()
+    await handler(hass, connection, payload)
+    if expect_error is None:
+        connection.send_error.assert_not_called()
+        return connection.send_result.call_args.args[1]
+    assert connection.send_error.call_args.args[1] == expect_error
+    return None
+
+
+@pytest.fixture
+def _no_signing(monkeypatch):
+    monkeypatch.setattr(
+        "custom_components.hair.fitting_signing.async_get_private_key",
+        AsyncMock(return_value=None),
+    )
+
+
+def _wire(fake_hass, tmp_path):
+    devices: list = []
+    manager = MagicMock()
+    manager.async_create_device = AsyncMock(
+        side_effect=lambda d: devices.append(d))
+    manager.async_update_device = AsyncMock()
+    manager._auto_map_command = MagicMock()
+    manager.get_device = MagicMock(
+        side_effect=lambda did: next(
+            (d for d in devices if d.id == did), None))
+    manager.async_get_matrix = AsyncMock(
+        side_effect=lambda did: load_matrix(str(tmp_path), did))
+    store = MagicMock()
+    store.get_device = MagicMock(
+        side_effect=lambda did: next(
+            (d for d in devices if d.id == did), None))
+    store.get_all_devices = MagicMock(side_effect=lambda: list(devices))
+    fake_hass.config.config_dir = str(tmp_path)
+    fake_hass.data[DOMAIN] = {"entry-1": {
+        "device_manager": manager, "store": store,
+        "matrix_listener": MagicMock(), "fitting_manager": None,
+    }}
+    return devices
+
+
+@pytest.fixture
+async def adopted(fake_hass, tmp_path):
+    parsed = parse_wig(KOMECO.read_text())
+    assert parsed.wig is not None, parsed.errors
+    wig = parsed.wig
+    stamp_receipt(wig, comb_wig(wig), "2026-08-22")
+    ensure_wigs_dir(tmp_path)
+    (wigs_dir(tmp_path) / SOURCE).write_text(
+        serialize_wig(wig), encoding="utf-8")
+    devices = _wire(fake_hass, tmp_path)
+    await _call(ws_wig_make_device, fake_hass, {
+        "id": 1, "type": "hair/wigs/make-device", "filename": SOURCE,
+        "name": "Komeco", "device_type": "ac",
+        "emitter_entity_ids": ["infrared.blaster"],
+    })
+    return fake_hass, devices[0], tmp_path, wig
+
+
+async def _tangles(hass, device):
+    return await _call(ws_device_tangles, hass, {
+        "id": 2, "type": "hair/device/tangles", "device_id": device.id,
+    })
+
+
+async def _repair_the_donors(hass, device):
+    """The 48-cell card, applied the way the surface would apply it."""
+    listing = await _tangles(hass, device)
+    card = next(c for c in listing["clusters"] if c["mechanic"] == "donor")
+    plan = await _call(ws_tangle_plan, hass, {
+        "id": 3, "type": "hair/device/tangle/plan",
+        "device_id": device.id, "cluster": card["id"],
+    })
+    return await _call(ws_tangle_apply_batch, hass, {
+        "id": 4, "type": "hair/device/tangle/apply-batch",
+        "device_id": device.id, "cluster": card["id"],
+        "tested": True, "tested_targets": plan["sample"],
+    })
+
+
+def _closet(tmp_path):
+    return sorted(p.name for p in wigs_dir(tmp_path).glob("*.wig.json"))
+
+
+def _load(tmp_path, filename):
+    parsed = parse_wig((wigs_dir(tmp_path) / filename).read_text())
+    assert parsed.wig is not None, parsed.errors
+    return parsed.wig
+
+
+class TestTheAnswerRidesBackWithTheRepair:
+    @pytest.mark.asyncio
+    async def test_the_batch_says_it_wrote(self, adopted, _no_signing):
+        """The field the UI gates its one line on."""
+        hass, device, tmp_path, _wig = adopted
+        result = await _repair_the_donors(hass, device)
+        assert result["applied"] == 48
+        assert result["wig"]["written"] is True
+        assert result["wig"]["filename"] in _closet(tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_nobody_called_save(self, adopted, _no_signing):
+        """The whole point. No save handler is imported by this file."""
+        hass, device, tmp_path, _wig = adopted
+        await _repair_the_donors(hass, device)
+
+        closet = _closet(tmp_path)
+        assert len(closet) == 2
+        successor_name = next(name for name in closet if name != SOURCE)
+        successor = _load(tmp_path, successor_name)
+
+        matrix = load_matrix(str(tmp_path), device.id)
+        cells = {cell_key(c): c for c in successor.climate.cells}
+        for cell in matrix.cells:
+            assert cells[cell_key(cell)].pronto == cell.pronto
+        repaired = [
+            key for key, cell in cells.items()
+            if (getattr(cell, "extra", None) or {}).get(PROVENANCE_KEY)
+        ]
+        assert len(repaired) == 48
+
+    @pytest.mark.asyncio
+    async def test_a_single_apply_writes_through_too(
+            self, adopted, _no_signing):
+        hass, device, tmp_path, _wig = adopted
+        listing = await _tangles(hass, device)
+        row = next(r for r in listing["rows"] if r.get("donor"))
+        result = await _call(ws_tangle_apply, hass, {
+            "id": 5, "type": "hair/device/tangle/apply",
+            "device_id": device.id, "target": row["id"],
+            "source": "donor", "pronto": row["donor"]["pronto"],
+            "tested": True,
+        })
+        assert result["wig"]["written"] is True
+        assert len(_closet(tmp_path)) == 2
+
+
+class TestWhatItWillNotDelete:
+    @pytest.mark.asyncio
+    async def test_the_contributors_file_survives_the_first_repair(
+            self, adopted, _no_signing):
+        """The original is not the flow's to remove, ever."""
+        hass, device, tmp_path, _wig = adopted
+        before = (wigs_dir(tmp_path) / SOURCE).read_text()
+        await _repair_the_donors(hass, device)
+        assert SOURCE in _closet(tmp_path)
+        assert (wigs_dir(tmp_path) / SOURCE).read_text() == before
+
+    @pytest.mark.asyncio
+    async def test_the_second_repair_replaces_the_first_version(
+            self, adopted, _no_signing):
+        """Not one file per click.
+
+        The mint stamps what it wrote; the next write reads that stamp
+        off the device's CURRENT source and only then allows itself to
+        supersede. So the closet holds the original and exactly one
+        repaired version, however many times somebody works the cards.
+        """
+        hass, device, tmp_path, _wig = adopted
+        first = await _repair_the_donors(hass, device)
+        assert len(_closet(tmp_path)) == 2
+
+        successor = _load(tmp_path, first["wig"]["filename"])
+        assert successor.extra.get(REPAIR_SUCCESSOR) is True
+
+        listing = await _tangles(hass, device)
+        row = listing["rows"][0]
+        second = await _call(ws_tangle_keep, hass, {
+            "id": 6, "type": "hair/device/tangle/keep",
+            "device_id": device.id, "target": row["id"], "tested": True,
+        })
+        assert second["wig"]["written"] is True
+        closet = _closet(tmp_path)
+        assert SOURCE in closet
+        assert len(closet) == 2, closet
+
+    @pytest.mark.asyncio
+    async def test_the_successor_names_the_original_as_its_parent(
+            self, adopted, _no_signing):
+        hass, device, tmp_path, wig = adopted
+        result = await _repair_the_donors(hass, device)
+        successor = _load(tmp_path, result["wig"]["filename"])
+        assert wig.wig_id in successor.supersedes
+
+    @pytest.mark.asyncio
+    async def test_the_wig_keeps_its_own_name_not_the_devices(
+            self, adopted, _no_signing):
+        """A device renamed in Home Assistant must not quietly rename
+        somebody's wig on the next repair."""
+        hass, device, tmp_path, wig = adopted
+        device.name = "Bedroom AC (upstairs)"
+        result = await _repair_the_donors(hass, device)
+        assert _load(tmp_path, result["wig"]["filename"]).name == wig.name
+
+
+class TestWhenThereIsNoWigToWrite:
+    @pytest.mark.asyncio
+    async def test_a_device_built_from_scratch_says_so(
+            self, fake_hass, tmp_path, _no_signing):
+        """Honestly, not as an error.
+
+        Nothing was adopted, so no wig is owed a new version -- and the
+        repair itself still stands. A caller that treated a missing
+        write as a failure would be refusing good work over a wig that
+        was never there.
+
+        Hand-built from the fan's signals rather than adopted, so the
+        device genuinely has no source. The fan is the fixture that
+        gives a flat device real findings: a matrix cell disagrees with
+        the LABEL its coordinates claim, and a flat command has no
+        coordinates to disagree with.
+        """
+        ensure_wigs_dir(tmp_path)
+        devices = _wire(fake_hass, tmp_path)
+        parsed = parse_wig(DREO.read_text())
+        assert parsed.wig is not None, parsed.errors
+        device = IRDevice(name="Hand-built fan", climate_matrix=False,
+                          emitter_entity_ids=["infrared.blaster"])
+        for signal in parsed.wig.signals:
+            device.add_command(IRCommand(
+                name=signal.alias, code=signal.pronto, protocol="PRONTO"))
+        devices.append(device)
+        assert not device.source_wig_id
+
+        listing = await _tangles(fake_hass, device)
+        row = listing["rows"][0]
+        clean = next(
+            signal.pronto for signal in parsed.wig.signals
+            if signal.alias not in {r["target"]["key"] for r in listing["rows"]}
+        )
+        result = await _call(ws_tangle_apply, fake_hass, {
+            "id": 7, "type": "hair/device/tangle/apply",
+            "device_id": device.id, "target": row["id"],
+            "source": "paste", "pronto": clean, "tested": True,
+        })
+        assert result["applied"] is True
+        assert result["wig"]["written"] is False
+        assert result["wig"]["reason"] == WROTE_NOT_ADOPTED
+
+    @pytest.mark.asyncio
+    async def test_a_source_that_left_the_closet_says_so(
+            self, adopted, _no_signing):
+        """Deleted from under the device. The repair still lands; the
+        write reports what happened instead of inventing a new file."""
+        hass, device, tmp_path, _wig = adopted
+        (wigs_dir(tmp_path) / SOURCE).unlink()
+        result = await _repair_the_donors(hass, device)
+        assert result["applied"] == 48
+        assert result["wig"]["written"] is False
+        assert result["wig"]["reason"] == "source_missing"
+
+
+class TestUndoFollowsToo:
+    @pytest.mark.asyncio
+    async def test_the_closet_does_not_stay_ahead_of_the_device(
+            self, adopted, _no_signing):
+        """Undo puts the old bytes back. A wig still holding the
+        repaired ones would be silently ahead of its own device."""
+        hass, device, tmp_path, _wig = adopted
+        listing = await _tangles(hass, device)
+        row = next(r for r in listing["rows"] if r.get("donor"))
+        await _call(ws_tangle_apply, hass, {
+            "id": 8, "type": "hair/device/tangle/apply",
+            "device_id": device.id, "target": row["id"],
+            "source": "donor", "pronto": row["donor"]["pronto"],
+            "tested": True,
+        })
+        reverted = await _call(ws_tangle_revert, hass, {
+            "id": 9, "type": "hair/device/tangle/revert",
+            "device_id": device.id, "target": row["id"],
+        })
+        assert reverted["reverted"] is True
+        assert reverted["wig"]["written"] is True
+
+        successor = _load(tmp_path, reverted["wig"]["filename"])
+        matrix = load_matrix(str(tmp_path), device.id)
+        cells = {cell_key(c): c for c in successor.climate.cells}
+        for cell in matrix.cells:
+            assert cells[cell_key(cell)].pronto == cell.pronto
+
+
+class TestKeepRidesOut:
+    @pytest.mark.asyncio
+    async def test_the_answer_reaches_the_wig_without_a_save(
+            self, adopted, _no_signing):
+        hass, device, tmp_path, _wig = adopted
+        listing = await _tangles(hass, device)
+        row = listing["rows"][0]
+        result = await _call(ws_tangle_keep, hass, {
+            "id": 10, "type": "hair/device/tangle/keep",
+            "device_id": device.id, "target": row["id"], "tested": True,
+            "note": "runs fine on my unit",
+        })
+        assert result["wig"]["written"] is True
+        raw = json.loads(
+            (wigs_dir(tmp_path) / result["wig"]["filename"]).read_text())
+        assert "runs fine on my unit" in json.dumps(raw)

--- a/custom_components/hair/websocket_api.py
+++ b/custom_components/hair/websocket_api.py
@@ -4982,7 +4982,8 @@ async def ws_wigs_save(
                 "current state.",
             )
             return
-        await _do_update(hass, connection, msg, device, attestation, key)
+        outcome = await _do_update(hass, msg, device, attestation, key)
+        refusals = _UPDATE_REFUSALS
     else:
         # CREATE and SUCCESSION are the same act at this layer: mint a
         # wig from the device's current commands and attest against
@@ -4998,19 +4999,38 @@ async def ws_wigs_save(
         # forced False in that case, so this call never
         # auto-supersedes on the Save As New route (item 2:
         # existing wig untouched).
-        await _do_create(
-            hass, connection, msg, device, attestation, key, replace=replace,
+        outcome = await _do_create(
+            hass, msg, device, attestation, key, replace=replace,
         )
+        refusals = _CREATE_REFUSALS
+
+    if isinstance(outcome, str):
+        connection.send_error(
+            msg["id"], outcome,
+            refusals.get(
+                outcome, "Nothing to write: no fitting, and nothing changed"
+            ),
+        )
+        return
+    connection.send_result(msg["id"], outcome)
 
 
 async def _do_update(
     hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
     msg: dict[str, Any],
     device: IRDevice,
     attestation: Any | None,
     key: str | None,
-) -> None:
+) -> dict[str, Any] | str:
+    """Write the device's changes back onto its source wig.
+
+    RETURNS rather than sends (C10). It used to answer the connection
+    directly, which made it reachable only from a websocket handler --
+    and the wig write-through has to reach the same machinery from the
+    repair path, where there is no dialog and no message id. So the
+    wire moved out to ``ws_wigs_save`` and what is left is the act
+    itself: a result dict, or one of ``_UPDATE_REFUSALS``' keys.
+    """
     manager: DeviceManager = _get_first_entry_data(hass)["device_manager"]
     device_matrix = (
         await manager.async_get_matrix(device.id)
@@ -5079,16 +5099,7 @@ async def _do_update(
         )]
         return result.as_dict()
 
-    result = await hass.async_add_executor_job(_write)
-    if isinstance(result, str):
-        connection.send_error(
-            msg["id"], result,
-            _UPDATE_REFUSALS.get(
-                result, "Nothing to write: no fitting, and nothing changed"
-            ),
-        )
-        return
-    connection.send_result(msg["id"], result)
+    return await hass.async_add_executor_job(_write)
 
 
 _UPDATE_REFUSALS = {
@@ -5162,14 +5173,24 @@ def _apply_metadata(wig: Any, edits: dict[str, str]) -> None:
 
 async def _do_create(
     hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
     msg: dict[str, Any],
     device: IRDevice,
     attestation: Any | None,
     key: str | None,
     replace: bool = False,
-) -> None:
+    mark_repair: bool = False,
+) -> dict[str, Any] | str:
     """Mint the wig (CREATE or SUCCESSION); optionally auto-replace.
+
+    RETURNS rather than sends (C10), for the reason given on
+    ``_do_update``: the repair write-through needs this machinery and
+    has no connection to answer. A refusal comes back as one of
+    ``_CREATE_REFUSALS``' keys.
+
+    ``mark_repair`` stamps the minted file as one the repair flow made.
+    That stamp is what later write-throughs read to decide they may
+    supersede: this machinery deletes only files it wrote itself, so a
+    contributor's original is never the thing that disappears.
 
     ``replace`` (Second Fitting v3) asks that, when this mint names a
     local ancestor to supersede, the supersede runs immediately after
@@ -5191,19 +5212,15 @@ async def _do_create(
     )
     build = build_wig_from_device(device, matrix)
     if build.wig is None:
-        connection.send_error(
-            msg["id"], "no_signals", "No exportable signals on that device"
-        )
-        return
+        return "no_signals"
     from .wig_save import reject_flat_exclusions
 
     if reject_flat_exclusions(attestation, build.wig):
-        connection.send_error(
-            msg["id"], "exclusion_on_flat_row",
-            "An exclusion reason can only be given on a matrix "
-            "checklist cell.",
-        )
-        return
+        return "exclusion_on_flat_row"
+    if mark_repair:
+        from .tangles import REPAIR_SUCCESSOR
+
+        build.wig.extra[REPAIR_SUCCESSOR] = True
     if msg.get("name", "").strip():
         build.wig.name = msg["name"].strip()
     for field_name in ("brand", "model", "notes"):
@@ -5288,10 +5305,7 @@ async def _do_create(
 
     result = await hass.async_add_executor_job(_write)
     if result is None:
-        connection.send_error(
-            msg["id"], "write_failed", "Could not write the wig file"
-        )
-        return
+        return "write_failed"
 
     # The device now has a wig in the closet, so it remembers it: the
     # next SAVE TO CLOSET offers UPDATE instead of minting a second copy
@@ -5316,7 +5330,16 @@ async def _do_create(
             })
         replaced["devices"] = receipts
 
-    connection.send_result(msg["id"], result)
+    return result
+
+
+_CREATE_REFUSALS = {
+    "no_signals": "No exportable signals on that device",
+    "exclusion_on_flat_row":
+        "An exclusion reason can only be given on a matrix checklist "
+        "cell.",
+    "write_failed": "Could not write the wig file",
+}
 
 
 # ---------------------------------------------------------------------------
@@ -7272,6 +7295,87 @@ async def ws_tangle_listen(
     )
 
 
+async def _write_through(
+    hass: HomeAssistant, device: IRDevice
+) -> dict[str, Any]:
+    """Push a finished repair back into the user's wig. C10.
+
+    The ruling (tangles-backend.md section 4, 2026-08-27) is that a
+    person who repairs an adopted device does not then have to go and
+    save it: the closet copy follows the device on its own, and the
+    UI's "Your wig has been updated." is allowed to render only once
+    this says it did.
+
+    It invokes the SHIPPED save machinery rather than a second copy of
+    it -- the same ``_do_create`` / ``_do_update`` the save dialog
+    drives, which is why those two stopped owning the connection. The
+    synthetic ``msg`` here is not a pretend websocket message; it is
+    the arguments dict those functions have always taken, carrying the
+    two things this caller has an opinion about: keep the wig's own
+    name, and yes, propose the lattice.
+
+    WHAT IT WILL AND WILL NOT DELETE. A mint stamps ``REPAIR_SUCCESSOR``
+    on what it writes, and ``replace`` is set only when the device's
+    CURRENT source carries that stamp. So the first repair on an
+    adopted device mints beside the contributor's original and leaves
+    it standing; every repair after that supersedes the version before
+    it. The closet settles at two files -- theirs, and the repaired one
+    -- instead of one file per click.
+
+    NEVER RAISES INTO THE REPAIR. The bytes are already on the device
+    and on disk by the time this runs; a wig that could not be written
+    is a thing to REPORT, not a reason to unwind a good repair. Every
+    failure comes back as ``{"written": False, "reason": ...}``.
+    """
+    from .tangles import REPAIR_SUCCESSOR, WROTE_NOT_ADOPTED
+
+    if not device.source_wig_id:
+        return {"written": False, "reason": WROTE_NOT_ADOPTED}
+
+    source_wig, _filename = await hass.async_add_executor_job(
+        _resolve_source, hass, device
+    )
+    if source_wig is None:
+        return {"written": False, "reason": "source_missing"}
+
+    # ALWAYS A MINT, never the UPDATE branch, and this is not an
+    # oversight. UPDATE edits the source file's text in place and can
+    # carry a lattice diff -- which is all the save dialog needs. A
+    # repair produces three things beyond changed bytes: a provenance
+    # record per cell, any KEEP attestations the person recorded, and
+    # a fresh comb receipt over the result. Those exist only in the
+    # wig the EXPORTER builds out of the device, so a write-through
+    # that took the UPDATE branch would silently drop them, and a KEEP
+    # (which changes no bytes at all) would refuse with
+    # "nothing_to_update" while the person watched their answer not
+    # arrive. Minting rebuilds from the device every time and carries
+    # all of it.
+    msg: dict[str, Any] = {
+        # The wig keeps its OWN name. build_wig_from_device would name
+        # the successor after the DEVICE, so a person who renamed the
+        # device in Home Assistant would watch their wig quietly get
+        # renamed on their next repair.
+        "name": source_wig.name or "",
+    }
+    outcome = await _do_create(
+        hass, msg, device, None, None,
+        replace=bool((source_wig.extra or {}).get(REPAIR_SUCCESSOR)),
+        mark_repair=True,
+    )
+
+    if isinstance(outcome, str):
+        return {"written": False, "reason": outcome}
+    written: dict[str, Any] = {
+        "written": True,
+        "filename": outcome.get("filename"),
+        "wig_id": outcome.get("wig_id"),
+    }
+    replaced = outcome.get("replaced")
+    if replaced:
+        written["replaced"] = replaced.get("old_filename")
+    return written
+
+
 def _apply_source(msg: dict[str, Any]) -> str:
     from .tangles import ORIGIN_CAPTURE, ORIGIN_DONOR, ORIGIN_PASTE
 
@@ -7449,6 +7553,7 @@ async def ws_tangle_apply(
         "target": row.id,
         "provenance": provenance,
         "verdict": verdict.as_dict(),
+        "wig": await _write_through(hass, device),
     })
 
 
@@ -7515,9 +7620,14 @@ async def ws_tangle_revert(
         record = revert_repair(command)
         await manager.async_update_device(device)
 
+    # UNDO writes through too (owner call, 2026-08-27). The old bytes
+    # are back on the device; leaving the closet holding the repaired
+    # ones would put the wig silently AHEAD of the device it came from,
+    # which is the same lie the write-through exists to prevent.
     connection.send_result(
         msg["id"], {"reverted": True, "target": msg["target"],
-                    "was": record})
+                    "was": record,
+                    "wig": await _write_through(hass, device)})
 
 
 @websocket_api.require_admin
@@ -7733,6 +7843,7 @@ async def ws_tangle_apply_batch(
         "cluster": msg["cluster"],
         "air_tested": sorted(tested_targets),
         "declined": plan.declined,
+        "wig": await _write_through(hass, device),
     })
 
 
@@ -7780,7 +7891,8 @@ async def ws_tangle_revert_run(
     manager: DeviceManager = _get_first_entry_data(hass)["device_manager"]
     await manager.async_update_device(device)
     connection.send_result(
-        msg["id"], {"reverted": len(holders), "run": msg["run"]})
+        msg["id"], {"reverted": len(holders), "run": msg["run"],
+                    "wig": await _write_through(hass, device)})
 
 
 @websocket_api.require_admin
@@ -7855,5 +7967,10 @@ async def ws_tangle_keep(
     device.tangle_attestations.append(record)
     manager: DeviceManager = _get_first_entry_data(hass)["device_manager"]
     await manager.async_update_device(device)
+    # KEEP is a DECIDE outcome and it changes what the wig SAYS, even
+    # though it changes no bytes: the attestation rides out in the
+    # receipt beside the finding it answers. So it writes through on
+    # the same terms as a repair.
     connection.send_result(
-        msg["id"], {"attested": True, "target": row.id, "record": record})
+        msg["id"], {"attested": True, "target": row.id, "record": record,
+                    "wig": await _write_through(hass, device)})

--- a/custom_components/hair/websocket_api.py
+++ b/custom_components/hair/websocket_api.py
@@ -9,6 +9,7 @@ from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from . import pluck
 from .capture import (
@@ -48,6 +49,7 @@ from .signal_monitor import SignalMonitor
 from .signal_store import SignalStore
 from .trigger_manager import TriggerManager
 from .wig_format import VERDICTS
+from .wig_format import cell_key as _cell_key
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -157,6 +159,8 @@ def async_register_websocket_commands(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, ws_tangle_pre_read)
     websocket_api.async_register_command(hass, ws_tangle_test_send)
     websocket_api.async_register_command(hass, ws_tangle_listen)
+    websocket_api.async_register_command(hass, ws_tangle_apply)
+    websocket_api.async_register_command(hass, ws_tangle_revert)
 
     # Triggers
     websocket_api.async_register_command(hass, ws_get_triggers)
@@ -7261,3 +7265,251 @@ async def ws_tangle_listen(
         hass, connection, msg, "tangle_capture", "tangle_listen_timeout",
         decorate=_decorate,
     )
+
+
+def _apply_source(msg: dict[str, Any]) -> str:
+    from .tangles import ORIGIN_CAPTURE, ORIGIN_DONOR, ORIGIN_PASTE
+
+    source = msg.get("source") or ORIGIN_PASTE
+    return source if source in {
+        ORIGIN_DONOR, ORIGIN_CAPTURE, ORIGIN_PASTE, "synthesized",
+    } else ORIGIN_PASTE
+
+
+async def _write_matrix_and_signal(
+    hass: HomeAssistant, device: IRDevice, matrix: Any
+) -> str | None:
+    """Persist a repaired lattice and tell everything that holds one.
+
+    The dispatch is not optional. A climate entity loads its matrix once
+    and, before the fix flow, was right to: matrix files only changed
+    when a device was created. A repair changes one under a live entity,
+    and without the signal the unit would go on receiving the bytes the
+    repair replaced.
+    """
+    from .matrix_store import SIGNAL_MATRIX_CHANGED, write_matrix
+
+    try:
+        await hass.async_add_executor_job(
+            write_matrix, hass.config.config_dir, device.id, matrix
+        )
+    except (OSError, ValueError) as err:
+        return str(err)
+
+    data = _get_first_entry_data(hass)
+    listener = data.get("matrix_listener") if data else None
+    if listener is not None:
+        # The lattice CHANGED, so every cached index and reading built
+        # from it is answering about a file that no longer exists.
+        listener.invalidate(device.id)
+    async_dispatcher_send(hass, SIGNAL_MATRIX_CHANGED, device.id)
+    return None
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command({
+    vol.Required("type"): f"{WS_PREFIX}/device/tangle/apply",
+    vol.Required("device_id"): str,
+    vol.Required("target"): str,
+    vol.Required("pronto"): vol.All(str, vol.Length(max=20000)),
+    vol.Required("tested"): bool,
+    vol.Optional("source"): str,
+    vol.Optional("detail"): dict,
+    vol.Optional("reading_disagreed"): bool,
+})
+@websocket_api.async_response
+async def ws_tangle_apply(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Write one repair, with its record and its undo.
+
+    THE ONLY DOOR through the no-cell-editing wall, and it is narrow on
+    purpose: it takes a finding reference, refuses a target that carries
+    no current finding, and is not reachable as a general cell editor.
+
+    ``tested`` is required and is RECORDED, never verified. The server
+    cannot watch somebody's air conditioner respond; what it can do is
+    write down that the claim was made and let the receipt carry it.
+
+    ``reading_disagreed`` is the escalation ladder's third rung. A
+    consistent mismatch is evidence about OUR reading rather than about
+    the person pressing the button, so the write is allowed -- but only
+    when it is declared, and the record then carries what the reading
+    said so repeated off-by-ones in one family can accumulate into the
+    map-defect report they are.
+    """
+    device, matrix = await _device_and_matrix(hass, msg["device_id"])
+    if device is None:
+        connection.send_error(msg["id"], "not_found", "Device not found")
+        return
+
+    from .pronto_validator import validate_pronto
+    from .tangles import (
+        APPLY_BAD_CANDIDATE,
+        APPLY_DISAGREEMENT_UNDECLARED,
+        APPLY_NO_FINDING,
+        APPLY_NOT_TESTED,
+        build_provenance,
+        list_tangles,
+        portholes_for,
+        pre_read,
+        project_device,
+        read_lattice,
+        write_repair,
+    )
+
+    if not msg["tested"]:
+        connection.send_error(
+            msg["id"], APPLY_NOT_TESTED,
+            "A repair is committed after a press, not before one",
+        )
+        return
+    if not validate_pronto(msg["pronto"]).valid:
+        connection.send_error(
+            msg["id"], APPLY_BAD_CANDIDATE, "That is not a usable code")
+        return
+
+    def _prepare() -> Any:
+        listing = list_tangles(device, matrix)
+        row = _resolve_target(listing, msg["target"])
+        if row is None:
+            return APPLY_NO_FINDING
+        wig, _sources = project_device(device, matrix)
+        lattice = read_lattice(matrix, wig)
+        verdict = pre_read(lattice, msg["pronto"], row.target.coordinates)
+        return row, lattice, verdict
+
+    prepared = await hass.async_add_executor_job(_prepare)
+    if isinstance(prepared, str):
+        connection.send_error(
+            msg["id"], prepared,
+            "That target carries no current finding",
+        )
+        return
+    row, lattice, verdict = prepared
+
+    declared = bool(msg.get("reading_disagreed"))
+    if verdict.matches is False and not declared:
+        connection.send_error(
+            msg["id"], APPLY_DISAGREEMENT_UNDECLARED,
+            "These bytes read as something else; say so to apply anyway",
+        )
+        return
+
+    provenance = build_provenance(
+        source=_apply_source(msg),
+        prior_pronto=row.pronto,
+        lattice=lattice,
+        row=row,
+        tested=True,
+        detail=msg.get("detail"),
+        disagreed=verdict.as_dict() if declared else None,
+    )
+
+    manager: DeviceManager = _get_first_entry_data(hass)["device_manager"]
+    if row.target.kind == "cell":
+        cell = next(
+            (c for c in matrix.cells if _cell_key(c) == row.target.key), None
+        )
+        if cell is None:
+            connection.send_error(
+                msg["id"], APPLY_NO_FINDING, "That cell is gone")
+            return
+        write_repair(cell, msg["pronto"], provenance)
+        # The porthole is a copy of the cell taken at adopt, and it is
+        # what TEST sends. Leaving it behind would hand somebody a
+        # button that still transmits the code they just repaired.
+        for porthole in portholes_for(device, row.target.coordinates):
+            write_repair(porthole, msg["pronto"], provenance)
+        failure = await _write_matrix_and_signal(hass, device, matrix)
+        if failure is not None:
+            connection.send_error(msg["id"], "write_failed", failure)
+            return
+        await manager.async_update_device(device)
+    else:
+        command = device.get_command(row.target.command_id or "")
+        if command is None:
+            connection.send_error(
+                msg["id"], APPLY_NO_FINDING, "That command is gone")
+            return
+        write_repair(command, msg["pronto"], provenance)
+        # Through async_update_device, so the known-command index
+        # rebuilds on the new bytes and the entity hooks fire (gotcha 6).
+        await manager.async_update_device(device)
+
+    connection.send_result(msg["id"], {
+        "applied": True,
+        "target": row.id,
+        "provenance": provenance,
+        "verdict": verdict.as_dict(),
+    })
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command({
+    vol.Required("type"): f"{WS_PREFIX}/device/tangle/revert",
+    vol.Required("device_id"): str,
+    vol.Required("target"): str,
+})
+@websocket_api.async_response
+async def ws_tangle_revert(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Put back what a repair replaced. One step, not a history."""
+    device, matrix = await _device_and_matrix(hass, msg["device_id"])
+    if device is None:
+        connection.send_error(msg["id"], "not_found", "Device not found")
+        return
+
+    from .tangles import (
+        APPLY_NOTHING_TO_REVERT,
+        TARGET_CELL,
+        portholes_for,
+        read_repair,
+        revert_repair,
+    )
+
+    kind, _, key = msg["target"].partition(":")
+    manager: DeviceManager = _get_first_entry_data(hass)["device_manager"]
+
+    if kind == TARGET_CELL:
+        cell = next(
+            (c for c in (matrix.cells if matrix else []) if _cell_key(c) == key),
+            None,
+        )
+        if cell is None or read_repair(cell) is None:
+            connection.send_error(
+                msg["id"], APPLY_NOTHING_TO_REVERT,
+                "Nothing was repaired here",
+            )
+            return
+        coordinates = {
+            "mode": cell.mode, "fan": cell.fan,
+            "swing": cell.swing, "temp": cell.temp,
+        }
+        record = revert_repair(cell)
+        for porthole in portholes_for(device, coordinates):
+            revert_repair(porthole)
+        failure = await _write_matrix_and_signal(hass, device, matrix)
+        if failure is not None:
+            connection.send_error(msg["id"], "write_failed", failure)
+            return
+        await manager.async_update_device(device)
+    else:
+        command = device.get_command(key)
+        if command is None or read_repair(command) is None:
+            connection.send_error(
+                msg["id"], APPLY_NOTHING_TO_REVERT,
+                "Nothing was repaired here",
+            )
+            return
+        record = revert_repair(command)
+        await manager.async_update_device(device)
+
+    connection.send_result(
+        msg["id"], {"reverted": True, "target": msg["target"],
+                    "was": record})

--- a/custom_components/hair/websocket_api.py
+++ b/custom_components/hair/websocket_api.py
@@ -153,6 +153,7 @@ def async_register_websocket_commands(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, ws_get_action_options)
     websocket_api.async_register_command(hass, ws_update_mapping)
     websocket_api.async_register_command(hass, ws_device_star)
+    websocket_api.async_register_command(hass, ws_device_tangles)
 
     # Triggers
     websocket_api.async_register_command(hass, ws_get_triggers)
@@ -7043,3 +7044,60 @@ async def ws_device_matrix_command(
     manager: DeviceManager = data["device_manager"]
     await manager.async_update_device(device)
     connection.send_result(msg["id"], await _device_full(hass, device))
+
+
+# --- Tangles: the fix flow (device-scoped findings) ---
+
+
+async def _device_and_matrix(
+    hass: HomeAssistant, device_id: str
+) -> tuple[IRDevice | None, Any]:
+    """Resolve a device and its lattice, or (None, None).
+
+    One helper for every tangle handler so the listing, the pre-read
+    and the guarded write can never disagree about what a device id
+    resolves to.
+    """
+    data = _get_first_entry_data(hass)
+    if data is None:
+        return None, None
+    manager: DeviceManager = data["device_manager"]
+    device = manager.get_device(device_id)
+    if device is None:
+        return None, None
+    matrix = (
+        await manager.async_get_matrix(device.id)
+        if device.climate_matrix else None
+    )
+    return device, matrix
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command({
+    vol.Required("type"): f"{WS_PREFIX}/device/tangles",
+    vol.Required("device_id"): str,
+})
+@websocket_api.async_response
+async def ws_device_tangles(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Every open finding on one device, derived from its live state.
+
+    Derived per call and never stored: combing what is on the device
+    now is the only reading that survives a repair (tangles.py module
+    docstring). The lattice work runs in the executor -- a 1,156-cell
+    comb is real arithmetic and the event loop is not the place for it.
+    """
+    device, matrix = await _device_and_matrix(hass, msg["device_id"])
+    if device is None:
+        connection.send_error(msg["id"], "not_found", "Device not found")
+        return
+
+    from .tangles import list_tangles
+
+    listing = await hass.async_add_executor_job(
+        list_tangles, device, matrix
+    )
+    connection.send_result(msg["id"], listing.as_dict())

--- a/custom_components/hair/websocket_api.py
+++ b/custom_components/hair/websocket_api.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import uuid
 from typing import Any
 
 import voluptuous as vol
@@ -161,6 +162,9 @@ def async_register_websocket_commands(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, ws_tangle_listen)
     websocket_api.async_register_command(hass, ws_tangle_apply)
     websocket_api.async_register_command(hass, ws_tangle_revert)
+    websocket_api.async_register_command(hass, ws_tangle_plan)
+    websocket_api.async_register_command(hass, ws_tangle_apply_batch)
+    websocket_api.async_register_command(hass, ws_tangle_revert_run)
 
     # Triggers
     websocket_api.async_register_command(hass, ws_get_triggers)
@@ -7513,3 +7517,266 @@ async def ws_tangle_revert(
     connection.send_result(
         msg["id"], {"reverted": True, "target": msg["target"],
                     "was": record})
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command({
+    vol.Required("type"): f"{WS_PREFIX}/device/tangle/plan",
+    vol.Required("device_id"): str,
+    vol.Required("cluster"): str,
+    vol.Optional("witness"): vol.All(str, vol.Length(max=20000)),
+    vol.Optional("witness_target"): str,
+    vol.Optional("candidates"): dict,
+})
+@websocket_api.async_response
+async def ws_tangle_plan(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """What a run would do, and which cells it wants pressed at.
+
+    Pure. Nothing is written and nothing is armed; this exists so the
+    surface can say "we will send 2 test signals" and know which two,
+    and so the sample a person is asked to prove is the sample the write
+    then records.
+    """
+    device, matrix = await _device_and_matrix(hass, msg["device_id"])
+    if device is None:
+        connection.send_error(msg["id"], "not_found", "Device not found")
+        return
+
+    from .tangles import list_tangles, plan_batch, project_device, read_lattice
+
+    def _plan() -> dict[str, Any]:
+        listing = list_tangles(device, matrix)
+        wig, _sources = project_device(device, matrix)
+        lattice = read_lattice(matrix, wig)
+        return plan_batch(
+            listing, lattice, msg["cluster"],
+            witness=msg.get("witness"),
+            witness_target=msg.get("witness_target"),
+            supplied=msg.get("candidates"),
+        ).as_dict()
+
+    connection.send_result(
+        msg["id"], await hass.async_add_executor_job(_plan))
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command({
+    vol.Required("type"): f"{WS_PREFIX}/device/tangle/apply-batch",
+    vol.Required("device_id"): str,
+    vol.Required("cluster"): str,
+    vol.Required("tested"): bool,
+    vol.Required("tested_targets"): [str],
+    vol.Optional("witness"): vol.All(str, vol.Length(max=20000)),
+    vol.Optional("witness_target"): str,
+    vol.Optional("candidates"): dict,
+    vol.Optional("reading_disagreed"): bool,
+})
+@websocket_api.async_response
+async def ws_tangle_apply_batch(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """One cause, one run: prove a sample on air, then write all of it.
+
+    The precedent is the dimension check, which attests axes rather than
+    walking six hundred cells. A run presses at a representative sample
+    spanning the card's modes and, on a pass, writes every member in one
+    batch -- with each cell's record honest about which tier it got:
+    air-tested, or rule-derived by a rule that was air-tested on named
+    cells.
+
+    NO PARTIAL BATCHES, EVER. Everything is resolved and read before
+    anything moves, and a failure anywhere leaves the lattice
+    byte-identical to what it was. That is not only failure handling: on
+    a shifted column, applying one cell of a cause at a time leaves the
+    repaired cell byte-identical to its still-broken neighbour, so the
+    batch is the correct unit of work as well as the safe one.
+    """
+    device, matrix = await _device_and_matrix(hass, msg["device_id"])
+    if device is None:
+        connection.send_error(msg["id"], "not_found", "Device not found")
+        return
+
+    from .tangles import (
+        APPLY_DISAGREEMENT_UNDECLARED,
+        APPLY_NOT_TESTED,
+        BATCH_EMPTY,
+        BATCH_SAMPLE_SHORT,
+        TARGET_CELL,
+        TIER_AIR_TESTED,
+        TIER_RULE_DERIVED,
+        build_provenance,
+        list_tangles,
+        plan_batch,
+        portholes_for,
+        project_device,
+        read_lattice,
+        repair_bytes,
+        repair_extras,
+        restore_holder,
+        sample_covers_modes,
+        write_repair,
+    )
+
+    if not msg["tested"]:
+        connection.send_error(
+            msg["id"], APPLY_NOT_TESTED,
+            "A run is committed after a press, not before one",
+        )
+        return
+
+    def _prepare() -> Any:
+        listing = list_tangles(device, matrix)
+        wig, _sources = project_device(device, matrix)
+        lattice = read_lattice(matrix, wig)
+        plan = plan_batch(
+            listing, lattice, msg["cluster"],
+            witness=msg.get("witness"),
+            witness_target=msg.get("witness_target"),
+            supplied=msg.get("candidates"),
+        )
+        return listing, lattice, plan
+
+    listing, lattice, plan = await hass.async_add_executor_job(_prepare)
+    if plan.refused:
+        connection.send_error(
+            msg["id"], plan.refused, "There is nothing to apply here")
+        return
+
+    rows = {row.id: row for row in listing.rows}
+    members = list(plan.candidates)
+    tested_targets = [t for t in msg["tested_targets"] if t in plan.candidates]
+    if not tested_targets or not sample_covers_modes(
+            rows, members, tested_targets):
+        connection.send_error(
+            msg["id"], BATCH_SAMPLE_SHORT,
+            "Every mode this covers has to be proved on air",
+        )
+        return
+
+    declared = bool(msg.get("reading_disagreed"))
+    disagreeing = [
+        member for member, candidate in plan.candidates.items()
+        if candidate["verdict"]["matches"] is False
+    ]
+    if disagreeing and not declared:
+        connection.send_error(
+            msg["id"], APPLY_DISAGREEMENT_UNDECLARED,
+            "Some of these read as something else; say so to apply anyway",
+        )
+        return
+
+    run = uuid.uuid4().hex
+    cells = {_cell_key(c): c for c in (matrix.cells if matrix else [])}
+    snapshot: list[tuple[Any, str, dict[str, Any]]] = []
+    writes: list[tuple[Any, str, dict[str, Any]]] = []
+    for member in members:
+        row = rows[member]
+        candidate = plan.candidates[member]
+        provenance = build_provenance(
+            source=candidate["origin"],
+            prior_pronto=row.pronto,
+            lattice=lattice,
+            row=row,
+            tested=True,
+            tier=(TIER_AIR_TESTED if member in tested_targets
+                  else TIER_RULE_DERIVED),
+            run=run,
+            tested_keys=[rows[t].target.key for t in tested_targets],
+            detail={k: v for k, v in candidate.items()
+                    if k in ("donor", "sibling", "witness_digest")},
+            disagreed=(candidate["verdict"] if declared
+                       and member in disagreeing else None),
+        )
+        if row.target.kind == TARGET_CELL:
+            holder = cells.get(row.target.key)
+            if holder is None:
+                connection.send_error(
+                    msg["id"], BATCH_EMPTY, "A cell in this run is gone")
+                return
+            holders = [holder, *portholes_for(device, row.target.coordinates)]
+        else:
+            holder = device.get_command(row.target.command_id or "")
+            if holder is None:
+                connection.send_error(
+                    msg["id"], BATCH_EMPTY, "A command in this run is gone")
+                return
+            holders = [holder]
+        for each in holders:
+            snapshot.append(
+                (each, repair_bytes(each), dict(repair_extras(each))))
+            writes.append((each, candidate["pronto"], provenance))
+
+    # Resolved, read and validated. Only now does anything move.
+    for holder, pronto, provenance in writes:
+        write_repair(holder, pronto, provenance)
+
+    if matrix is not None:
+        failure = await _write_matrix_and_signal(hass, device, matrix)
+        if failure is not None:
+            for holder, pronto, extras in snapshot:
+                restore_holder(holder, pronto, extras)
+            connection.send_error(msg["id"], "write_failed", failure)
+            return
+
+    manager: DeviceManager = _get_first_entry_data(hass)["device_manager"]
+    await manager.async_update_device(device)
+    connection.send_result(msg["id"], {
+        "applied": len(members),
+        "run": run,
+        "cluster": msg["cluster"],
+        "air_tested": sorted(tested_targets),
+        "declined": plan.declined,
+    })
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command({
+    vol.Required("type"): f"{WS_PREFIX}/device/tangle/revert-run",
+    vol.Required("device_id"): str,
+    vol.Required("run"): str,
+})
+@websocket_api.async_response
+async def ws_tangle_revert_run(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Undo a whole run. One APPLY is one undo."""
+    device, matrix = await _device_and_matrix(hass, msg["device_id"])
+    if device is None:
+        connection.send_error(msg["id"], "not_found", "Device not found")
+        return
+
+    from .tangles import (
+        APPLY_NOTHING_TO_REVERT,
+        read_repair,
+        revert_repair,
+    )
+
+    holders = [
+        holder for holder in
+        [*(matrix.cells if matrix else []), *device.commands]
+        if (read_repair(holder) or {}).get("run") == msg["run"]
+    ]
+    if not holders:
+        connection.send_error(
+            msg["id"], APPLY_NOTHING_TO_REVERT, "No such run on this device")
+        return
+    for holder in holders:
+        revert_repair(holder)
+
+    if matrix is not None:
+        failure = await _write_matrix_and_signal(hass, device, matrix)
+        if failure is not None:
+            connection.send_error(msg["id"], "write_failed", failure)
+            return
+    manager: DeviceManager = _get_first_entry_data(hass)["device_manager"]
+    await manager.async_update_device(device)
+    connection.send_result(
+        msg["id"], {"reverted": len(holders), "run": msg["run"]})

--- a/custom_components/hair/websocket_api.py
+++ b/custom_components/hair/websocket_api.py
@@ -165,6 +165,7 @@ def async_register_websocket_commands(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, ws_tangle_plan)
     websocket_api.async_register_command(hass, ws_tangle_apply_batch)
     websocket_api.async_register_command(hass, ws_tangle_revert_run)
+    websocket_api.async_register_command(hass, ws_tangle_keep)
 
     # Triggers
     websocket_api.async_register_command(hass, ws_get_triggers)
@@ -7780,3 +7781,79 @@ async def ws_tangle_revert_run(
     await manager.async_update_device(device)
     connection.send_result(
         msg["id"], {"reverted": len(holders), "run": msg["run"]})
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command({
+    vol.Required("type"): f"{WS_PREFIX}/device/tangle/keep",
+    vol.Required("device_id"): str,
+    vol.Required("target"): str,
+    vol.Required("tested"): bool,
+    vol.Optional("note"): vol.All(str, vol.Length(max=500)),
+})
+@websocket_api.async_response
+async def ws_tangle_keep(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """The other outcome: looked at it, it works, keep it.
+
+    A finding is a doubt about bytes, and a person with the hardware in
+    front of them can answer it. This records that answer -- the target,
+    the exact bytes it is about, the classes it answers, the map version
+    that raised them, and the same tested assertion the write requires.
+
+    Nothing is deleted. The finding stands in the receipt and the wig
+    carries both the math and the human's answer, because attested is a
+    different thing from clean and has to keep reading as one. What
+    changes is that the row leaves the work list, and re-combing stays
+    quiet about it for exactly as long as the bytes and the map hold
+    still.
+    """
+    device, matrix = await _device_and_matrix(hass, msg["device_id"])
+    if device is None:
+        connection.send_error(msg["id"], "not_found", "Device not found")
+        return
+
+    from .tangles import (
+        KEEP_NO_FINDING,
+        KEEP_NOT_TESTED,
+        build_attestation,
+        list_tangles,
+        project_device,
+        read_lattice,
+    )
+
+    if not msg["tested"]:
+        connection.send_error(
+            msg["id"], KEEP_NOT_TESTED,
+            "Keeping a code means having tried it",
+        )
+        return
+
+    def _prepare() -> Any:
+        listing = list_tangles(device, matrix)
+        row = _resolve_target(listing, msg["target"])
+        if row is None:
+            return KEEP_NO_FINDING
+        wig, _sources = project_device(device, matrix)
+        return row, read_lattice(matrix, wig)
+
+    prepared = await hass.async_add_executor_job(_prepare)
+    if isinstance(prepared, str):
+        connection.send_error(
+            msg["id"], prepared, "That target carries no current finding")
+        return
+    row, lattice = prepared
+
+    record = build_attestation(row, lattice, note=msg.get("note"))
+    device.tangle_attestations = [
+        existing for existing in device.tangle_attestations
+        if existing.get("key") != record["key"]
+    ]
+    device.tangle_attestations.append(record)
+    manager: DeviceManager = _get_first_entry_data(hass)["device_manager"]
+    await manager.async_update_device(device)
+    connection.send_result(
+        msg["id"], {"attested": True, "target": row.id, "record": record})

--- a/custom_components/hair/websocket_api.py
+++ b/custom_components/hair/websocket_api.py
@@ -154,6 +154,9 @@ def async_register_websocket_commands(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, ws_update_mapping)
     websocket_api.async_register_command(hass, ws_device_star)
     websocket_api.async_register_command(hass, ws_device_tangles)
+    websocket_api.async_register_command(hass, ws_tangle_pre_read)
+    websocket_api.async_register_command(hass, ws_tangle_test_send)
+    websocket_api.async_register_command(hass, ws_tangle_listen)
 
     # Triggers
     websocket_api.async_register_command(hass, ws_get_triggers)
@@ -5333,6 +5336,7 @@ def _arm_listen(
     msg: dict[str, Any],
     capture_event: str,
     timeout_event: str,
+    decorate: Any = None,
 ) -> None:
     """Arm the Sniffer for one capture into a Replace box.
 
@@ -5414,6 +5418,13 @@ def _arm_listen(
         }
         if vote is not None:
             payload["repeats_disagree"] = vote.as_dict()
+        if decorate is not None:
+            # The fix flow adds what the capture READS AS against the
+            # target it was aimed at, so the surface can answer in the
+            # device's own words without a second round trip. Everything
+            # above stays identical -- one listen path, one capture
+            # notice, one set of semantics.
+            decorate(payload)
         connection.send_event(msg_id, payload)
 
     @callback
@@ -7101,3 +7112,152 @@ async def ws_device_tangles(
         list_tangles, device, matrix
     )
     connection.send_result(msg["id"], listing.as_dict())
+
+
+def _resolve_target(listing: Any, target_id: str) -> Any:
+    """The row a fix names, or None. One place, so every handler agrees."""
+    for row in listing.rows:
+        if row.id == target_id:
+            return row
+    return None
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command({
+    vol.Required("type"): f"{WS_PREFIX}/device/tangle/pre-read",
+    vol.Required("device_id"): str,
+    vol.Required("pronto"): vol.All(str, vol.Length(max=20000)),
+    vol.Optional("target"): str,
+})
+@websocket_api.async_response
+async def ws_tangle_pre_read(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """What a candidate reads as, before anything is written.
+
+    Pure read: no store is touched and nothing is armed. ``target`` is
+    the row this candidate is proposed for; without it the bytes are
+    still read and reported, there is simply no claim to check them
+    against and the verdict says so rather than inventing a failure.
+    """
+    device, matrix = await _device_and_matrix(hass, msg["device_id"])
+    if device is None:
+        connection.send_error(msg["id"], "not_found", "Device not found")
+        return
+
+    from .tangles import list_tangles, pre_read, project_device, read_lattice
+
+    def _read() -> dict[str, Any] | str:
+        coordinates = None
+        if msg.get("target"):
+            row = _resolve_target(list_tangles(device, matrix), msg["target"])
+            if row is None:
+                return "unknown_target"
+            coordinates = row.target.coordinates
+        wig, _sources = project_device(device, matrix)
+        lattice = read_lattice(matrix, wig)
+        return pre_read(lattice, msg["pronto"], coordinates).as_dict()
+
+    result = await hass.async_add_executor_job(_read)
+    if isinstance(result, str):
+        connection.send_error(
+            msg["id"], result, "That target carries no current finding")
+        return
+    connection.send_result(msg["id"], result)
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command({
+    vol.Required("type"): f"{WS_PREFIX}/device/tangle/test-send",
+    vol.Required("device_id"): str,
+    vol.Required("pronto"): vol.All(str, vol.Length(max=20000)),
+    vol.Optional("send_count", default=1): vol.All(int, vol.Range(min=1, max=10)),
+})
+@websocket_api.async_response
+async def ws_tangle_test_send(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Send candidate bytes at the real unit. Nothing is saved.
+
+    This is the press the guarded write is gated on, and it has to
+    happen before the write or it proves nothing.
+    """
+    data = _get_first_entry_data(hass)
+    if data is None:
+        connection.send_error(msg["id"], "not_configured", "HAIR not configured")
+        return
+    manager: DeviceManager = data["device_manager"]
+    try:
+        landed = await manager.async_test_send(
+            msg["device_id"], msg["pronto"],
+            send_count=msg.get("send_count", 1),
+        )
+    except KeyError:
+        connection.send_error(msg["id"], "not_found", "Device not found")
+        return
+    except RuntimeError as err:
+        connection.send_error(msg["id"], "send_failed", str(err))
+        return
+    connection.send_result(
+        msg["id"], {"sent": True, "emitters": sorted(landed)})
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command({
+    vol.Required("type"): f"{WS_PREFIX}/device/tangle/listen",
+    vol.Required("device_id"): str,
+    vol.Optional("target"): str,
+})
+@websocket_api.async_response
+async def ws_tangle_listen(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Arm the Sniffer for one capture aimed at a target.
+
+    Rides the same listen path the command editor uses, so a capture
+    arrives here exactly as it arrives there, R1 capture notice and
+    all. What this adds is CONTEXT: the capture is pre-read against the
+    target's own label before the event leaves, so the surface can say
+    what it heard in the device's own words without a second round trip.
+    """
+    device, matrix = await _device_and_matrix(hass, msg["device_id"])
+    if device is None:
+        connection.send_error(msg["id"], "not_found", "Device not found")
+        return
+
+    from .tangles import list_tangles, pre_read, project_device, read_lattice
+
+    def _context() -> tuple[Any, Any] | str:
+        coordinates = None
+        if msg.get("target"):
+            row = _resolve_target(list_tangles(device, matrix), msg["target"])
+            if row is None:
+                return "unknown_target"
+            coordinates = row.target.coordinates
+        wig, _sources = project_device(device, matrix)
+        return read_lattice(matrix, wig), coordinates
+
+    prepared = await hass.async_add_executor_job(_context)
+    if isinstance(prepared, str):
+        connection.send_error(
+            msg["id"], prepared, "That target carries no current finding")
+        return
+    lattice, coordinates = prepared
+
+    def _decorate(payload: dict[str, Any]) -> None:
+        payload["verdict"] = pre_read(
+            lattice, payload["pronto"], coordinates
+        ).as_dict()
+        if msg.get("target"):
+            payload["target"] = msg["target"]
+
+    _arm_listen(
+        hass, connection, msg, "tangle_capture", "tangle_listen_timeout",
+        decorate=_decorate,
+    )

--- a/custom_components/hair/wig_comb.py
+++ b/custom_components/hair/wig_comb.py
@@ -795,6 +795,17 @@ _FIELD_COORDINATE = {
 
 _POWER_FIELD = "power"
 
+# The same reading, under public names, for the fix flow.
+#
+# ``tangles.py`` has to answer "what does this cell actually send" with
+# the identical family vote and the identical coordinate vocabulary the
+# sweep used to doubt it. A second implementation over there would be
+# two answers to one question, and the first time they disagreed the
+# repair would be offered against a reading nobody filed. Aliases
+# rather than a rename so every call site here stays as it reads.
+FIELD_COORDINATE = _FIELD_COORDINATE
+POWER_FIELD = _POWER_FIELD
+
 
 @dataclass(frozen=True)
 class _Code:
@@ -907,6 +918,12 @@ def _read_family(
         # nothing was ever a candidate.
         coverage.protocol["rejected"] = rejected
     return chosen, readings
+
+
+#: See FIELD_COORDINATE above: one reading, two callers.
+read_family = _read_family
+matrix_codes = _matrix_codes
+Code = _Code
 
 
 def _temperature_moves(

--- a/custom_components/hair/wig_export.py
+++ b/custom_components/hair/wig_export.py
@@ -142,7 +142,7 @@ def build_wig_from_device(
         sources.append(command.id)
     if not signals and matrix is None:
         return WigBuild(None, skipped, sources, notes)
-    return WigBuild(
+    build = WigBuild(
         Wig(
             name=(device.name or "Exported Device").strip()
             or "Exported Device",
@@ -170,3 +170,10 @@ def build_wig_from_device(
         sources,
         notes,
     )
+    # The KEEP outcomes ride out with the codes. Parked on the wig
+    # rather than stamped, because the comb receipt they belong inside
+    # is written later, by the re-comb on the way to the closet.
+    from .tangles import carry_attestations
+
+    carry_attestations(build.wig, device)
+    return build

--- a/custom_components/hair/wig_save.py
+++ b/custom_components/hair/wig_save.py
@@ -887,10 +887,24 @@ def recomb(wig: Wig) -> int:
     changing the bytes does. The comb doubts bytes; a person vouches
     for hardware; a row can honestly carry both.
     """
-    from .wig_comb import comb_wig, stamp_receipt
+    from .tangles import ATTESTED_KEY, ATTESTED_PENDING
+    from .wig_comb import COMB_KEY, comb_wig, stamp_receipt
 
     report = comb_wig(wig)
     stamp_receipt(wig, report, _now_date())
+    # A device that repaired what it could and vouched for the rest
+    # carries both out. The attestations are parked on the wig by the
+    # exporter because the receipt does not exist until the line above;
+    # they belong INSIDE it, beside the findings they answer, so the
+    # shop's own re-derive sees the math and the human's answer
+    # together.
+    carried = wig.extra.pop(ATTESTED_PENDING, None)
+    if isinstance(carried, list) and carried:
+        receipt = wig.extra.get(COMB_KEY)
+        if isinstance(receipt, dict):
+            receipt[ATTESTED_KEY] = [
+                dict(record) for record in carried if isinstance(record, dict)
+            ]
     return report.suspects
 
 


### PR DESCRIPTION
Backend for the device repair flow: comb findings surface per device, clustered by cause, and repair through one guarded write path.

- Device-scoped listing over websocket: rows derived live from a fresh comb of the projected device, cause cards, coverage notes, advisories, and standing attestations.
- Donor search on the matrix readers: a flagged cell suggests a donor whose read matches its label; no donor means an honest abstain.
- Candidate plumbing: pre-read, test-send, and listen-into-context, all read-only.
- The guarded write: apply requires a current finding and an explicit tested assertion, records provenance including the prior bytes, and reverts one step. A mismatched candidate must declare the disagreement to apply.
- Witnessed-field synthesis for cells with no donor anywhere, gated on ratified maps, built from each cell's own sibling capture.
- Batch apply per cause with representative air tests and two-tier provenance; a failed test writes nothing; revert works per run.
- Keep: attest a finding as verified working; expires structurally when bytes or map change.
- Completing a repair writes a new version of the source wig through the existing succession machinery, and the result reports whether that write succeeded.
- A live climate entity re-reads its lattice when a repair changes it.

No user-facing strings and no frontend in this branch; the UI ships separately. 164 new tests; suites and lint green on both CI flavors.
