### PR TITLE
Detangler round one: the backend batch

### DIFF
--- a/custom_components/hair/field_readers.py
+++ b/custom_components/hair/field_readers.py
@@ -197,6 +197,35 @@ class FieldMap:
                 return spec
         return None
 
+    @property
+    def repeats_identically(self) -> bool:
+        """Does this map declare its frames to be one payload, repeated?
+
+        DECLARED, never inferred. The evidence is the map's own two
+        statements: a layout whose frames are all the same width, and a
+        ratified ``frame_repeat`` rule saying every other frame equals
+        the payload one. A family that merely happens to send two frames
+        of equal width says nothing here, and TCL112 is why that matters
+        -- it carries [112, 112] with the payload in the SECOND frame
+        and no repeat rule at all, so its two frames are two different
+        things and one of them alone is not the code.
+
+        This is the whole licence behind the short-capture branch in
+        ``read_code``. Without it a lone frame is an unidentifiable
+        fragment; with it, the map has already said that a single clean
+        frame carries everything the family transmits.
+        """
+        if len(self.frame_layout) < 2 or len(set(self.frame_layout)) != 1:
+            return False
+        others = set(range(len(self.frame_layout))) - {self.payload_frame}
+        declared = {
+            int(rule.params.get("frame", -1) or -1)
+            for rule in self.integrity
+            if rule.type == RULE_FRAME_REPEAT and rule.ratified
+            and int(rule.params.get("equals", 0) or 0) == self.payload_frame
+        }
+        return bool(others) and others <= declared
+
 
 @dataclass(frozen=True)
 class Reading:
@@ -563,6 +592,56 @@ def _matches_identity(
     return True
 
 
+def _matches_repeat(field_map: FieldMap, frames: list[list[int]]) -> bool:
+    """A capture carrying fewer frames than the map declares.
+
+    Only for a map that declares identical repeats, and only when the
+    frames present are the declared width and the payload index is one
+    of them. Every other short capture stays unidentified: losing a
+    frame that carries something of its own loses the code.
+    """
+    declared = len(field_map.frame_layout)
+    if not field_map.repeats_identically:
+        return False
+    if not frames or len(frames) >= declared:
+        return False
+    if field_map.payload_frame >= len(frames):
+        return False
+    width = field_map.frame_layout[0]
+    return all(
+        abs(len(frame) - width) <= field_map.bits_tolerance
+        for frame in frames
+    )
+
+
+def _payload_holds(
+    field_map: FieldMap, decoded: list[tuple[int, ...]]
+) -> bool:
+    """Does what is here satisfy every ratified rule that can judge it?
+
+    The doubled shape IS evidence, and a short capture spends it: the
+    repeat rule cannot be evaluated on frames that did not arrive. So
+    identification asks the frame that DID arrive to hold together on
+    the map's own terms instead, and a family with nothing left to
+    check with keeps its full-layout requirement. A rule that cannot be
+    evaluated is not a pass here any more than it is anywhere else.
+    """
+    reading = Reading(
+        protocol_id=field_map.protocol_id, frames=tuple(decoded)
+    )
+    judged = False
+    for rule in field_map.integrity:
+        if not rule.ratified:
+            continue
+        holds = check_integrity(reading, rule)
+        if holds is None:
+            continue
+        if not holds:
+            return False
+        judged = True
+    return judged
+
+
 def read_code(
     pronto: str, maps: list[FieldMap] | None = None,
     prefer: str | None = None,
@@ -572,6 +651,11 @@ def read_code(
     ``prefer`` names the protocol to try first, which is what makes a
     1,156-cell sweep cheap: a lattice is one family, so the map that
     read the last cell reads the next one.
+
+    TWO PASSES, and the order is the point. A code matching a map's
+    declared layout outright wins over any short-capture reading of any
+    map, so relaxing the layout for repeat families can never take a
+    code away from the family that transmits it whole.
     """
     candidates = maps if maps is not None else library()
     if not candidates:
@@ -583,17 +667,44 @@ def read_code(
     if prefer:
         ordered = sorted(candidates, key=lambda m: m.protocol_id != prefer)
     unreadable = False
+    split: list[tuple[FieldMap, list[list[int]]]] = []
     for field_map in ordered:
         frames, failed = read_frames(field_map.timing, timings)
         if failed:
             unreadable = True
             continue
+        split.append((field_map, frames))
         if not _matches_layout(field_map, frames):
             continue
         decoded = [
             bits_to_bytes(frame, field_map.bit_order) for frame in frames
         ]
         if not _matches_identity(field_map, decoded):
+            continue
+        return Reading(
+            protocol_id=field_map.protocol_id,
+            frames=tuple(decoded),
+        )
+
+    # THE HALF PRESS. A receiver hands back what it heard between two
+    # gaps, so a family that transmits its frame twice arrives as two
+    # capture events of one frame each, and neither of them matches a
+    # layout that wants both. Every one of those reads as garbled today
+    # -- the whole of issue 9, and the reason a MITSUBISHI144 column
+    # cannot be recaptured from the remote at all. A map that declares
+    # its frames identical has already said the payload survives on its
+    # own, so the frame that arrived is read on those terms, with the
+    # identity bytes and the map's own integrity standing in for the
+    # shape that did not arrive.
+    for field_map, frames in split:
+        if not _matches_repeat(field_map, frames):
+            continue
+        decoded = [
+            bits_to_bytes(frame, field_map.bit_order) for frame in frames
+        ]
+        if not _matches_identity(field_map, decoded):
+            continue
+        if not _payload_holds(field_map, decoded):
             continue
         return Reading(
             protocol_id=field_map.protocol_id,

--- a/custom_components/hair/tangles.py
+++ b/custom_components/hair/tangles.py
@@ -1007,6 +1007,81 @@ def build_attestation(
     return record
 
 
+#: Written into an attestation's note when the ladder wrote it rather
+#: than the keep button. The two are the same answer arrived at down
+#: different roads, and a later reader deserves to know which: a KEEP
+#: says "these bytes are right and the finding is wrong about them",
+#: while this says "I heard the disputed value with my own remote and I
+#: am keeping it anyway". Same standing, different story.
+ATTEST_LADDER_OVERRIDE = "ladder-override"
+
+
+def written_digest(
+    device: IRDevice, matrix: ClimateMatrix | None, row: TangleRow
+) -> str | None:
+    """The digest the NEXT listing will compute for this row.
+
+    A row's digest is about the bytes it carries, so a write moves it,
+    and an answer keyed to the bytes that were just REPLACED expires the
+    instant it is recorded. This reads the row's target back out of the
+    device, after the write, through the same recipe the listing uses,
+    which is the only way the two can be relied on to agree.
+    """
+    if row.target.kind == TARGET_CELL:
+        if matrix is None:
+            return None
+        if row.target.key in ("off", "on"):
+            pronto = matrix.off if row.target.key == "off" else matrix.on
+            return None if not pronto else _cell_digest(pronto)
+        cell = next(
+            (c for c in matrix.cells if cell_key(c) == row.target.key), None
+        )
+        return None if cell is None else _cell_digest(cell.pronto)
+    wig, _sources = project_device(device, matrix)
+    if wig is None:
+        return None
+    signal = next(
+        (s for s in wig.signals if s.alias == row.target.key), None
+    )
+    if signal is None:
+        return None
+    return row_digest(
+        signal.pronto, signal.ditto_count, signal.bypass_protocol
+    )
+
+
+def attest_override(
+    device: IRDevice, matrix: ClimateMatrix | None,
+    row: TangleRow, lattice: LatticeReading,
+) -> dict[str, Any] | None:
+    """The standing answer a USE IT ANYWAY leaves behind (issue 8).
+
+    The ladder's third rung admits our READING may be at fault, and a
+    person who presses it has done the one thing the server cannot: they
+    aimed the remote and heard what the unit answers to. Before this,
+    that answer was written into the bytes and nowhere else, so the next
+    listing re-derived the same finding from the same map and asked the
+    same question again -- and the pulled command beside it read
+    REPAIRED, so the two surfaces disagreed about a row the person had
+    already settled.
+
+    Recording it as an attestation is the shipped mechanism for exactly
+    this, expiry included: the key binds the answer to the bytes now on
+    the device and to the map version that doubted them, so the moment
+    either moves the finding is open again on its own.
+
+    Returns None when the target cannot be read back, in which case
+    nothing is recorded: an attestation keyed to a guess would be worse
+    than the nagging.
+    """
+    digest = written_digest(device, matrix, row)
+    if digest is None:
+        return None
+    return build_attestation(
+        replace(row, digest=digest), lattice, note=ATTEST_LADDER_OVERRIDE
+    )
+
+
 def standing_attestation(
     device: IRDevice, row: TangleRow, lattice: LatticeReading
 ) -> dict[str, Any] | None:

--- a/custom_components/hair/tangles.py
+++ b/custom_components/hair/tangles.py
@@ -40,6 +40,7 @@ from . import field_readers
 from .models import IRCommand, IRDevice
 from .wig_comb import (
     ADVISORY_CHECKS,
+    CHECK_DUPLICATE_LABELS,
     CHECK_DUPLICATED_NEIGHBOUR,
     CHECK_FIELD_MISMATCH,
     FIELD_COORDINATE,
@@ -234,6 +235,29 @@ def _findings_by_key(report: Any) -> dict[str, list[Finding]]:
     return grouped
 
 
+def _promoted_pairs(report: Any) -> list[Finding]:
+    """Duplicate-label findings that DECIDE can actually act on.
+
+    B3, issue 5, owner ruled 2026-08-29. `duplicate-labels` is advisory
+    and stays advisory: a flat file has no lattice to prove intent, and
+    same-code-different-label is genuinely right on a toggle remote
+    where one button says Power On and Power Off. Nothing here changes
+    the suspect count or the closet's comb chip.
+
+    What changes is that a pair reaches the surface that can answer it.
+    DECIDE's rename-or-delete UI is built for exactly two rows carrying
+    the same bytes, and a pair is the one shape of this finding where
+    the question has a small, obvious set of answers: which of these two
+    names is the liar. Three or more is a mess a person should look at
+    rather than a question a card can ask, so those stay advisory only.
+    """
+    return [
+        finding for finding in report.findings
+        if finding.check == CHECK_DUPLICATE_LABELS
+        and len(finding.keys) == 2 and len(set(finding.keys)) == 2
+    ]
+
+
 def _cell_digest(pronto: str) -> str:
     """A cell's current-bytes digest.
 
@@ -256,6 +280,10 @@ def list_tangles(
 
     report = comb_wig(wig)
     grouped = _findings_by_key(report)
+    promoted = _promoted_pairs(report)
+    for finding in promoted:
+        for key in finding.keys:
+            grouped.setdefault(key, []).append(finding)
     coverage = report.coverage.to_dict() if report.coverage else None
     listing.coverage = coverage
     protocol = None
@@ -274,9 +302,10 @@ def list_tangles(
 
     rows: list[TangleRow] = []
     lattice = read_lattice(matrix, wig)
+    lifted = {id(finding) for finding in promoted}
     listing.advisories = [
         finding.to_dict() for finding in report.findings
-        if finding.check in ADVISORY_CHECKS
+        if finding.check in ADVISORY_CHECKS and id(finding) not in lifted
     ]
     if matrix is not None:
         portholes = {
@@ -1973,6 +2002,24 @@ def _cause_of(
         if name is not None:
             return CLUSTER_FIELD, (CLUSTER_FIELD, name), name, {
                 "field": name}
+
+    # Two names over one payload cluster the same way a duplicated
+    # neighbour does, and for the same reason: the card is about the
+    # GROUP, and its job is to list every place the bytes turn up. The
+    # lattice road reaches this through the comb's matrix check and a
+    # flat file reaches it through duplicate labels (B3), but what a
+    # person is looking at on the card is identical either way.
+    if leading == CHECK_DUPLICATE_LABELS:
+        # Keyed on the PAYLOAD rather than on the row digest, because
+        # that is what the comb grouped these two by. Two names over one
+        # code can still carry different ditto counts, and a card that
+        # split on those would ask the same question twice and answer
+        # neither: the question is which name is the liar, and the
+        # dittos have no opinion about that.
+        payload = _cell_digest(row.pronto)
+        return CLUSTER_IDENTICAL, (
+            CLUSTER_IDENTICAL, payload,
+        ), None, {"digest": payload}
 
     if leading == CHECK_DUPLICATED_NEIGHBOUR:
         return CLUSTER_IDENTICAL, (

--- a/custom_components/hair/tests/test_repeat_frame_capture.py
+++ b/custom_components/hair/tests/test_repeat_frame_capture.py
@@ -1,0 +1,344 @@
+"""Identifying a two-frame family from the one frame that arrived.
+
+Issue 9 of the detangler round, proven live on the Daikin 1103 file
+2026-08-29 and reproduced here from the fixture's own bytes. A
+MITSUBISHI144 press transmits 144 bits twice with a gap between them,
+the receiver hands back what it heard between gaps, and so one press
+arrives as two capture events of one frame each. Identification wanted
+both frames, so every half read as unidentified and the surface called
+a perfectly clean press garbled. A whole column of that file cannot be
+recaptured from the remote until this changes.
+
+The fix is reader-side and nothing else. Capture stitching would add
+latency to every capture on the shared monitor path to serve two
+families out of twelve; the maps already carry the fact that makes
+stitching unnecessary, which is that their frames are declared
+IDENTICAL. A map that says so has said the payload survives on its
+own.
+
+What replaces the missing evidence is the point of the tests below. The
+doubled shape was evidence, and a half press spends it, so the frame
+that did arrive has to hold together on the map's own terms instead:
+identity bytes, and every ratified integrity rule that can still be
+judged. A corrupted half stays unidentified, which is the difference
+between reading less and believing more.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from custom_components.hair import field_readers as fr
+from custom_components.hair.tangles import pre_read, read_lattice
+from custom_components.hair.wig_adapters import _broadlink_b64_to_pronto
+from custom_components.hair.wig_format import ClimateCell, ClimateMatrix, Wig
+
+PACKS = Path(__file__).parent / "fixtures" / "field-packs"
+
+
+def _map(protocol_id: str) -> fr.FieldMap:
+    for candidate in fr.load_maps():
+        if candidate.protocol_id == protocol_id:
+            return candidate
+    raise AssertionError(f"{protocol_id} is not vendored")
+
+
+def _first_code(pack: str) -> str:
+    """The first code in a synthesized field pack, as Pronto."""
+    raw = json.loads((PACKS / pack).read_text())
+
+    def walk(node: object) -> str | None:
+        if isinstance(node, str):
+            return node
+        if isinstance(node, dict):
+            for value in node.values():
+                found = walk(value)
+                if found:
+                    return found
+        return None
+
+    encoded = walk(raw["commands"])
+    assert encoded, f"{pack} carries no codes"
+    pronto = _broadlink_b64_to_pronto(encoded)
+    assert pronto, f"{pack} did not convert"
+    return pronto
+
+
+def _words(pronto: str) -> list[int]:
+    return [int(word, 16) for word in pronto.split()]
+
+
+def _rebuild(head: list[int], body: list[int]) -> str:
+    words = list(head) + list(body)
+    words[2] = len(body) // 2
+    words[3] = 0
+    return " ".join(f"{word:04X}" for word in words)
+
+
+def _halves(pronto: str, field_map: fr.FieldMap) -> tuple[str, str]:
+    """One press, cut at the gap the receiver itself cuts at."""
+    words = _words(pronto)
+    head, body = words[:4], words[4:]
+    unit = words[1] * 0.241246
+    boundary = None
+    for index in range(0, len(body) - 1, 2):
+        if body[index + 1] * unit >= field_map.timing.gap_min:
+            boundary = index + 2
+            break
+    assert boundary is not None, "the fixture code carries no frame gap"
+    return _rebuild(head, body[:boundary]), _rebuild(head, body[boundary:])
+
+
+def _flip(pronto: str, field_map: fr.FieldMap, bit: int) -> str:
+    """One data bit of frame 0, rewritten to the other symbol.
+
+    Through the map's own positions, so the flip lands on the pulse
+    that actually carries the bit rather than on a word counted by
+    hand.
+    """
+    timings = fr.pronto_microseconds(pronto)
+    assert timings is not None
+    _frames, places, failed = fr.read_frames_positioned(
+        field_map.timing, timings
+    )
+    assert not failed
+    pair = places[0][bit]
+    words = _words(pronto)
+    body = words[4:]
+    unit = words[1] * 0.241246
+    space = body[pair * 2 + 1] * unit
+    other = (
+        field_map.timing.one.nominal
+        if field_map.timing.zero.holds(space)
+        else field_map.timing.zero.nominal
+    )
+    body[pair * 2 + 1] = max(1, round(other / unit))
+    return _rebuild(words[:4], body)
+
+
+def _pack_matrix(pack: str) -> tuple[Wig, ClimateMatrix]:
+    """A one-family lattice from a pack, enough to read against."""
+    raw = json.loads((PACKS / pack).read_text())
+    cells: list[ClimateCell] = []
+    for mode, by_fan in raw["commands"].items():
+        if not isinstance(by_fan, dict):
+            continue
+        for fan, by_swing in by_fan.items():
+            if not isinstance(by_swing, dict):
+                continue
+            for swing, by_temp in by_swing.items():
+                if not isinstance(by_temp, dict):
+                    continue
+                for temp, code in by_temp.items():
+                    if not isinstance(code, str):
+                        continue
+                    cells.append(ClimateCell(
+                        mode=mode, fan=fan, swing=swing, temp=float(temp),
+                        pronto=_broadlink_b64_to_pronto(code) or "",
+                    ))
+    temps = [cell.temp for cell in cells if cell.temp is not None]
+    matrix = ClimateMatrix(
+        min_temp=min(temps), max_temp=max(temps),
+        off=cells[0].pronto, cells=cells,
+        modes=sorted({cell.mode for cell in cells if cell.mode}),
+        fan_modes=sorted({cell.fan for cell in cells if cell.fan}),
+        swing_modes=sorted({cell.swing for cell in cells if cell.swing}),
+    )
+    return Wig(name="Pack", signals=[], climate=matrix), matrix
+
+
+@pytest.fixture
+def mitsubishi() -> fr.FieldMap:
+    return _map("MITSUBISHI144")
+
+
+@pytest.fixture
+def full(mitsubishi: fr.FieldMap) -> str:
+    return _first_code("MITSUBISHI144.json")
+
+
+class TestTheHalfPressIdentifies:
+    def test_the_full_code_still_identifies(self, full, mitsubishi):
+        """First, because the relaxation must cost nothing. A code that
+        arrives whole is read by the layout branch exactly as before."""
+        reading = fr.read_code(full, [mitsubishi])
+        assert reading.protocol_id == "MITSUBISHI144"
+        assert len(reading.frames) == 2
+
+    def test_each_half_identifies_on_its_own(self, full, mitsubishi):
+        """The defect, cured. Before this branch both halves came back
+        unidentified and the fix flow said garbled."""
+        for half in _halves(full, mitsubishi):
+            reading = fr.read_code(half, [mitsubishi])
+            assert reading.protocol_id == "MITSUBISHI144"
+            assert reading.declined is None
+            assert len(reading.frames) == 1
+
+    def test_a_half_reads_the_same_fields_as_the_whole(
+            self, full, mitsubishi):
+        """Identification is worth nothing on its own. The half has to
+        say the same thing the press said, field for field."""
+        whole = fr.read_code(full, [mitsubishi])
+        half = fr.read_code(_halves(full, mitsubishi)[0], [mitsubishi])
+        read = {
+            spec.name: (
+                fr.read_field(whole, spec), fr.read_field(half, spec),
+            )
+            for spec in mitsubishi.fields if spec.ratified
+        }
+        assert read, "the map states no ratified fields"
+        for name, (from_whole, from_half) in read.items():
+            assert from_whole == from_half, name
+
+    def test_the_second_half_reads_it_too(self, full, mitsubishi):
+        """Both capture events are the same press. Whichever one the
+        surface happens to hand over has to answer the same way, or the
+        repair depends on which half the receiver reported first."""
+        first, second = _halves(full, mitsubishi)
+        spec = mitsubishi.field_named("temperature")
+        assert spec is not None
+        from_first = fr.read_field(fr.read_code(first, [mitsubishi]), spec)
+        from_second = fr.read_field(fr.read_code(second, [mitsubishi]), spec)
+        assert from_first is not None
+        assert from_first == from_second
+
+
+class TestIntegrityStillBinds:
+    def test_a_corrupted_half_is_refused(self, full, mitsubishi):
+        """The compensating control, and the reason this is safe.
+
+        A half press has no repeat to check itself against, so the
+        map's checksum stands in for the shape that did not arrive. Flip
+        one data bit and the frame no longer adds up, so it is not this
+        family's code and identification says so.
+        """
+        half = _halves(full, mitsubishi)[0]
+        bent = _flip(half, mitsubishi, 56)
+        assert fr.read_code(half, [mitsubishi]).protocol_id == "MITSUBISHI144"
+        reading = fr.read_code(bent, [mitsubishi])
+        assert reading.protocol_id is None
+        assert reading.declined is not None
+
+    def test_the_identity_bytes_still_gate_it(self, full, mitsubishi):
+        """A frame of the right width that is not this family stays
+        unidentified, same as it ever was."""
+        half = _halves(full, mitsubishi)[0]
+        bent = _flip(half, mitsubishi, 2)      # inside identity byte 0
+        assert fr.read_code(bent, [mitsubishi]).protocol_id is None
+
+    def test_the_repeat_rule_reads_as_unevaluated_not_passed(
+            self, full, mitsubishi):
+        """A rule that cannot be judged is never a pass, and a half
+        press is exactly the case that tempts a shortcut."""
+        reading = fr.read_code(_halves(full, mitsubishi)[0], [mitsubishi])
+        assert reading.protocol_id == "MITSUBISHI144"
+        rule = next(
+            r for r in mitsubishi.integrity
+            if r.type == fr.RULE_FRAME_REPEAT
+        )
+        assert fr.check_integrity(reading, rule) is None
+
+    def test_the_whole_code_is_not_held_to_the_new_standard(
+            self, full, mitsubishi):
+        """Deliberate asymmetry, stated so nobody 'fixes' it.
+
+        A code that matches the declared layout identifies on its shape,
+        as it always has, and a checksum failure on it surfaces as a
+        comb finding about a code we know the family of. Only the short
+        branch, which has spent the shape, has to buy identification
+        with integrity.
+        """
+        bent = _flip(full, mitsubishi, 56)
+        assert fr.read_code(bent, [mitsubishi]).protocol_id == "MITSUBISHI144"
+
+
+class TestOnlyWhereTheMapSaysSo:
+    def test_a_single_frame_family_is_untouched(self):
+        """ZHLT01 declares one frame. There is no short capture of a
+        one-frame code, and nothing about it changes."""
+        code = _first_code("ZHLT01.json")
+        zhlt = _map("ZHLT01")
+        assert zhlt.repeats_identically is False
+        reading = fr.read_code(code, [zhlt])
+        assert reading.protocol_id == "ZHLT01"
+        assert len(reading.frames) == 1
+
+    def test_two_frames_are_not_enough_to_qualify(self):
+        """TCL112 sends [112, 112] and carries its payload in the
+        SECOND frame, with no repeat rule anywhere. Its two frames are
+        two different things, so one of them is not the code and this
+        branch must not touch it."""
+        tcl = _map("TCL112")
+        assert tcl.repeats_identically is False
+        code = _first_code("TCL112.json")
+        for half in _halves(code, tcl):
+            assert fr.read_code(half, [tcl]).protocol_id is None
+
+    def test_the_declaring_maps_are_the_two_that_declare_it(self):
+        """The licence comes from the map and from nowhere else, so
+        which maps hold it is a fact worth pinning: adding a third is a
+        map change somebody reviewed."""
+        holders = {
+            candidate.protocol_id for candidate in fr.load_maps()
+            if candidate.repeats_identically
+        }
+        assert holders == {"MITSUBISHI144", "MIDEA_COOLIX"}
+
+    def test_a_whole_code_outranks_any_half_reading(self, full, mitsubishi):
+        """Two passes, in order. The full library is offered the code
+        first and the layout branch answers, so no short reading can
+        take a code away from the family that transmits it whole."""
+        reading = fr.read_code(full)
+        assert reading.protocol_id == "MITSUBISHI144"
+        assert len(reading.frames) == 2
+
+
+class TestTheSurfaceStopsSayingGarbled:
+    """What the fix is FOR, one layer up.
+
+    The listen ladder judges a capture through ``pre_read``. Before
+    this, a half press reached it unidentified, so the row could only
+    offer USE IT ANYWAY on a code that was never in doubt.
+    """
+
+    def test_a_half_press_reads_against_its_own_cell(self, mitsubishi):
+        wig, matrix = _pack_matrix("MITSUBISHI144.json")
+        lattice = read_lattice(matrix, wig)
+        assert lattice.readable
+        cell = matrix.cells[0]
+        coordinates = {
+            "mode": cell.mode, "fan": cell.fan,
+            "swing": cell.swing, "temp": cell.temp,
+        }
+        half = _halves(cell.pronto, mitsubishi)[0]
+        verdict = pre_read(lattice, half, coordinates)
+        assert verdict.readable
+        assert verdict.protocol == "MITSUBISHI144"
+        assert verdict.matches is True
+        assert verdict.mismatches == []
+
+    def test_and_a_half_press_of_the_wrong_cell_still_disagrees(
+            self, mitsubishi):
+        """Readable is not agreeable. The ladder still has something to
+        say when the press is not the one the row asked for."""
+        wig, matrix = _pack_matrix("MITSUBISHI144.json")
+        lattice = read_lattice(matrix, wig)
+        column = sorted(
+            (c for c in matrix.cells
+             if (c.mode, c.fan, c.swing)
+             == (matrix.cells[0].mode, matrix.cells[0].fan,
+                 matrix.cells[0].swing)),
+            key=lambda c: c.temp or 0,
+        )
+        target, other = column[0], column[-1]
+        assert target.temp != other.temp
+        verdict = pre_read(
+            lattice, _halves(other.pronto, mitsubishi)[0],
+            {"mode": target.mode, "fan": target.fan,
+             "swing": target.swing, "temp": target.temp},
+        )
+        assert verdict.readable
+        assert verdict.matches is False
+        assert "temperature" in verdict.mismatches

--- a/custom_components/hair/tests/test_tangle_decide_pairs.py
+++ b/custom_components/hair/tests/test_tangle_decide_pairs.py
@@ -1,0 +1,217 @@
+"""Two names, one code, and a card that can ask about it.
+
+Issue 5 of the detangler round. The practice-dupe wig was built to
+surface a DECIDE pair -- "Speed Down" carrying "Power"'s code -- and the
+device showed one LISTEN row and no DECIDE card at all. The comb had
+found it and called it `duplicate-labels`, which is ADVISORY, and
+advisories never became rows. DECIDE's only feed was a two-member
+`identical-bytes` cluster, which only the matrix-lattice check could
+produce, so on a flat wig DECIDE could not populate in any build.
+
+Owner ruled 2026-08-29: promote the pair, and only the pair.
+
+The classification does not move. `duplicate-labels` stays advisory,
+stays out of the suspect count, and the closet's comb chip reads
+exactly as before -- a flat file has no lattice to prove intent, and
+same-code-different-label is right on a toggle remote. What changes is
+that the ONE shape of it with a small obvious answer reaches the
+surface built to ask: two names over one payload, rename or delete.
+Three or more stays a mess for a person to look at rather than a
+question a card can ask.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from custom_components.hair.models import (
+    CommandCategory,
+    IRCommand,
+    IRDevice,
+)
+from custom_components.hair.tangles import CLUSTER_IDENTICAL, list_tangles
+from custom_components.hair.wig_comb import (
+    CHECK_DUPLICATE_LABELS,
+    CHECK_FRAME_DISAGREEMENT,
+    comb_wig,
+    stamp_receipt,
+    suspect_findings,
+)
+from custom_components.hair.wig_format import Wig, parse_wig
+
+FIXTURES = Path(__file__).parent / "fixtures"
+DREO = (FIXTURES / "wigs" / "dreo-fan-dr-haf004s-perfect-fit.wig.json")
+
+POWER = "Power"
+DUPE = "Speed Down"
+#: The Dreo's own frame-disagreement row, inherited from the real
+#: capture and nothing to do with the pair. This is the LISTEN row the
+#: owner saw where he expected a DECIDE card.
+LISTENER = "Oscillate Horizontal"
+
+
+@pytest.fixture
+def dreo() -> Wig:
+    parsed = parse_wig(DREO.read_text())
+    assert parsed.wig is not None, parsed.errors
+    return parsed.wig
+
+
+def _device(wig: Wig, copies: dict[str, str]) -> IRDevice:
+    """The wig as a flat device, with `copies` aliases sharing a code."""
+    by_alias = {signal.alias: signal for signal in wig.signals}
+    device = IRDevice(
+        name="Practice Fan", emitter_entity_ids=["infrared.blaster"]
+    )
+    for signal in wig.signals:
+        source = copies.get(signal.alias)
+        device.add_command(IRCommand(
+            name=signal.alias, category=CommandCategory.CUSTOM,
+            protocol="PRONTO",
+            code=by_alias[source].pronto if source else signal.pronto,
+            repeat_count=signal.ditto_count,
+            tx_force_raw=signal.bypass_protocol,
+        ))
+    return device
+
+
+def _flat_wig(wig: Wig, copies: dict[str, str]) -> Wig:
+    """The same shape as a wig, for combing on its own."""
+    from dataclasses import replace
+
+    by_alias = {signal.alias: signal for signal in wig.signals}
+    return replace(wig, signals=[
+        replace(signal, pronto=by_alias[copies[signal.alias]].pronto)
+        if signal.alias in copies else signal
+        for signal in wig.signals
+    ])
+
+
+def _listing(wig: Wig, copies: dict[str, str]) -> dict:
+    return list_tangles(_device(wig, copies), None).as_dict()
+
+
+def _rows_for(listing: dict, alias: str) -> list[dict]:
+    return [
+        row for row in listing["rows"]
+        if row["target"]["key"] == alias
+    ]
+
+
+class TestThePairBecomesACard:
+    def test_both_names_get_a_row(self, dreo):
+        listing = _listing(dreo, {DUPE: POWER})
+        assert len(_rows_for(listing, POWER)) == 1
+        assert len(_rows_for(listing, DUPE)) == 1
+        for alias in (POWER, DUPE):
+            classes = _rows_for(listing, alias)[0]["classes"]
+            assert CHECK_DUPLICATE_LABELS in classes
+
+    def test_they_land_in_one_two_member_cluster(self, dreo):
+        """What DECIDE reads. Two rows and one card, not two cards of
+        one row each."""
+        listing = _listing(dreo, {DUPE: POWER})
+        ids = {
+            row["id"] for row in listing["rows"]
+            if row["target"]["key"] in (POWER, DUPE)
+        }
+        pairs = [
+            cluster for cluster in listing["clusters"]
+            if cluster["rule"] == CLUSTER_IDENTICAL
+        ]
+        assert len(pairs) == 1
+        assert set(pairs[0]["members"]) == ids
+
+    def test_one_card_even_when_the_two_carry_different_dittos(self, dreo):
+        """The rows' digests take the ditto count in, so keying the card
+        on them would split a pair that differs only in delivery. The
+        card is keyed on the payload the comb grouped them by."""
+        listing = _listing(dreo, {DUPE: POWER})
+        digests = {
+            row["digest"] for row in listing["rows"]
+            if row["target"]["key"] in (POWER, DUPE)
+        }
+        assert len(digests) == 2
+        assert len([
+            c for c in listing["clusters"] if c["rule"] == CLUSTER_IDENTICAL
+        ]) == 1
+
+    def test_the_pair_leaves_the_advisory_list(self, dreo):
+        """No double-report. A finding that became rows is not also
+        reported as something nobody acted on."""
+        listing = _listing(dreo, {DUPE: POWER})
+        assert [
+            advisory for advisory in listing["advisories"]
+            if advisory["check"] == CHECK_DUPLICATE_LABELS
+        ] == []
+
+
+class TestTheClassificationDoesNotMove:
+    def test_the_comb_still_calls_it_advisory(self, dreo):
+        """Promotion happens in the listing. The comb is untouched, so
+        the file's own receipt reads exactly as it did."""
+        report = comb_wig(_flat_wig(dreo, {DUPE: POWER}))
+        finding = next(
+            f for f in report.findings if f.check == CHECK_DUPLICATE_LABELS
+        )
+        assert finding.advisory is True
+        assert sorted(finding.keys) == sorted([POWER, DUPE])
+
+    def test_the_pair_counts_as_no_suspects(self, dreo):
+        """The closet chip and the suspect count are the owner's stated
+        boundary on this change."""
+        wig = _flat_wig(dreo, {DUPE: POWER})
+        stamp_receipt(wig, comb_wig(wig), "2026-08-29")
+        suspects = suspect_findings(wig)
+        assert POWER not in suspects
+        assert DUPE not in suspects
+
+
+class TestOnlyExactlyTwo:
+    def test_three_names_stay_advisory_with_no_rows(self, dreo):
+        """A pair has one question with two answers. Three is a mess a
+        person should look at, not a card."""
+        listing = _listing(dreo, {DUPE: POWER, "Timer": POWER})
+        for alias in (POWER, DUPE, "Timer"):
+            assert _rows_for(listing, alias) == []
+        assert [
+            advisory for advisory in listing["advisories"]
+            if advisory["check"] == CHECK_DUPLICATE_LABELS
+        ] != []
+
+    def test_a_clean_wig_still_has_no_pair_card(self, dreo):
+        listing = _listing(dreo, {})
+        assert [
+            cluster for cluster in listing["clusters"]
+            if cluster["rule"] == CLUSTER_IDENTICAL
+        ] == []
+
+
+class TestThePracticeDupeShape:
+    """The fixture the owner was actually holding: one planted pair, and
+    the Dreo's own unrelated frame disagreement."""
+
+    def test_a_decide_pair_and_one_listen_row(self, dreo):
+        listing = _listing(dreo, {DUPE: POWER})
+        by_rule: dict[str, list] = {}
+        for cluster in listing["clusters"]:
+            by_rule.setdefault(cluster["rule"], []).append(cluster)
+        assert len(by_rule[CLUSTER_IDENTICAL]) == 1
+        assert len(by_rule[CLUSTER_IDENTICAL][0]["members"]) == 2
+
+        others = [
+            cluster for cluster in listing["clusters"]
+            if cluster["rule"] != CLUSTER_IDENTICAL
+        ]
+        assert len(others) == 1
+        listener = _rows_for(listing, LISTENER)
+        assert len(listener) == 1
+        assert CHECK_FRAME_DISAGREEMENT in listener[0]["classes"]
+        assert others[0]["members"] == [listener[0]["id"]]
+
+    def test_the_pair_does_not_swallow_the_listen_row(self, dreo):
+        """Three rows in total, and the LISTEN one is still its own
+        question."""
+        listing = _listing(dreo, {DUPE: POWER})
+        assert len(listing["rows"]) == 3

--- a/custom_components/hair/tests/test_tangle_ladder_keep.py
+++ b/custom_components/hair/tests/test_tangle_ladder_keep.py
@@ -1,0 +1,282 @@
+"""What USE IT ANYWAY leaves behind.
+
+Issue 8 of the detangler round, reproduced by the owner on the practice
+AC 2026-08-29: the ladder settled a row, and closing and reopening the
+device brought the same row back as a LISTEN ask. Worse, the pulled
+command beside it read REPAIRED while the tangle row asked again, so
+the two surfaces disagreed about a question the person had already
+answered.
+
+Nothing was broken in the write. The bytes landed, the porthole
+followed, the wig was updated. What was missing is that the finding is
+DERIVED: the next listing re-combs the file, reads the same disputed
+value out of the same bytes, and files the same finding, because
+nothing anywhere remembered that a person had looked at it and said
+keep it.
+
+That memory already exists and is called an attestation. The keep
+endpoint writes one; this makes the ladder's third rung write the same
+record, keyed to the bytes it just wrote, so it expires on its own the
+moment those bytes or the map that doubted them move.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.hair.const import DOMAIN
+from custom_components.hair.models import (
+    CommandCategory,
+    IRCommand,
+    IRDevice,
+)
+from custom_components.hair.tangles import (
+    ATTEST_LADDER_OVERRIDE,
+    build_attestation,
+    list_tangles,
+    project_device,
+    read_lattice,
+    read_repair,
+)
+from custom_components.hair.websocket_api import (
+    ws_tangle_apply,
+    ws_tangle_revert,
+)
+from custom_components.hair.wig_comb import CHECK_FIELD_MISMATCH
+from custom_components.hair.wig_format import (
+    Wig,
+    cell_key,
+    parse_wig,
+    row_digest,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+KOMECO = (FIXTURES / "wigs"
+          / "komeco-airconditioner-kos-09qc-3hx-perfect-fit.wig.json")
+
+TARGET_KEY = "heat_cool/medium/off/25"
+TARGET = f"cell:{TARGET_KEY}"
+#: One step BELOW the target: this cell's bytes read as the target's own
+#: label, which is what a donor repair copies and what reads clean.
+CLEAN_KEY = "heat_cool/medium/off/24"
+#: One step ABOVE: these bytes read as 27 against a cell claiming 25, so
+#: the disagreement survives the write. That is the ladder's case.
+DISPUTED_KEY = "heat_cool/medium/off/26"
+
+
+@pytest.fixture
+def komeco() -> Wig:
+    parsed = parse_wig(KOMECO.read_text())
+    assert parsed.wig is not None, parsed.errors
+    return parsed.wig
+
+
+@pytest.fixture
+def wired(fake_hass, komeco, tmp_path):
+    """A Komeco device with one porthole over the target cell."""
+    matrix = komeco.climate
+    cells = {cell_key(c): c for c in matrix.cells}
+    device = IRDevice(name="Komeco", climate_matrix=True,
+                      emitter_entity_ids=["infrared.blaster"])
+    device.add_command(IRCommand(
+        name="Heat_cool 25 medium off", category=CommandCategory.CUSTOM,
+        protocol="PRONTO", code=cells[TARGET_KEY].pronto, repeat_count=0,
+        matrix_cell={"mode": "heat_cool", "fan": "medium",
+                     "swing": "off", "temp": 25.0},
+        comb_suspect=True, comb_finding=CHECK_FIELD_MISMATCH,
+    ))
+    manager = MagicMock()
+    manager.get_device = MagicMock(return_value=device)
+    manager.async_get_matrix = AsyncMock(return_value=matrix)
+    manager.async_update_device = AsyncMock()
+    fake_hass.config.config_dir = str(tmp_path)
+    fake_hass.data[DOMAIN] = {"entry-1": {
+        "device_manager": manager, "matrix_listener": MagicMock(),
+    }}
+    return fake_hass, device, matrix, cells
+
+
+def _conn():
+    connection = MagicMock()
+    connection.send_result = MagicMock()
+    connection.send_error = MagicMock()
+    return connection
+
+
+async def _apply(hass, device, pronto, **extra):
+    connection = _conn()
+    payload = {
+        "id": 1, "type": "hair/device/tangle/apply",
+        "device_id": device.id, "target": TARGET,
+        "pronto": pronto, "tested": True,
+    }
+    payload.update(extra)
+    await ws_tangle_apply(hass, connection, payload)
+    connection.send_error.assert_not_called()
+    return connection.send_result.call_args.args[1]
+
+
+def _rows(device, matrix):
+    listing = list_tangles(device, matrix)
+    return (
+        {row["id"] for row in listing.as_dict()["rows"]},
+        {row["id"] for row in listing.as_dict()["attested"]},
+    )
+
+
+class TestTheOverrideIsRemembered:
+    @pytest.mark.asyncio
+    async def test_the_apply_records_an_attestation(self, wired):
+        hass, device, _matrix, cells = wired
+        result = await _apply(
+            hass, device, cells[DISPUTED_KEY].pronto,
+            source="capture", reading_disagreed=True,
+        )
+        assert result["verdict"]["matches"] is False
+        assert result["attested"] is not None
+        assert len(device.tangle_attestations) == 1
+
+    @pytest.mark.asyncio
+    async def test_the_row_leaves_the_work_list(self, wired):
+        """The defect itself. Reopening the device used to bring the
+        same ask straight back."""
+        hass, device, matrix, cells = wired
+        open_before, _ = _rows(device, matrix)
+        assert f"cell:{TARGET_KEY}" in open_before
+        await _apply(
+            hass, device, cells[DISPUTED_KEY].pronto,
+            source="capture", reading_disagreed=True,
+        )
+        open_after, answered = _rows(device, matrix)
+        assert f"cell:{TARGET_KEY}" not in open_after
+        assert f"cell:{TARGET_KEY}" in answered
+
+    @pytest.mark.asyncio
+    async def test_the_two_surfaces_agree_afterwards(self, wired):
+        """The owner's extra wrinkle: the pulled command read REPAIRED
+        while the tangle row asked again. Both now say settled."""
+        hass, device, matrix, cells = wired
+        await _apply(
+            hass, device, cells[DISPUTED_KEY].pronto,
+            source="capture", reading_disagreed=True,
+        )
+        porthole = device.commands[0]
+        assert read_repair(porthole) is not None
+        open_after, answered = _rows(device, matrix)
+        assert f"cell:{TARGET_KEY}" not in open_after
+        assert f"cell:{TARGET_KEY}" in answered
+
+    @pytest.mark.asyncio
+    async def test_the_finding_itself_is_untouched(self, wired):
+        """Attested is not clean, and has to keep reading as one. The
+        answered row still carries the finding it answers."""
+        hass, device, matrix, cells = wired
+        await _apply(
+            hass, device, cells[DISPUTED_KEY].pronto,
+            source="capture", reading_disagreed=True,
+        )
+        listing = list_tangles(device, matrix).as_dict()
+        row = next(
+            r for r in listing["attested"] if r["id"] == f"cell:{TARGET_KEY}"
+        )
+        assert CHECK_FIELD_MISMATCH in row["classes"]
+        assert row["attested"]["note"] == ATTEST_LADDER_OVERRIDE
+
+
+class TestWhatTheRecordSays:
+    @pytest.mark.asyncio
+    async def test_the_note_marks_the_road_it_came_down(self, wired):
+        """A KEEP says the finding is wrong about these bytes. This says
+        the person heard the disputed value and is keeping it anyway.
+        Same standing, and a later reader should be able to tell them
+        apart."""
+        hass, device, _matrix, cells = wired
+        result = await _apply(
+            hass, device, cells[DISPUTED_KEY].pronto,
+            source="capture", reading_disagreed=True,
+        )
+        assert result["attested"]["note"] == ATTEST_LADDER_OVERRIDE
+
+    @pytest.mark.asyncio
+    async def test_it_is_keyed_to_the_bytes_just_written(self, wired):
+        """Not to the bytes it replaced. An answer keyed to the old
+        digest would expire the instant it was recorded, which is the
+        same nagging with extra steps."""
+        hass, device, _matrix, cells = wired
+        written = cells[DISPUTED_KEY].pronto
+        result = await _apply(
+            hass, device, written, source="capture", reading_disagreed=True,
+        )
+        assert result["attested"]["digest"] == row_digest(written, 0, False)
+        assert cells[TARGET_KEY].pronto == written
+
+    @pytest.mark.asyncio
+    async def test_it_is_the_keep_endpoint_s_own_record(self, wired):
+        """Same record, from the same builder, so one reader
+        understands both roads and the receipt carries one shape."""
+        hass, device, matrix, cells = wired
+        listing = list_tangles(device, matrix)
+        wig, _sources = project_device(device, matrix)
+        lattice = read_lattice(matrix, wig)
+        reference = build_attestation(listing.rows[0], lattice, note="keep")
+
+        result = await _apply(
+            hass, device, cells[DISPUTED_KEY].pronto,
+            source="capture", reading_disagreed=True,
+        )
+        assert set(result["attested"]) == set(reference)
+        assert result["attested"]["tested"] is True
+        assert result["attested"]["map"]["id"] == "ZHLT01"
+        assert result["attested"]["target"] == TARGET_KEY
+        assert result["attested"]["kind"] == "cell"
+
+    @pytest.mark.asyncio
+    async def test_a_later_write_reopens_it(self, wired):
+        """The whole expiry mechanism, and there is nothing scheduled in
+        it: change the bytes and the key stops matching."""
+        hass, device, matrix, cells = wired
+        await _apply(
+            hass, device, cells[DISPUTED_KEY].pronto,
+            source="capture", reading_disagreed=True,
+        )
+        _open, answered = _rows(device, matrix)
+        assert f"cell:{TARGET_KEY}" in answered
+
+        connection = _conn()
+        await ws_tangle_revert(hass, connection, {
+            "id": 2, "type": "hair/device/tangle/revert",
+            "device_id": device.id, "target": TARGET,
+        })
+        connection.send_error.assert_not_called()
+        open_after, answered_after = _rows(device, matrix)
+        assert f"cell:{TARGET_KEY}" in open_after
+        assert f"cell:{TARGET_KEY}" not in answered_after
+        # The record is still there and simply no longer applies, which
+        # is the design: nothing is swept, so there is no sweep to be
+        # wrong.
+        assert len(device.tangle_attestations) == 1
+
+
+class TestWhatRecordsNothing:
+    @pytest.mark.asyncio
+    async def test_a_repair_that_reads_clean_records_nothing(self, wired):
+        """The finding clears on its own arithmetic. An attestation here
+        would be claiming a dispute that no longer exists."""
+        hass, device, _matrix, cells = wired
+        result = await _apply(
+            hass, device, cells[CLEAN_KEY].pronto,
+            source="donor", reading_disagreed=True,
+        )
+        assert result["verdict"]["matches"] is True
+        assert result["attested"] is None
+        assert device.tangle_attestations == []
+
+    @pytest.mark.asyncio
+    async def test_an_ordinary_donor_repair_records_nothing(self, wired):
+        hass, device, _matrix, cells = wired
+        result = await _apply(
+            hass, device, cells[CLEAN_KEY].pronto, source="donor")
+        assert result["attested"] is None
+        assert device.tangle_attestations == []

--- a/custom_components/hair/tests/test_wig_upload_row.py
+++ b/custom_components/hair/tests/test_wig_upload_row.py
@@ -1,0 +1,244 @@
+"""The drop path stops asking twice.
+
+Issue 6 of the detangler round, backend half. Dropping a file on the
+ghost tile sat silent long enough that the owner doubted it had
+registered. The import itself is not the slow part: `wigs/upload`
+parses, converts, combs, checks supersession and writes, and it knows
+the landed wig completely by the time it returns. What followed was the
+waste -- the drop path then ran a whole `wigs/list`, which re-scans and
+re-parses EVERY wig in the closet and computes claims, receipts and
+matrix summaries for each, to find the one row whose filename it had
+known since the write.
+
+So the upload result carries that row. `wigs/list` is untouched: this
+is the drop path's shortcut, not a replacement for the closet's own
+payload, and the two have to agree about the same file or the shortcut
+is a second truth. That agreement is what this file pins hardest.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.hair.const import DOMAIN
+from custom_components.hair.websocket_api import ws_wigs_list, ws_wigs_upload
+from custom_components.hair.wig_format import (
+    ClimateCell,
+    ClimateMatrix,
+    Wig,
+    WigSignal,
+    serialize_wig,
+)
+
+from .test_wig_comb import _code
+
+#: Everything the picker row needs, and the fields the drop path used
+#: to go back to the closet for.
+ROW_FIELDS = (
+    "filename", "name", "brand", "model", "kind", "signal_count",
+    "matrix", "comb",
+)
+
+
+@pytest.fixture
+def wigs_dir_path(tmp_path):
+    directory = tmp_path / "hair" / "wigs"
+    directory.mkdir(parents=True)
+    return directory
+
+
+def _connection():
+    conn = MagicMock()
+    conn.send_result = MagicMock()
+    conn.send_error = MagicMock()
+    conn.user.name = "dab"
+    return conn
+
+
+def _wire(fake_hass, tmp_path):
+    fake_hass.config.config_dir = str(tmp_path)
+    fake_hass.data[DOMAIN] = {"entry-1": {
+        "device_manager": MagicMock(),
+        "fitting_manager": None,
+        "store": None,
+    }}
+
+
+def _flat() -> Wig:
+    return Wig(
+        name="Practice Remote", brand="Testco", model="TM-1", kind="fan",
+        signals=[
+            WigSignal(alias=f"Button {i}", pronto=_code([11], seed=i))
+            for i in range(4)
+        ],
+    )
+
+
+def _matrix() -> Wig:
+    cells = [
+        ClimateCell(mode="cool", fan="auto", temp=float(temp),
+                    pronto=_code([10], seed=temp))
+        for temp in range(16, 22)
+    ]
+    return Wig(
+        name="Practice AC", brand="Testco", model="AC-9", kind="ac",
+        signals=[], climate=ClimateMatrix(
+            min_temp=16.0, max_temp=30.0,
+            off=_code([10], seed=90), cells=cells,
+        ),
+    )
+
+
+async def _upload(fake_hass, text: str, **extra) -> dict:
+    conn = _connection()
+    payload = {"id": 1, "type": "hair/wigs/upload", "text": text}
+    payload.update(extra)
+    await ws_wigs_upload(fake_hass, conn, payload)
+    return conn.send_result.call_args.args[1]
+
+
+async def _closet_row(fake_hass, filename: str) -> dict:
+    conn = _connection()
+    await ws_wigs_list(fake_hass, conn, {"id": 2, "type": "hair/wigs/list"})
+    rows = {
+        row["filename"]: row
+        for row in conn.send_result.call_args.args[1]["wigs"]
+    }
+    return rows[filename]
+
+
+class TestTheLandedRowComesBack:
+    @pytest.mark.asyncio
+    async def test_a_native_wig_carries_every_row_field(
+            self, fake_hass, tmp_path, wigs_dir_path):
+        _wire(fake_hass, tmp_path)
+        result = await _upload(fake_hass, serialize_wig(_flat()))
+        assert result["success"]
+        entry = result["files"][0]
+        for field in ROW_FIELDS:
+            assert field in entry, field
+        assert entry["name"] == "Practice Remote"
+        assert entry["brand"] == "Testco"
+        assert entry["model"] == "TM-1"
+        assert entry["kind"] == "fan"
+        assert entry["signal_count"] == 4
+        assert entry["matrix"] is None
+
+    @pytest.mark.asyncio
+    async def test_a_matrix_wig_carries_its_matrix_summary(
+            self, fake_hass, tmp_path, wigs_dir_path):
+        """The chip the picker draws for a lattice. Computing it here
+        costs nothing: the wig is already parsed and in hand."""
+        _wire(fake_hass, tmp_path)
+        result = await _upload(fake_hass, serialize_wig(_matrix()))
+        entry = result["files"][0]
+        assert entry["signal_count"] == 0
+        assert entry["matrix"] is not None
+        assert entry["matrix"]["cells"] == 6
+        assert entry["matrix"]["modes"] == ["cool"]
+        assert entry["matrix"]["min_temp"] == 16.0
+
+    @pytest.mark.asyncio
+    async def test_it_says_what_the_closet_says(
+            self, fake_hass, tmp_path, wigs_dir_path):
+        """The point. A shortcut that disagrees with the surface it is
+        short-cutting is a second truth, not a shortcut."""
+        _wire(fake_hass, tmp_path)
+        result = await _upload(fake_hass, serialize_wig(_matrix()))
+        entry = result["files"][0]
+        row = await _closet_row(fake_hass, result["filename"])
+        for field in ROW_FIELDS:
+            assert entry[field] == row[field], field
+
+    @pytest.mark.asyncio
+    async def test_the_comb_summary_still_rides(
+            self, fake_hass, tmp_path, wigs_dir_path):
+        """It was already there and stays there: import is the cheapest
+        moment in a wig's life to look."""
+        _wire(fake_hass, tmp_path)
+        result = await _upload(fake_hass, serialize_wig(_flat()))
+        assert result["files"][0]["comb"] is not None
+        assert result["files"][0]["comb"]["suspects"] == 0
+
+
+class TestConversionCarriesItToo:
+    @pytest.mark.asyncio
+    async def test_a_smartir_drop_lands_a_full_row(
+            self, fake_hass, tmp_path, wigs_dir_path):
+        """A converted file is exactly the case where the person is
+        least sure anything happened."""
+        _wire(fake_hass, tmp_path)
+        source = {
+            "manufacturer": "Testco",
+            "supportedModels": ["TM-1"],
+            "supportedController": "MQTT",
+            "commandsEncoding": "Pronto",
+            "commands": {
+                "power": _code([11], seed=1),
+                "volumeUp": _code([11], seed=2),
+            },
+        }
+        result = await _upload(
+            fake_hass, json.dumps(source), filename="1234.json")
+        assert result["success"] and result["format"] == "smartir"
+        entry = result["files"][0]
+        for field in ROW_FIELDS:
+            assert field in entry, field
+        assert entry["signal_count"] == 2
+        row = await _closet_row(fake_hass, result["filename"])
+        for field in ROW_FIELDS:
+            assert entry[field] == row[field], field
+
+
+class TestNothingElseMoves:
+    @pytest.mark.asyncio
+    async def test_the_failure_shape_is_unchanged(
+            self, fake_hass, tmp_path, wigs_dir_path):
+        _wire(fake_hass, tmp_path)
+        result = await _upload(fake_hass, "{\"not\": \"a wig\"}")
+        assert result["success"] is False
+        assert result["errors"]
+        assert "files" not in result
+
+    @pytest.mark.asyncio
+    async def test_the_duplicate_receipt_is_unchanged(
+            self, fake_hass, tmp_path, wigs_dir_path):
+        """The row rides alongside what was already on the entry, not
+        instead of it."""
+        _wire(fake_hass, tmp_path)
+        text = serialize_wig(_flat())
+        await _upload(fake_hass, text)
+        again = await _upload(fake_hass, text)
+        entry = again["files"][0]
+        assert entry["duplicate_of"] is not None
+        assert entry["duplicates"]
+        assert entry["signal_count"] == 4
+
+    @pytest.mark.asyncio
+    async def test_the_closet_payload_is_untouched(
+            self, fake_hass, tmp_path, wigs_dir_path):
+        """wigs/list keeps every field it had. The drop path got a
+        shortcut; the closet did not lose anything."""
+        _wire(fake_hass, tmp_path)
+        await _upload(fake_hass, serialize_wig(_flat()))
+        row = await _closet_row(
+            fake_hass,
+            (await _closet_row_names(fake_hass))[0],
+        )
+        for field in (
+            "filename", "name", "brand", "model", "notes", "origin",
+            "signal_count", "signals", "kind", "identifiers", "matrix",
+            "fitting", "comb", "linked_devices",
+        ):
+            assert field in row, field
+
+
+async def _closet_row_names(fake_hass) -> list[str]:
+    conn = _connection()
+    await ws_wigs_list(fake_hass, conn, {"id": 3, "type": "hair/wigs/list"})
+    return [
+        row["filename"]
+        for row in conn.send_result.call_args.args[1]["wigs"]
+    ]

--- a/custom_components/hair/websocket_api.py
+++ b/custom_components/hair/websocket_api.py
@@ -4057,6 +4057,7 @@ async def ws_wigs_upload(
         from datetime import UTC, datetime
 
         from .wig_adapters import convert, sniff_format
+        from .wig_climate import matrix_summary
         from .wig_comb import comb_wig, receipt_summary, stamp_receipt
         from .wig_format import (
             drop_legacy_fittings,
@@ -4113,6 +4114,23 @@ async def ws_wigs_upload(
                     matches[0]["filename"] if matches else None
                 ),
                 "duplicates": matches,
+                # THE PICKER ROW (B4, issue 6). Everything below is
+                # already computed by the work this handler just did, and
+                # the drop path used to go and get it again by running a
+                # whole wigs/list -- a re-scan and re-parse of EVERY wig
+                # in the closet, with claims, receipts and matrix
+                # summaries for each, to find the one row whose filename
+                # it had known since the write. The wait was long enough
+                # that the owner doubted the drop had registered.
+                # wigs/list is unchanged; this is the drop path's
+                # shortcut, not a replacement for it.
+                "model": wig.model,
+                "kind": wig.kind,
+                "signal_count": len(wig.signals),
+                "matrix": (
+                    matrix_summary(wig.climate)
+                    if wig.climate is not None else None
+                ),
             }
 
         result = parse_wig(text)

--- a/custom_components/hair/websocket_api.py
+++ b/custom_components/hair/websocket_api.py
@@ -7473,6 +7473,46 @@ def _apply_source(msg: dict[str, Any]) -> str:
     } else ORIGIN_PASTE
 
 
+async def _keep_the_override(
+    hass: HomeAssistant,
+    device: Any,
+    matrix: Any,
+    row: Any,
+    lattice: Any,
+    verdict: Any,
+    declared: bool,
+) -> dict[str, Any] | None:
+    """Record the standing answer behind a USE IT ANYWAY. B2, issue 8.
+
+    Only where there is an answer to record. A declared override whose
+    bytes still read as the disputed value is a person overruling the
+    map, and that has to survive the next listing or the surface asks
+    again -- the exact loop the owner reproduced on the practice AC.
+    Bytes that read clean after the write record nothing: the finding
+    clears on its own arithmetic and an attestation would be claiming a
+    dispute that no longer exists.
+
+    Called after the write and before the save, so the digest it keys on
+    is the one now on the device and one save carries both.
+    """
+    if not declared or verdict.matches is not False:
+        return None
+
+    from .tangles import attest_override
+
+    record = await hass.async_add_executor_job(
+        attest_override, device, matrix, row, lattice
+    )
+    if record is None:
+        return None
+    device.tangle_attestations = [
+        existing for existing in device.tangle_attestations
+        if existing.get("key") != record["key"]
+    ]
+    device.tangle_attestations.append(record)
+    return record
+
+
 async def _write_matrix_and_signal(
     hass: HomeAssistant, device: IRDevice, matrix: Any
 ) -> str | None:
@@ -7634,6 +7674,9 @@ async def ws_tangle_apply(
         if failure is not None:
             connection.send_error(msg["id"], "write_failed", failure)
             return
+        attested = await _keep_the_override(
+            hass, device, matrix, row, lattice, verdict, declared,
+        )
         await manager.async_update_device(device)
     else:
         command = device.get_command(row.target.command_id or "")
@@ -7642,6 +7685,9 @@ async def ws_tangle_apply(
                 msg["id"], APPLY_NO_FINDING, "That command is gone")
             return
         write_repair(command, msg["pronto"], provenance)
+        attested = await _keep_the_override(
+            hass, device, matrix, row, lattice, verdict, declared,
+        )
         # Through async_update_device, so the known-command index
         # rebuilds on the new bytes and the entity hooks fire (gotcha 6).
         await manager.async_update_device(device)
@@ -7651,6 +7697,7 @@ async def ws_tangle_apply(
         "target": row.id,
         "provenance": provenance,
         "verdict": verdict.as_dict(),
+        "attested": attested,
         "wig": await _write_through(hass, device),
     })
 


### PR DESCRIPTION
Round one of the owner play-session fixes, backend half. Four commits: repeat-frame families identify from the frame that arrived (issue 9), the ladder override records a standing answer so settled rows stay settled (issue 8), duplicate-label pairs reach DECIDE (issue 5), and the upload result carries the landed row so the drop path stops re-scanning the closet (issue 6). 42 new tests; plan and evidence in the internal round-one docs.