### PR TITLE
CI: cache pip downloads between runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
         run: |
@@ -37,6 +39,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Adds pip download caching to the test and lint jobs, keyed on pyproject.toml. Cuts the dependency install minutes from every CI run after the first; the cache invalidates itself whenever pyproject.toml changes. No test or code changes.