### PR TITLE
ci: test on Python 3.13 and 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12", "3.14"]
+        python-version: ["3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
 
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: pip
           cache-dependency-path: pyproject.toml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,15 @@ version = "0.9.6"
 description = "HAIR - Home Assistant IR Device Manager"
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 authors = [
     { name = "David Bailey", email = "david.a.bailey@gmail.com" },
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: End Users/Desktop",
-    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 [tool.setuptools.packages.find]
@@ -49,8 +50,9 @@ test = [
     # newest 5.x today and picks up 6.x automatically once it is published.
     # Upstream moved to 7.x in 2026-07; the commands.Command contract is
     # unchanged from 5.x (verified against the 7.5.0 source), so the cap
-    # tracks the next major.
-    "infrared-protocols>=5.6,<9.0; python_version >= '3.13'",
+    # tracks the next major. The library publishes for Python 3.13 and
+    # up, which is also HA 2026.4's floor, so the pin is unconditional.
+    "infrared-protocols>=5.6,<9.0",
 ]
 lint = [
     "ruff>=0.4",
@@ -62,14 +64,14 @@ testpaths = ["custom_components/hair/tests"]
 asyncio_mode = "auto"
 
 [tool.ruff]
-target-version = "py312"
+target-version = "py313"
 line-length = 99
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "B", "SIM", "RUF"]
 
 [tool.mypy]
-python_version = "3.12"
+python_version = "3.13"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false


### PR DESCRIPTION
HA 2026.4, the floor in hacs.json, runs on Python 3.13, and infrared-protocols publishes for 3.13 and up. The 3.12 leg was skipping the 38 decoder tests that need that library, so it proved less than it looked.

Legs are now the floor and the tip: 3.13 and 3.14. requires-python, the classifiers, the ruff target, and the mypy target move with it, and the infrared-protocols pin loses its version marker. Lint runs on 3.13.
