### PR TITLE
Tangle listen stays armed, decoded means readable, receipts earn their tier

### DIFF
--- a/custom_components/hair/tangles.py
+++ b/custom_components/hair/tangles.py
@@ -739,8 +739,22 @@ def pre_read(
 PROVENANCE_KEY = "hair_repair"
 
 #: The write is honest about how much of it was proven on air.
+#:
+#: ``air-tested`` is a claim about the ROOM: somebody pointed this at
+#: the unit and pressed. It is only ever written where there is send
+#: evidence behind it -- a positive ``sends_fired`` for that row, or
+#: membership in a batch's air-tested sample. Everything else a person
+#: accepts is ``accepted``, which is the honest word for "a human said
+#: yes to these bytes" and claims nothing about a transmission.
+#:
+#: RULED 2026-08-28, ship-blocker. Single apply used to DEFAULT to
+#: air-tested, so a bench run produced 48 records claiming it with zero
+#: sends behind them. The code did what it said; what it said
+#: overclaimed, against this project's own rule that the server must
+#: not pretend to verify a press it cannot see.
 TIER_AIR_TESTED = "air-tested"
 TIER_RULE_DERIVED = "rule-derived"
+TIER_ACCEPTED = "accepted"
 
 #: Stamped in a minted wig's ``extra`` when the repair write-through
 #: (C10) is what minted it. The write-through reads it back off the
@@ -778,7 +792,8 @@ def build_provenance(
     lattice: LatticeReading,
     row: TangleRow,
     tested: bool,
-    tier: str = TIER_AIR_TESTED,
+    sends_fired: int = 0,
+    tier: str | None = None,
     run: str | None = None,
     tested_keys: list[str] | None = None,
     detail: dict[str, Any] | None = None,
@@ -794,13 +809,24 @@ def build_provenance(
     somebody's air conditioner respond and must not pretend to; what it
     can do is write down that the assertion was made, and let the
     receipt carry it where anybody can read it.
+
+    ``sends_fired`` is the countable half of that, and the reason the
+    tier can be trusted: it is how many times the surface actually
+    fired this row's code, recorded verbatim. The tier DERIVES from it
+    when a caller does not force one, so the old dangerous default --
+    air-tested for anything that reached this function -- cannot come
+    back by omission. A caller may still pass ``tier`` explicitly, and
+    the batch does: its air-tested sample is evidenced by the sample
+    itself rather than by a per-row count.
     """
+    fired = max(0, int(sends_fired or 0))
     record: dict[str, Any] = {
         "origin": "fix",
         "source": source,
         "applied": _now(),
         "tested": bool(tested),
-        "tier": tier,
+        "sends_fired": fired,
+        "tier": tier or (TIER_AIR_TESTED if fired else TIER_ACCEPTED),
         "prior": {
             "pronto": prior_pronto,
             "digest": _cell_digest(prior_pronto),

--- a/custom_components/hair/tests/test_tangle_listen_fixes.py
+++ b/custom_components/hair/tests/test_tangle_listen_fixes.py
@@ -1,0 +1,360 @@
+"""Two bench findings on the fix flow's LISTEN, both real.
+
+Found in window 2 with hardware in the room, confirmed in source by
+review, and both of the kind that only a real press exposes: the code
+was self-consistent and the tests around it passed.
+
+ONE. The listen subscription was single-shot. ``_finish()`` unsubscribed
+after the first forwarded capture, so one arm delivered one capture --
+and the mismatch ladder counts misses on ONE arm. Hear 18 when 19 was
+asked for, say so; hear it again, say so again; on the third, offer USE
+IT ANYWAY, the rung that admits our reading may be at fault rather than
+the remote. That third rung was unreachable through real presses no
+matter how many times somebody pressed, because after the first there
+was nobody listening.
+
+TWO. ``decoded`` meant the wrong thing. It was
+``bool(decoded_fingerprint)`` -- the GENERAL protocol classifier, which
+does not recognise AC protocols like ZHLT01 at all -- while the very
+same event carried a field-tier verdict that had read the press
+perfectly. The surface obeys the flag, so a byte-perfect press rendered
+"came through garbled". Any device on a map-read protocol could never
+capture cleanly.
+
+Neither needed a frontend change. Both were the backend telling the
+truth about the wrong question.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.hair.const import DOMAIN
+from custom_components.hair.models import IRDevice
+from custom_components.hair.websocket_api import (
+    ws_command_listen,
+    ws_tangle_listen,
+)
+from custom_components.hair.wig_format import Wig, cell_key, parse_wig
+
+FIXTURES = Path(__file__).parent / "fixtures"
+KOMECO = (FIXTURES / "wigs"
+          / "komeco-airconditioner-kos-09qc-3hx-perfect-fit.wig.json")
+
+#: A cell whose label the fix flow would aim a press at.
+TARGET = "heat_cool/medium/off/25"
+
+
+@pytest.fixture(scope="module")
+def komeco() -> Wig:
+    parsed = parse_wig(KOMECO.read_text())
+    assert parsed.wig is not None, parsed.errors
+    return parsed.wig
+
+
+def _cell(wig: Wig, key: str):
+    return next(c for c in wig.climate.cells if cell_key(c) == key)
+
+
+class _Monitor:
+    """The signal monitor's subscriber feed, as much as is needed."""
+
+    def __init__(self) -> None:
+        self.subscribers: list = []
+
+    def subscribe(self, cb) -> None:
+        self.subscribers.append(cb)
+
+    def unsubscribe(self, cb) -> None:
+        if cb in self.subscribers:
+            self.subscribers.remove(cb)
+
+    def emit(self, summary) -> None:
+        for cb in list(self.subscribers):
+            cb(summary)
+
+
+class _Store:
+    """A signal store whose next capture is whatever was last set.
+
+    One store, many presses: the point of half these tests is that a
+    second and third press reach the same armed listener, so the store
+    has to be able to answer differently each time.
+    """
+
+    def __init__(self, pronto: str) -> None:
+        self.pronto = pronto
+        self.decoded_fingerprint = None
+
+    def get_device(self, _device_id):
+        signal = MagicMock()
+        signal.code = self.pronto
+        signal.protocol = "PRONTO"
+        signal.decoded_fingerprint = self.decoded_fingerprint
+        signal.decoded_protocol = None
+        signal.heard_by = ["infrared.receiver"]
+        device = MagicMock()
+        device.get_signal_by_id = MagicMock(return_value=signal)
+        return device
+
+
+class _Timer:
+    def __init__(self) -> None:
+        self.cancelled = False
+
+    def cancel(self) -> None:
+        self.cancelled = True
+
+
+def _wire(fake_hass, komeco, pronto):
+    device = IRDevice(name="Komeco", climate_matrix=True,
+                      emitter_entity_ids=["infrared.blaster"])
+    manager = MagicMock()
+    manager.get_device = MagicMock(return_value=device)
+    manager.async_get_matrix = AsyncMock(return_value=komeco.climate)
+    monitor = _Monitor()
+    store = _Store(pronto)
+    fake_hass.data[DOMAIN] = {"entry-1": {
+        "device_manager": manager,
+        "signal_monitor": monitor,
+        "signal_store": store,
+    }}
+    timers: list[_Timer] = []
+
+    def _call_later(_delay, callback):
+        timer = _Timer()
+        timer.callback = callback
+        timers.append(timer)
+        return timer
+
+    fake_hass.loop = MagicMock()
+    fake_hass.loop.call_later = MagicMock(side_effect=_call_later)
+    return device, monitor, store, timers
+
+
+def _conn():
+    connection = MagicMock()
+    connection.subscriptions = {}
+    return connection
+
+
+def _press(monitor):
+    monitor.emit({"device_id": "d", "device_fingerprint": "f",
+                  "signal_id": "s", "protocol": "PRONTO"})
+
+
+def _events(connection):
+    return [call.args[1] for call in connection.send_event.call_args_list]
+
+
+async def _arm_tangle(fake_hass, connection, device, target=TARGET):
+    msg = {"id": 9, "type": "hair/device/tangle/listen",
+           "device_id": device.id}
+    if target:
+        msg["target"] = f"cell:{target}"
+    await ws_tangle_listen(fake_hass, connection, msg)
+
+
+class TestTheLadderCanClimb:
+    """Three misses on one arm, which is what USE IT ANYWAY costs."""
+
+    @pytest.mark.asyncio
+    async def test_three_mismatched_presses_all_forward(self, fake_hass,
+                                                        komeco):
+        wrong = _cell(komeco, "heat_cool/medium/off/28")
+        device, monitor, _store, _timers = _wire(
+            fake_hass, komeco, wrong.pronto)
+        connection = _conn()
+        await _arm_tangle(fake_hass, connection, device)
+        assert connection.send_result.call_args.args[1] == {"listening": True}
+
+        for _ in range(3):
+            _press(monitor)
+
+        events = _events(connection)
+        assert len(events) == 3, "the ladder never gets past its first rung"
+        for event in events:
+            assert event["type"] == "tangle_capture"
+            assert event["verdict"]["matches"] is False
+            assert event["verdict"]["reads_as"]["temperature"] == 29.0
+
+    @pytest.mark.asyncio
+    async def test_the_listener_is_still_subscribed_between_presses(
+            self, fake_hass, komeco):
+        """The mechanism, not just the count. A window that forwarded
+        three events while unsubscribing would be a different bug."""
+        wrong = _cell(komeco, "heat_cool/medium/off/28")
+        device, monitor, _store, _timers = _wire(
+            fake_hass, komeco, wrong.pronto)
+        await _arm_tangle(fake_hass, _conn(), device)
+        assert len(monitor.subscribers) == 1
+        _press(monitor)
+        assert len(monitor.subscribers) == 1
+
+    @pytest.mark.asyncio
+    async def test_the_presses_can_differ(self, fake_hass, komeco):
+        """A real ladder is somebody trying again, not the same event
+        replayed: the second press reads as its own reading."""
+        device, monitor, store, _timers = _wire(
+            fake_hass, komeco, _cell(komeco, "heat_cool/medium/off/28").pronto)
+        connection = _conn()
+        await _arm_tangle(fake_hass, connection, device)
+
+        _press(monitor)
+        store.pronto = _cell(komeco, "heat_cool/medium/off/24").pronto
+        _press(monitor)
+
+        reads = [e["verdict"]["reads_as"]["temperature"]
+                 for e in _events(connection)]
+        assert reads == [29.0, 25.0]
+
+    @pytest.mark.asyncio
+    async def test_each_press_gets_a_fresh_silence_window(self, fake_hass,
+                                                          komeco):
+        """The timeout is a silence window, not a total budget. A
+        ladder that lost its listener because somebody paused between
+        presses would fail the way the single-shot bug failed."""
+        wrong = _cell(komeco, "heat_cool/medium/off/28")
+        device, monitor, _store, timers = _wire(
+            fake_hass, komeco, wrong.pronto)
+        await _arm_tangle(fake_hass, _conn(), device)
+        assert len(timers) == 1
+
+        _press(monitor)
+        assert timers[0].cancelled is True
+        assert len(timers) == 2
+        assert timers[1].cancelled is False
+
+
+class TestItStillEndsWhenItShould:
+    """Open-ended is not the same as never closing."""
+
+    @pytest.mark.asyncio
+    async def test_the_timeout_still_tears_it_down(self, fake_hass, komeco):
+        wrong = _cell(komeco, "heat_cool/medium/off/28")
+        device, monitor, _store, timers = _wire(
+            fake_hass, komeco, wrong.pronto)
+        connection = _conn()
+        await _arm_tangle(fake_hass, connection, device)
+
+        _press(monitor)
+        timers[-1].callback()
+
+        assert monitor.subscribers == []
+        assert _events(connection)[-1] == {"type": "tangle_listen_timeout"}
+        _press(monitor)
+        assert len(_events(connection)) == 2, "a torn-down window forwarded"
+
+    @pytest.mark.asyncio
+    async def test_the_client_can_unsubscribe(self, fake_hass, komeco):
+        """Cancel, or simply closing the dialog. The subscription is
+        registered for exactly this and it still is."""
+        wrong = _cell(komeco, "heat_cool/medium/off/28")
+        device, monitor, _store, _timers = _wire(
+            fake_hass, komeco, wrong.pronto)
+        connection = _conn()
+        await _arm_tangle(fake_hass, connection, device)
+
+        assert 9 in connection.subscriptions
+        connection.subscriptions[9]()
+        assert monitor.subscribers == []
+        _press(monitor)
+        assert _events(connection) == []
+
+
+class TestTheOtherListenersAreUnchanged:
+    """One flag, one surface. The command editor's Replace box holds
+    one code, so its window is still one capture and done."""
+
+    @pytest.mark.asyncio
+    async def test_the_command_editor_stays_single_shot(self, fake_hass,
+                                                        komeco):
+        donor = _cell(komeco, "heat_cool/medium/off/24")
+        _device, monitor, _store, _timers = _wire(
+            fake_hass, komeco, donor.pronto)
+        connection = _conn()
+        ws_command_listen(fake_hass, connection,
+                          {"id": 4, "type": "hair/command/listen"})
+
+        _press(monitor)
+        _press(monitor)
+
+        assert len(_events(connection)) == 1
+        assert monitor.subscribers == []
+
+
+class TestDecodedMeansReadable:
+    """The flag the surface renders "garbled" from."""
+
+    @pytest.mark.asyncio
+    async def test_a_map_read_capture_arrives_decoded(self, fake_hass,
+                                                      komeco):
+        """The whole bug in one assertion. This capture is a real
+        ZHLT01 frame: the general classifier gives it no fingerprint
+        (decoded_fingerprint is None, exactly as on the bench) and the
+        field tier reads it perfectly. Before the fix it arrived
+        decoded false and rendered as garbage."""
+        donor = _cell(komeco, "heat_cool/medium/off/24")
+        device, monitor, store, _timers = _wire(
+            fake_hass, komeco, donor.pronto)
+        assert store.decoded_fingerprint is None
+        connection = _conn()
+        await _arm_tangle(fake_hass, connection, device)
+
+        _press(monitor)
+        event = _events(connection)[0]
+        assert event["decoded"] is True
+        assert event["verdict"]["protocol"] == "ZHLT01"
+        assert event["verdict"]["reads_as"]["temperature"] == 25.0
+
+    @pytest.mark.asyncio
+    async def test_a_mismatched_press_is_still_decoded(self, fake_hass,
+                                                       komeco):
+        """Readable is not the same as right. A press that reads as the
+        wrong temperature came through perfectly well, and the ladder
+        depends on saying which number it heard."""
+        wrong = _cell(komeco, "heat_cool/medium/off/28")
+        device, monitor, _store, _timers = _wire(
+            fake_hass, komeco, wrong.pronto)
+        connection = _conn()
+        await _arm_tangle(fake_hass, connection, device)
+
+        _press(monitor)
+        event = _events(connection)[0]
+        assert event["decoded"] is True
+        assert event["verdict"]["matches"] is False
+
+    @pytest.mark.asyncio
+    async def test_the_general_classifier_still_counts(self, fake_hass,
+                                                       komeco):
+        """OR, not instead of. A code the classifier recognises is
+        decoded whatever the field tier makes of it."""
+        donor = _cell(komeco, "heat_cool/medium/off/24")
+        device, monitor, store, _timers = _wire(
+            fake_hass, komeco, donor.pronto)
+        store.decoded_fingerprint = "nec:0x20df:0x10ef"
+        connection = _conn()
+        await _arm_tangle(fake_hass, connection, device)
+
+        _press(monitor)
+        assert _events(connection)[0]["decoded"] is True
+
+    @pytest.mark.asyncio
+    async def test_something_neither_reader_knows_is_not_decoded(
+            self, fake_hass, komeco):
+        """The flag still means something. Widening it to "readable"
+        must not quietly widen it to "always true", or the surface
+        loses the only way it has to say a capture came through badly.
+        """
+        device, monitor, _store, _timers = _wire(
+            fake_hass, komeco,
+            "0000 006D 0004 0000 0060 0018 0018 0018 0018 0018 0018 0018")
+        connection = _conn()
+        await _arm_tangle(fake_hass, connection, device)
+
+        _press(monitor)
+        event = _events(connection)[0]
+        assert event["decoded"] is False
+        assert event["verdict"]["protocol"] is None

--- a/custom_components/hair/tests/test_tangle_receipt_tier.py
+++ b/custom_components/hair/tests/test_tangle_receipt_tier.py
@@ -1,0 +1,360 @@
+"""What a repair record is allowed to claim about the room.
+
+RULED 2026-08-28, ship-blocker. A bench run produced 48 repair records
+carrying ``tier: "air-tested"`` with zero sends behind them. Nothing
+lied on purpose: single apply DEFAULTED the tier to air-tested, and
+``tested`` is an assertion the caller makes rather than anything the
+server checks. The code did what it said. What it said overclaimed,
+against this project's own rule that the server must never pretend to
+verify a press it cannot see.
+
+The honest form, from design brief section 8: apply and apply-batch
+take ``sends_fired`` per row, the record keeps that number verbatim,
+and ``air-tested`` is written ONLY where there is send evidence behind
+it -- a positive count for that row, or membership in a batch's
+air-tested sample. Everything else a person accepts is ``accepted``,
+which claims exactly what happened: a human said yes to these bytes.
+
+The distinction is worth more than the word. ``air-tested`` is the
+strongest thing a record can say, it is what a later reader will trust
+when deciding whether to re-prove a cell, and a tier that arrives free
+with every write is worth nothing to them.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.hair.const import DOMAIN
+from custom_components.hair.matrix_store import load_matrix
+from custom_components.hair.models import (
+    CommandCategory,
+    IRCommand,
+    IRDevice,
+)
+from custom_components.hair.tangles import (
+    PROVENANCE_KEY,
+    TIER_ACCEPTED,
+    TIER_AIR_TESTED,
+    TIER_RULE_DERIVED,
+    list_tangles,
+    read_repair,
+)
+from custom_components.hair.websocket_api import (
+    ws_tangle_apply,
+    ws_tangle_apply_batch,
+    ws_tangle_plan,
+    ws_wig_make_device,
+)
+from custom_components.hair.wig_comb import (
+    CHECK_FIELD_MISMATCH,
+    comb_wig,
+    stamp_receipt,
+)
+from custom_components.hair.wig_export import build_wig_from_device
+from custom_components.hair.wig_format import (
+    Wig,
+    cell_key,
+    parse_wig,
+    serialize_wig,
+)
+from custom_components.hair.wig_store import ensure_wigs_dir, wigs_dir
+
+FIXTURES = Path(__file__).parent / "fixtures"
+KOMECO = (FIXTURES / "wigs"
+          / "komeco-airconditioner-kos-09qc-3hx-perfect-fit.wig.json")
+
+TARGET_KEY = "heat_cool/medium/off/25"
+TARGET = f"cell:{TARGET_KEY}"
+DONOR_KEY = "heat_cool/medium/off/24"
+
+
+@pytest.fixture
+def komeco() -> Wig:
+    parsed = parse_wig(KOMECO.read_text())
+    assert parsed.wig is not None, parsed.errors
+    return parsed.wig
+
+
+@pytest.fixture
+def wired(fake_hass, komeco, tmp_path):
+    matrix = komeco.climate
+    cells = {cell_key(c): c for c in matrix.cells}
+    device = IRDevice(name="Komeco", climate_matrix=True,
+                      emitter_entity_ids=["infrared.blaster"])
+    device.add_command(IRCommand(
+        name="Heat_cool 25 medium off", category=CommandCategory.CUSTOM,
+        protocol="PRONTO", code=cells[TARGET_KEY].pronto, repeat_count=0,
+        matrix_cell={"mode": "heat_cool", "fan": "medium",
+                     "swing": "off", "temp": 25.0},
+        comb_suspect=True, comb_finding=CHECK_FIELD_MISMATCH,
+    ))
+    manager = MagicMock()
+    manager.get_device = MagicMock(return_value=device)
+    manager.async_get_matrix = AsyncMock(return_value=matrix)
+    manager.async_update_device = AsyncMock()
+    fake_hass.config.config_dir = str(tmp_path)
+    fake_hass.data[DOMAIN] = {"entry-1": {
+        "device_manager": manager, "matrix_listener": MagicMock(),
+    }}
+    return fake_hass, device, matrix, cells
+
+
+def _conn():
+    connection = MagicMock()
+    connection.send_result = MagicMock()
+    connection.send_error = MagicMock()
+    return connection
+
+
+async def _apply(hass, device, pronto, **extra):
+    connection = _conn()
+    payload = {
+        "id": 1, "type": "hair/device/tangle/apply",
+        "device_id": device.id, "target": TARGET,
+        "pronto": pronto, "tested": True,
+    }
+    payload.update(extra)
+    await ws_tangle_apply(hass, connection, payload)
+    connection.send_error.assert_not_called()
+    return connection
+
+
+def _record(cells):
+    return read_repair(cells[TARGET_KEY])
+
+
+class TestASingleApplyClaimsOnlyWhatItCan:
+    @pytest.mark.asyncio
+    async def test_no_sends_is_accepted_never_air_tested(self, wired):
+        """The bench's 48 records, in one assertion. This is the exact
+        shape that produced them: a person accepted a repair and
+        pressed nothing."""
+        hass, device, _matrix, cells = wired
+        await _apply(hass, device, cells[DONOR_KEY].pronto,
+                     source="donor", sends_fired=0)
+        record = _record(cells)
+        assert record["tier"] == TIER_ACCEPTED
+        assert record["tier"] != TIER_AIR_TESTED
+        assert record["sends_fired"] == 0
+
+    @pytest.mark.asyncio
+    async def test_an_absent_field_is_also_accepted(self, wired):
+        """The regression that mattered. The old code DEFAULTED to
+        air-tested, so a caller that said nothing about sends got the
+        strongest claim in the vocabulary for free."""
+        hass, device, _matrix, cells = wired
+        await _apply(hass, device, cells[DONOR_KEY].pronto, source="donor")
+        record = _record(cells)
+        assert record["tier"] == TIER_ACCEPTED
+        assert record["sends_fired"] == 0
+
+    @pytest.mark.asyncio
+    async def test_a_press_earns_air_tested(self, wired):
+        hass, device, _matrix, cells = wired
+        await _apply(hass, device, cells[DONOR_KEY].pronto,
+                     source="donor", sends_fired=1)
+        record = _record(cells)
+        assert record["tier"] == TIER_AIR_TESTED
+        assert record["sends_fired"] == 1
+
+    @pytest.mark.asyncio
+    async def test_the_count_is_recorded_verbatim(self, wired):
+        """Not a boolean. "accepted, N sends fired" needs the N, and a
+        reader deciding whether to re-prove a cell wants to know
+        whether it was pressed once or six times."""
+        hass, device, _matrix, cells = wired
+        await _apply(hass, device, cells[DONOR_KEY].pronto,
+                     source="donor", sends_fired=6)
+        assert _record(cells)["sends_fired"] == 6
+
+    @pytest.mark.asyncio
+    async def test_tested_still_means_what_it_meant(self, wired):
+        """``tested`` is still the caller's assertion, still recorded,
+        still never verified. sends_fired does not replace it -- it is
+        the countable evidence beside it."""
+        hass, device, _matrix, cells = wired
+        await _apply(hass, device, cells[DONOR_KEY].pronto,
+                     source="donor", sends_fired=0)
+        assert _record(cells)["tested"] is True
+
+
+class TestTheBatchKeepsItsTwoTiers:
+    @pytest.fixture
+    async def adopted(self, fake_hass, tmp_path):
+        parsed = parse_wig(KOMECO.read_text())
+        wig = parsed.wig
+        stamp_receipt(wig, comb_wig(wig), "2026-08-22")
+        ensure_wigs_dir(tmp_path)
+        (wigs_dir(tmp_path) / "komeco.wig.json").write_text(
+            serialize_wig(wig), encoding="utf-8")
+        devices: list = []
+        manager = MagicMock()
+        manager.async_create_device = AsyncMock(
+            side_effect=lambda d: devices.append(d))
+        manager.async_update_device = AsyncMock()
+        manager._auto_map_command = MagicMock()
+        manager.get_device = MagicMock(
+            side_effect=lambda did: next(
+                (d for d in devices if d.id == did), None))
+        manager.async_get_matrix = AsyncMock(
+            side_effect=lambda did: load_matrix(str(tmp_path), did))
+        store = MagicMock()
+        store.get_device = manager.get_device
+        store.get_all_devices = MagicMock(side_effect=lambda: list(devices))
+        fake_hass.config.config_dir = str(tmp_path)
+        fake_hass.data[DOMAIN] = {"entry-1": {
+            "device_manager": manager, "store": store,
+            "matrix_listener": MagicMock(), "fitting_manager": None,
+        }}
+        connection = _conn()
+        await ws_wig_make_device(fake_hass, connection, {
+            "id": 1, "type": "hair/wigs/make-device",
+            "filename": "komeco.wig.json", "name": "Komeco",
+            "device_type": "ac", "emitter_entity_ids": ["infrared.blaster"],
+        })
+        return fake_hass, devices[0], tmp_path
+
+    async def _read_plan(self, hass, device):
+        """The plan alone, so a caller can decide what to fire BEFORE
+        the batch runs. A repair is one-way: the fixture hands back one
+        device, and once its donor cluster is spent there is no second
+        run to compare against."""
+        from custom_components.hair.websocket_api import ws_device_tangles
+
+        conn = _conn()
+        await ws_device_tangles(hass, conn, {
+            "id": 2, "type": "hair/device/tangles", "device_id": device.id})
+        listing = conn.send_result.call_args.args[1]
+        card = next(c for c in listing["clusters"]
+                    if c["mechanic"] == "donor")
+        conn = _conn()
+        await ws_tangle_plan(hass, conn, {
+            "id": 3, "type": "hair/device/tangle/plan",
+            "device_id": device.id, "cluster": card["id"]})
+        return card, conn.send_result.call_args.args[1]
+
+    async def _apply_plan(self, hass, device, card, plan, **extra):
+        conn = _conn()
+        payload = {
+            "id": 4, "type": "hair/device/tangle/apply-batch",
+            "device_id": device.id, "cluster": card["id"],
+            "tested": True, "tested_targets": plan["sample"],
+        }
+        payload.update(extra)
+        await ws_tangle_apply_batch(hass, conn, payload)
+        conn.send_error.assert_not_called()
+        return conn.send_result.call_args.args[1]
+
+    async def _run_batch(self, hass, device, **extra):
+        card, plan = await self._read_plan(hass, device)
+        return plan, await self._apply_plan(
+            hass, device, card, plan, **extra)
+
+    def _tiers(self, tmp_path, device):
+        matrix = load_matrix(str(tmp_path), device.id)
+        out: dict[str, int] = {}
+        for cell in matrix.cells:
+            record = read_repair(cell)
+            if record:
+                out[record["tier"]] = out.get(record["tier"], 0) + 1
+        return out
+
+    @pytest.mark.asyncio
+    async def test_the_sample_is_air_tested_and_the_rest_derived(
+            self, adopted):
+        """Unchanged by the ruling, and pinned here so the fix cannot
+        quietly flatten a run into one tier."""
+        hass, device, tmp_path = adopted
+        _plan, result = await self._run_batch(hass, device)
+        assert result["applied"] == 48
+        tiers = self._tiers(tmp_path, device)
+        assert tiers[TIER_AIR_TESTED] == len(result["air_tested"])
+        assert tiers[TIER_RULE_DERIVED] == 48 - len(result["air_tested"])
+        assert TIER_ACCEPTED not in tiers
+
+    @pytest.mark.asyncio
+    async def test_a_fired_row_earns_air_tested_on_its_own_evidence(
+            self, adopted):
+        """On TOP of the sample, not instead of it. A row the surface
+        actually fired has the same evidence the sample has."""
+        hass, device, tmp_path = adopted
+        card, plan = await self._read_plan(hass, device)
+        extra = next(m for m in plan["candidates"]
+                     if m not in plan["sample"])
+        result = await self._apply_plan(
+            hass, device, card, plan, sends_fired={extra: 2})
+
+        assert result["applied"] == 48
+        assert extra not in result["air_tested"]
+        tiers = self._tiers(tmp_path, device)
+        assert tiers[TIER_AIR_TESTED] == len(result["air_tested"]) + 1
+        assert tiers[TIER_RULE_DERIVED] == 48 - len(result["air_tested"]) - 1
+
+        matrix = load_matrix(str(tmp_path), device.id)
+        fired = next(read_repair(c) for c in matrix.cells
+                     if cell_key(c) == extra.split(":", 1)[-1])
+        assert fired["sends_fired"] == 2
+        assert fired["tier"] == TIER_AIR_TESTED
+
+    @pytest.mark.asyncio
+    async def test_every_batch_record_carries_its_count(self, adopted):
+        hass, device, tmp_path = adopted
+        await self._run_batch(hass, device)
+        matrix = load_matrix(str(tmp_path), device.id)
+        records = [read_repair(c) for c in matrix.cells if read_repair(c)]
+        assert len(records) == 48
+        assert all("sends_fired" in r for r in records)
+
+
+class TestItRidesOutInTheReceipt:
+    @pytest.mark.asyncio
+    async def test_the_field_reaches_the_exported_wig(self, wired):
+        """The wire field has to survive all the way to the file, or
+        the receipt a person reads still cannot say it."""
+        hass, device, matrix, cells = wired
+        await _apply(hass, device, cells[DONOR_KEY].pronto,
+                     source="donor", sends_fired=3)
+
+        build = build_wig_from_device(device, matrix)
+        assert build.wig is not None
+        exported = {cell_key(c): c for c in build.wig.climate.cells}
+        record = (getattr(exported[TARGET_KEY], "extra", None)
+                  or {}).get(PROVENANCE_KEY)
+        assert record["sends_fired"] == 3
+        assert record["tier"] == TIER_AIR_TESTED
+
+    @pytest.mark.asyncio
+    async def test_an_accepted_repair_says_so_in_the_file(self, wired):
+        hass, device, matrix, cells = wired
+        await _apply(hass, device, cells[DONOR_KEY].pronto, source="donor")
+
+        build = build_wig_from_device(device, matrix)
+        raw = json.loads(serialize_wig(build.wig))
+        text = json.dumps(raw)
+        assert '"tier": "accepted"' in text
+        assert '"tier": "air-tested"' not in text
+
+
+class TestTheBenchRegressionShape:
+    @pytest.mark.asyncio
+    async def test_the_forty_eight_would_not_read_air_tested_today(
+            self, wired):
+        """The record of what went wrong, as a test.
+
+        On the bench, 48 cells were repaired through single applies
+        with nothing pressed, and every record claimed air-tested. The
+        same sequence now produces accepted with a zero count, which is
+        both true and the thing a later reader needs in order to know
+        the cell is still worth proving.
+        """
+        hass, device, _matrix, cells = wired
+        listing = list_tangles(device, _matrix)
+        assert any(r.target.key == TARGET_KEY for r in listing.rows)
+
+        await _apply(hass, device, cells[DONOR_KEY].pronto, source="donor")
+        record = _record(cells)
+        assert (record["tier"], record["sends_fired"]) == (TIER_ACCEPTED, 0)

--- a/custom_components/hair/tests/test_tangles_candidates.py
+++ b/custom_components/hair/tests/test_tangles_candidates.py
@@ -252,10 +252,16 @@ class TestOverTheWire:
 class TestListeningIntoContext:
     """The same listen path, aimed at a target.
 
-    Nothing about listening changes: one capture, the R1 notice, the
-    Mirror filter, the timeout. What is added is the read-back against
-    the cell the capture was aimed at, so a surface can answer "heard
-    it: 25 degrees" or "heard 29" without a second round trip.
+    The R1 notice, the Mirror filter and the timeout are all the shared
+    path's, unchanged. What is added is the read-back against the cell
+    the capture was aimed at, so a surface can answer "heard it: 25
+    degrees" or "heard 29" without a second round trip.
+
+    This class used to open by saying one capture per arm, which was
+    true of the shared path and wrong for this caller: the mismatch
+    ladder counts misses on ONE arm, so the fix flow's window stays
+    open. See test_tangle_listen_fixes.py, which pins that and the
+    reason it was not noticed here.
     """
 
     class _Monitor:

--- a/custom_components/hair/websocket_api.py
+++ b/custom_components/hair/websocket_api.py
@@ -5378,13 +5378,29 @@ def _arm_listen(
     capture_event: str,
     timeout_event: str,
     decorate: Any = None,
+    keep_listening: bool = False,
 ) -> None:
-    """Arm the Sniffer for one capture into a Replace box.
+    """Arm the Sniffer for captures into a Replace box.
 
     A subscription, not a one-shot: the window has to be cancellable
     from the dialog (Cancel, or simply closing it), and the house
-    already listens this way for capture sessions. Emits exactly one
-    capture event or one timeout event, then stops.
+    already listens this way for capture sessions.
+
+    ONE CAPTURE OR MANY is the caller's call, and the two answers are
+    both right for their own surface. A Replace box holds one code, so
+    the command editor and the fitting row take the default: forward
+    the first capture and stop. The fix flow's LISTEN needs the
+    opposite, because its mismatch ladder counts misses on ONE arm --
+    with a single-shot window the third rung is unreachable through
+    real presses, however many times somebody presses. Those callers
+    pass ``keep_listening`` and the window stays open: every capture
+    forwards, and teardown waits for the client to unsubscribe or for
+    the timeout.
+
+    The timeout is a silence window, not a total budget, so it is
+    restarted after each forwarded capture. A ladder that dropped its
+    listener mid-climb because the person took a moment between presses
+    would fail in exactly the way this argument exists to prevent.
 
     It rides ``signal_monitor``'s existing subscriber feed rather than
     opening a second capture path. That feed also carries MIRROR rows,
@@ -5441,7 +5457,18 @@ def _arm_listen(
             # window with nothing in it.
             return
         heard = getattr(signal, "heard_by", None) or []
-        _finish()
+        if keep_listening:
+            # Stay armed, and give the next press a fresh silence
+            # window. Teardown is the client's job now, or the
+            # timeout's.
+            timer = state.get("timer")
+            if timer is not None:
+                timer.cancel()
+            state["timer"] = hass.loop.call_later(
+                FITTING_LISTEN_TIMEOUT_S, _on_timeout
+            )
+        else:
+            _finish()
         # Repeats of one press should be identical, and the moment to say
         # otherwise is now, while the remote is still in somebody's hand
         # and pressing the button again costs nothing (fitting integrity
@@ -7292,13 +7319,22 @@ async def ws_tangle_listen(
     connection: websocket_api.ActiveConnection,
     msg: dict[str, Any],
 ) -> None:
-    """Arm the Sniffer for one capture aimed at a target.
+    """Arm the Sniffer for captures aimed at a target.
 
     Rides the same listen path the command editor uses, so a capture
     arrives here exactly as it arrives there, R1 capture notice and
     all. What this adds is CONTEXT: the capture is pre-read against the
     target's own label before the event leaves, so the surface can say
     what it heard in the device's own words without a second round trip.
+
+    CAPTURES, PLURAL. This arm stays open (``keep_listening``) because
+    the LISTEN ladder counts mismatches on one arm: hear 18 when 19 was
+    asked for, say so, hear it again, say so again, and on the third
+    offer USE IT ANYWAY -- the rung that admits our READING may be at
+    fault rather than the remote. A single-shot window made that third
+    rung unreachable no matter how many times somebody pressed, because
+    the second press had nobody listening for it. Found on the bench
+    with real hardware.
     """
     device, matrix = await _device_and_matrix(hass, msg["device_id"])
     if device is None:
@@ -7325,15 +7361,25 @@ async def ws_tangle_listen(
     lattice, coordinates = prepared
 
     def _decorate(payload: dict[str, Any]) -> None:
-        payload["verdict"] = pre_read(
-            lattice, payload["pronto"], coordinates
-        ).as_dict()
+        verdict = pre_read(lattice, payload["pronto"], coordinates)
+        payload["verdict"] = verdict.as_dict()
+        # DECODED MEANS READABLE, and this is the only place that knows
+        # the second way to read something. The generic flag underneath
+        # is the general protocol classifier, which does not recognise
+        # AC protocols at all -- so a byte-perfect ZHLT01 press arrived
+        # decoded false and the surface, obeying the flag, called it
+        # garbled while the very same event carried a clean field-tier
+        # reading of it. Widened here rather than in _arm_listen
+        # because the field tier is this caller's knowledge: the
+        # command editor and the fitting row have no lattice to read
+        # against and their flag is right as it stands.
+        payload["decoded"] = bool(payload.get("decoded")) or verdict.readable
         if msg.get("target"):
             payload["target"] = msg["target"]
 
     _arm_listen(
         hass, connection, msg, "tangle_capture", "tangle_listen_timeout",
-        decorate=_decorate,
+        decorate=_decorate, keep_listening=True,
     )
 
 

--- a/custom_components/hair/websocket_api.py
+++ b/custom_components/hair/websocket_api.py
@@ -7510,6 +7510,11 @@ async def _write_matrix_and_signal(
     vol.Required("target"): str,
     vol.Required("pronto"): vol.All(str, vol.Length(max=20000)),
     vol.Required("tested"): bool,
+    #: How many times the surface actually fired this row's code. The
+    #: evidence behind an air-tested tier, and zero is a perfectly
+    #: normal answer: accepting a repair without pressing anything is
+    #: allowed, it just does not get to claim the room.
+    vol.Optional("sends_fired"): vol.All(int, vol.Range(min=0)),
     vol.Optional("source"): str,
     vol.Optional("detail"): dict,
     vol.Optional("reading_disagreed"): bool,
@@ -7601,6 +7606,11 @@ async def ws_tangle_apply(
         lattice=lattice,
         row=row,
         tested=True,
+        # No tier argument: it derives from the send evidence. This
+        # call used to take the default, which was air-tested, so
+        # every single apply claimed the room whether or not anybody
+        # had pressed anything (ruled a ship-blocker 2026-08-28).
+        sends_fired=msg.get("sends_fired", 0),
         detail=msg.get("detail"),
         disagreed=verdict.as_dict() if declared else None,
     )
@@ -7769,6 +7779,10 @@ async def ws_tangle_plan(
     vol.Required("cluster"): str,
     vol.Required("tested"): bool,
     vol.Required("tested_targets"): [str],
+    #: Per-row send tallies, keyed by target id. A row the surface
+    #: actually fired is air-tested on its own evidence, on top of the
+    #: sample the run pressed at.
+    vol.Optional("sends_fired"): {str: vol.All(int, vol.Range(min=0))},
     vol.Optional("witness"): vol.All(str, vol.Length(max=20000)),
     vol.Optional("witness_target"): str,
     vol.Optional("candidates"): dict,
@@ -7871,6 +7885,10 @@ async def ws_tangle_apply_batch(
         return
 
     run = uuid.uuid4().hex
+    fired: dict[str, int] = {
+        key: max(0, int(value or 0))
+        for key, value in (msg.get("sends_fired") or {}).items()
+    }
     cells = {_cell_key(c): c for c in (matrix.cells if matrix else [])}
     snapshot: list[tuple[Any, str, dict[str, Any]]] = []
     writes: list[tuple[Any, str, dict[str, Any]]] = []
@@ -7883,7 +7901,12 @@ async def ws_tangle_apply_batch(
             lattice=lattice,
             row=row,
             tested=True,
-            tier=(TIER_AIR_TESTED if member in tested_targets
+            sends_fired=fired.get(member, 0),
+            # The batch keeps its two tiers. What changes is that a row
+            # the surface actually fired earns air-tested on its own
+            # evidence too, instead of only by being in the sample.
+            tier=(TIER_AIR_TESTED
+                  if member in tested_targets or fired.get(member, 0)
                   else TIER_RULE_DERIVED),
             run=run,
             tested_keys=[rows[t].target.key for t in tested_targets],


### PR DESCRIPTION
Two listen fixes and one receipt fix, all three found on the bench with real hardware.

The listen arm was single-shot: one capture per arm, so the mismatch ladder could never reach its third rung. The arm now stays open for the tangle flow (opt-in, so the command editor and fitting row are unchanged), forwarding every capture until the client unsubscribes or the silence window expires.

The event's decoded flag meant only the general protocol classifier, which never recognises map-read AC protocols, so a byte-perfect press rendered as garbled. Decoded now means readable: the general classifier or a clean field-tier read.

Repair receipts no longer claim air-tested by default. Apply payloads carry sends_fired per row, provenance records the count verbatim, and air-tested is granted only where send evidence stands behind it; the honest tier for a human yes with no sends is accepted. Verified end to end on the bench: real air captures flipping to capturable, the ladder reached through real transmissions, and both receipt shapes read back from the exported file.
